### PR TITLE
Implement professor password setup endpoint

### DIFF
--- a/backend/controllers/professorController.js
+++ b/backend/controllers/professorController.js
@@ -1,0 +1,39 @@
+const { body, validationResult } = require('express-validator');
+const professorService = require('../services/professorService');
+
+const setupProfessorPassword = [
+  body('setupToken').isString().trim().notEmpty(),
+  body('newPassword').isString().notEmpty(),
+
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { setupToken, newPassword } = req.body;
+
+    try {
+      const result = await professorService.setInitialPassword(
+        setupToken,
+        newPassword
+      );
+
+      return res.status(200).json(result);
+    } catch (error) {
+      if (error.message === 'INVALID_SETUP_TOKEN') {
+        return res.status(400).json({ message: 'Setup token is invalid or expired' });
+      }
+
+      if (error.message === 'INVALID_PASSWORD_POLICY') {
+        return res.status(400).json({
+          message: 'Password must be at least 8 characters and include uppercase, lowercase, number, and special character',
+        });
+      }
+
+      return res.status(500).json({ message: 'Internal Server Error' });
+    }
+  },
+];
+
+module.exports = { setupProfessorPassword };

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -19,6 +19,10 @@ const User = sequelize.define('User', {
     type: DataTypes.STRING,
     allowNull: false,
   },
+  password: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
   role: {
     type: DataTypes.ENUM('STUDENT', 'PROFESSOR', 'COORDINATOR', 'ADMIN'),
     allowNull: false,

--- a/backend/routes/professors.js
+++ b/backend/routes/professors.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { setupProfessorPassword } = require('../controllers/professorController');
+
+const router = express.Router();
+
+router.post('/password-setup', setupProfessorPassword);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,10 +1,23 @@
 require('dotenv').config();
 const express = require('express');
 const sequelize = require('./db');
+const User = require('./models/User');
 const app = express();
 
 // Middleware
 app.use(express.json());
+
+const ensureSqliteColumns = async () => {
+  const queryInterface = sequelize.getQueryInterface();
+  const userTable = await queryInterface.describeTable('Users');
+
+  if (!userTable.password) {
+    await queryInterface.addColumn('Users', 'password', {
+      type: User.getAttributes().password.type,
+      allowNull: true,
+    });
+  }
+};
 
 // Connect to SQLite and sync models
 sequelize.authenticate()
@@ -12,12 +25,15 @@ sequelize.authenticate()
     console.log("SQLite connected");
     return sequelize.sync();
   })
+  .then(() => ensureSqliteColumns())
   .then(() => console.log("Database synced"))
   .catch(err => console.log("Database error:", err));
 
 // Routes
 const adminRoutes = require('./routes/admin');
+const professorRoutes = require('./routes/professors');
 app.use('/api/v1/admin', adminRoutes);
+app.use('/api/v1/professors', professorRoutes);
 
 // Error handling middleware
 app.use((err, req, res, next) => {

--- a/backend/services/professorService.js
+++ b/backend/services/professorService.js
@@ -1,4 +1,6 @@
 const crypto = require('crypto');
+const bcrypt = require('bcryptjs');
+const { Op } = require('sequelize');
 const sequelize = require('../db');
 const User = require('../models/User');
 const Professor = require('../models/Professor');
@@ -6,7 +8,7 @@ const Professor = require('../models/Professor');
 class ProfessorService {
 
   generateSecureToken() {
-    return crypto.randomBytes(32).toString('hex'); // 64 char
+    return `pst_${crypto.randomBytes(32).toString('hex')}`;
   }
 
   hashToken(token) {
@@ -14,6 +16,17 @@ class ProfessorService {
       .createHash('sha256')
       .update(token)
       .digest('hex');
+  }
+
+  isValidPassword(password) {
+    if (typeof password !== 'string') {
+      return false;
+    }
+
+    const passwordPolicy =
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}$/;
+
+    return passwordPolicy.test(password);
   }
 
   async registerProfessor(email, fullName, department) {
@@ -70,6 +83,46 @@ class ProfessorService {
       await transaction.rollback();
       throw error;
     }
+  }
+
+  async setInitialPassword(setupToken, newPassword) {
+    if (!setupToken || typeof setupToken !== 'string') {
+      throw new Error('INVALID_SETUP_TOKEN');
+    }
+
+    if (!this.isValidPassword(newPassword)) {
+      throw new Error('INVALID_PASSWORD_POLICY');
+    }
+
+    const passwordSetupTokenHash = this.hashToken(setupToken);
+
+    const user = await User.findOne({
+      where: {
+        role: 'PROFESSOR',
+        status: 'PASSWORD_SETUP_REQUIRED',
+        passwordSetupTokenHash,
+        passwordSetupTokenExpiresAt: {
+          [Op.gt]: new Date(),
+        },
+      },
+    });
+
+    if (!user) {
+      throw new Error('INVALID_SETUP_TOKEN');
+    }
+
+    const hashedPassword = await bcrypt.hash(newPassword, 10);
+
+    await user.update({
+      password: hashedPassword,
+      status: 'ACTIVE',
+      passwordSetupTokenHash: null,
+      passwordSetupTokenExpiresAt: null,
+    });
+
+    return {
+      message: 'Password set successfully',
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
This PR implements Issue 8 by adding the professor initial password setup flow.

## Changes
- added `POST /api/v1/professors/password-setup`
- validated setup token before allowing password creation
- enforced password policy for initial password setup
- hashed the new password with `bcryptjs`
- activated professor accounts after successful password setup
- invalidated setup tokens after first use
- added SQLite-compatible handling for the new `password` column on startup

## Request
```json
{
  "setupToken": "pst_xxx",
  "newPassword": "NewStrongPassword123!"
}
