### PR TITLE
Improve GitHub linking fallback and duplicate link handling

### DIFF
--- a/backend/controllers/studentController.js
+++ b/backend/controllers/studentController.js
@@ -233,6 +233,7 @@ async function handleGitHubCallback(req, res) {
       return redirectToFrontendWithResult(res, 'success', {
         githubUsername: profile.githubUsername,
         studentId: student.studentId,
+        mockOAuth: githubLinkService.hasRealGitHubOAuthConfig() ? '' : '1',
       });
     }
 
@@ -242,7 +243,10 @@ async function handleGitHubCallback(req, res) {
       githubUsername: profile.githubUsername,
     });
   } catch (error) {
-    const status = error.code === 'GITHUB_ACCOUNT_ALREADY_LINKED' ? 409 : 500;
+    const status = (
+      error.code === 'GITHUB_ACCOUNT_ALREADY_LINKED' ||
+      error.code === 'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT'
+    ) ? 409 : 500;
 
     if (shouldRedirectToFrontend(req)) {
       return redirectToFrontendWithResult(res, 'error', {
@@ -293,6 +297,13 @@ const storeLinkedGitHubAccount = [
       }
 
       if (error.code === 'GITHUB_ACCOUNT_ALREADY_LINKED') {
+        return res.status(409).json({
+          code: error.code,
+          message: error.message,
+        });
+      }
+
+      if (error.code === 'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT') {
         return res.status(409).json({
           code: error.code,
           message: error.message,

--- a/backend/services/githubLinkService.js
+++ b/backend/services/githubLinkService.js
@@ -7,11 +7,27 @@ const User = require('../models/User');
 
 const OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
 
+function hasRealGitHubOAuthConfig() {
+  return Boolean(process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET);
+}
+
 function buildAuthorizationUrl(state) {
   // GitHub expects the generated state to round-trip through the authorize screen
   // so we can validate that the callback belongs to the original student session.
+  if (!hasRealGitHubOAuthConfig()) {
+    // In local dev without GitHub OAuth credentials, we short-circuit to the
+    // backend callback so the rest of the linking pipeline can still be tested
+    // without sending the browser to a broken GitHub authorize URL.
+    const params = new URLSearchParams({
+      code: `mock-code-${state}`,
+      state,
+    });
+
+    return `/api/v1/auth/github/callback?${params.toString()}`;
+  }
+
   const params = new URLSearchParams({
-    client_id: process.env.GITHUB_CLIENT_ID || 'github_client_id_placeholder',
+    client_id: process.env.GITHUB_CLIENT_ID,
     scope: 'read:user',
     state,
   });
@@ -59,10 +75,7 @@ async function consumeOAuthState(state) {
 }
 
 async function exchangeCodeForToken(code) {
-  const clientId = process.env.GITHUB_CLIENT_ID;
-  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
-
-  if (!clientId || !clientSecret) {
+  if (!hasRealGitHubOAuthConfig()) {
     // The mock path keeps local development and tests usable when real GitHub
     // OAuth credentials are intentionally absent.
     return `mock-token-${code}`;
@@ -75,8 +88,8 @@ async function exchangeCodeForToken(code) {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      client_id: clientId,
-      client_secret: clientSecret,
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
       code,
     }),
   });
@@ -90,7 +103,7 @@ async function exchangeCodeForToken(code) {
 }
 
 async function fetchGitHubProfile(accessToken, user) {
-  if (!process.env.GITHUB_CLIENT_ID || !process.env.GITHUB_CLIENT_SECRET) {
+  if (!hasRealGitHubOAuthConfig()) {
     // Tests and local dry-runs use deterministic mock identities so the rest of
     // the linking pipeline can still be exercised without external API calls.
     return {
@@ -151,6 +164,17 @@ async function storeLinkedGitHubAccount({ studentId, githubId, githubUsername })
       transaction,
     });
 
+    if (
+      existingLinkedAccount &&
+      existingLinkedAccount.githubId === githubId &&
+      existingLinkedAccount.githubUsername === githubUsername &&
+      student.githubLinked
+    ) {
+      const error = new Error('GitHub account is already linked for this student.');
+      error.code = 'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT';
+      throw error;
+    }
+
     let linkedAccount;
     if (existingLinkedAccount) {
       // Re-linking the same student updates the stored GitHub identity instead of
@@ -181,5 +205,6 @@ module.exports = {
   exchangeCodeForToken,
   fetchGitHubProfile,
   getFrontendUrl,
+  hasRealGitHubOAuthConfig,
   storeLinkedGitHubAccount,
 };

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -244,7 +244,7 @@ test('github linking flow rejects unauthenticated requests and links account aft
   assert.equal(authenticated.response.status, 200);
   assert.match(authenticated.json.authorizationUrl, /state=/);
 
-  const state = new URL(authenticated.json.authorizationUrl).searchParams.get('state');
+  const state = new URL(authenticated.json.authorizationUrl, baseUrl).searchParams.get('state');
 
   const missingQuery = await request('/api/v1/auth/github/callback');
   assert.equal(missingQuery.response.status, 400);
@@ -263,6 +263,15 @@ test('github linking flow rejects unauthenticated requests and links account aft
 
   const linkedAccount = await LinkedGitHubAccount.findOne({ where: { userId: student.id } });
   assert.equal(linkedAccount.githubUsername, 'student-11070001000');
+
+  const duplicateLinkAttempt = await request(`/api/v1/auth/github/callback?code=test-code-2&state=${new URL((await request('/api/v1/students/me/github/link', {
+    headers: await authHeaderFor(student),
+  })).json.authorizationUrl, baseUrl).searchParams.get('state')}`);
+  assert.equal(duplicateLinkAttempt.response.status, 409);
+  assert.equal(
+    duplicateLinkAttempt.json.code,
+    'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT'
+  );
 
   const reusedState = await request(`/api/v1/auth/github/callback?code=test-code&state=${state}`);
   assert.equal(reusedState.response.status, 400);
@@ -284,7 +293,7 @@ test('github callback redirects browser clients back to frontend with success st
   const authenticated = await request('/api/v1/students/me/github/link', {
     headers: await authHeaderFor(student),
   });
-  const state = new URL(authenticated.json.authorizationUrl).searchParams.get('state');
+  const state = new URL(authenticated.json.authorizationUrl, baseUrl).searchParams.get('state');
 
   const response = await fetch(`${baseUrl}/api/v1/auth/github/callback?code=test-code&state=${state}`, {
     headers: {


### PR DESCRIPTION
## Summary
This PR improves the backend behavior of the GitHub linking flow in two edge cases: when GitHub OAuth credentials are not configured, and when the same student tries to link an already linked GitHub account again.

## What Changed
- added a local mock callback fallback when `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` are not configured
- prevented the frontend from being redirected to a broken GitHub authorize URL with an empty client id
- added explicit duplicate-link detection for the same student and same GitHub account
- returned a dedicated error code for already-linked student accounts
- updated backend tests to cover the new fallback and duplicate-link behavior

## Testing
- ran `npm test` in `backend`
- verified the real GitHub OAuth flow with valid GitHub credentials
- verified the mock fallback flow with empty GitHub OAuth credentials
- verified duplicate linking no longer returns a false success state

## Notes
- this PR is a follow-up fix for the previously merged GitHub linking backend work
- `backend/.env` is still required for real OAuth testing
- when credentials are empty, the flow now uses a local mock callback instead of redirecting to a broken GitHub URL

Refs Issue 9
Refs Issue 10
Refs Issue 11
Refs Issue 17
Refs Issue 18
