### PR TITLE
Improve GitHub linking feedback for mock and duplicate states

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,8 @@ function mapErrorResponse(payload) {
       return { type: 'error', title: 'Weak password', result: 'Rejected' };
     case 'STUDENT_NOT_ELIGIBLE':
       return { type: 'error', title: 'Student not eligible', result: 'Rejected' };
+    case 'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT':
+      return { type: 'warning', title: 'GitHub already linked', result: 'Already linked' };
     default:
       return { type: 'error', title: 'Validation failed', result: 'Failed' };
   }
@@ -55,18 +57,23 @@ export default function App() {
 
     // The backend already condensed the callback outcome into safe UI params.
     // We render those and then strip them from the visible URL immediately.
+    const usedMockOAuth = params.get('mockOAuth') === '1';
     const nextFeedback = githubLinkStatus === 'success'
       ? {
           type: 'success',
           title: 'GitHub linked successfully',
-          message: `${params.get('githubUsername') || 'your GitHub account'} is now linked to this student account.`,
+          message: usedMockOAuth
+            ? 'GitHub OAuth credentials are not configured in the backend .env file, so this run used the local mock callback flow instead of the real GitHub authorize screen.'
+            : `${params.get('githubUsername') || 'your GitHub account'} is now linked to this student account.`,
           studentId: params.get('studentId') || '',
-          result: 'GitHub linked',
+          result: usedMockOAuth ? 'Mock OAuth flow' : 'GitHub linked',
           userId: '',
         }
       : {
-          type: 'error',
-          title: 'GitHub link failed',
+          type: params.get('code') === 'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT' ? 'warning' : 'error',
+          title: params.get('code') === 'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT'
+            ? 'GitHub already linked'
+            : 'GitHub link failed',
           message: params.get('message') || 'GitHub OAuth callback failed.',
           studentId: params.get('studentId') || '',
           result: params.get('code') || 'OAuth error',
@@ -80,6 +87,7 @@ export default function App() {
     params.delete('studentId');
     params.delete('code');
     params.delete('message');
+    params.delete('mockOAuth');
     const nextQuery = params.toString();
     const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ''}`;
     window.history.replaceState({}, '', nextUrl);


### PR DESCRIPTION
## Summary
This PR improves the frontend feedback shown during GitHub linking for mock fallback runs and duplicate linking attempts.

## What Changed
- updated the GitHub callback success state to show a clear message when the backend is using the local mock OAuth flow
- removed the temporary warning-at-start behavior for mock linking
- ensured the final callback result stays in the success panel for mock runs
- improved feedback when the same GitHub account is already linked for the current student
- prevented duplicate linking from looking like a fresh successful link

## Testing
- ran the frontend locally with the backend
- verified the real GitHub OAuth flow with valid credentials
- verified the mock fallback flow with empty GitHub OAuth credentials
- verified duplicate linking now shows an already-linked style result instead of a false success

## Notes
- this PR is a follow-up fix for the previously merged GitHub linking frontend work
- the student token input remains a development/testing helper and not a full authentication feature

Refs Issue 24
Refs Issue 25
