### PR TITLE
feat: implement student account creation flow

### DIFF
--- a/backend/controllers/studentController.js
+++ b/backend/controllers/studentController.js
@@ -1,5 +1,6 @@
 const { body, validationResult } = require('express-validator');
 const githubLinkService = require('../services/githubLinkService');
+const studentAccountService = require('../services/studentAccountService');
 const studentService = require('../services/studentService');
 
 function shouldRedirectToFrontend(req) {
@@ -82,11 +83,61 @@ const registerStudentValidation = [
       });
     }
 
-    const student = await studentService.createStudent({
+    const student = await studentAccountService.createStudentAccountFromValidatedData({
       studentId,
       email,
       fullName,
       password,
+    });
+
+    return res.status(201).json({
+      valid: true,
+      userId: student.id,
+      studentId: student.studentId,
+      message: 'Student account created successfully',
+    });
+  },
+];
+
+const createStudentAccount = [
+  body('studentId').isString().trim().matches(/^[0-9]{11}$/),
+  body('email').isEmail().normalizeEmail(),
+  body('fullName').isString().trim().isLength({ min: 3 }),
+  body('passwordHash').isString().trim().notEmpty(),
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      const validationError = buildRegistrationValidationError(errors.array()[0].path);
+      const status = validationError.code === 'WEAK_PASSWORD' ? 422 : 400;
+      return res.status(status).json(validationError);
+    }
+
+    const {
+      studentId,
+      email,
+      fullName,
+      passwordHash,
+    } = req.body;
+
+    if (await studentService.isStudentRegistered(studentId)) {
+      return res.status(409).json({
+        code: 'ALREADY_REGISTERED',
+        message: 'Student is already registered.',
+      });
+    }
+
+    if (await studentService.findStudentByEmail(email)) {
+      return res.status(409).json({
+        code: 'DUPLICATE_EMAIL',
+        message: 'Email is already in use.',
+      });
+    }
+
+    const student = await studentAccountService.createStudentAccountRecord({
+      studentId,
+      email,
+      fullName,
+      passwordHash,
     });
 
     return res.status(201).json({
@@ -319,6 +370,7 @@ const storeLinkedGitHubAccount = [
 ];
 
 module.exports = {
+  createStudentAccount,
   getStudentValidation,
   handleGitHubCallback,
   registerStudentValidation,

--- a/backend/routes/students.js
+++ b/backend/routes/students.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { authenticate } = require('../middleware/auth');
 const {
+  createStudentAccount,
   getStudentValidation,
   handleGitHubCallback,
   registerStudentValidation,
@@ -12,6 +13,7 @@ const {
 const router = express.Router();
 
 router.post('/students/registration-validation', registerStudentValidation);
+router.post('/user-database/students', createStudentAccount);
 router.get('/user-database/students/:studentId/validation', getStudentValidation);
 router.patch('/user-database/students/:studentId/github-link', updateStudentGitHubLink);
 router.get('/students/me/github/link', authenticate, startGitHubLink);

--- a/backend/services/studentAccountService.js
+++ b/backend/services/studentAccountService.js
@@ -1,0 +1,30 @@
+const bcrypt = require('bcryptjs');
+const User = require('../models/User');
+const studentService = require('./studentService');
+
+async function createStudentAccountRecord({ studentId, email, fullName, passwordHash }) {
+  return User.create({
+    studentId,
+    email: studentService.normalizeEmail(email),
+    fullName: fullName.trim(),
+    passwordHash,
+    role: 'STUDENT',
+    status: 'ACTIVE',
+  });
+}
+
+async function createStudentAccountFromValidatedData({ studentId, email, fullName, password }) {
+  const passwordHash = await bcrypt.hash(password, 10);
+
+  return createStudentAccountRecord({
+    studentId,
+    email,
+    fullName,
+    passwordHash,
+  });
+}
+
+module.exports = {
+  createStudentAccountFromValidatedData,
+  createStudentAccountRecord,
+};

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -1,5 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 
 process.env.JWT_SECRET = 'test-secret';
@@ -219,6 +220,70 @@ test('student registration validates eligibility, password strength, duplication
     studentId: '11070001000',
     alreadyRegistered: true,
   });
+
+  const createdStudent = await User.findOne({
+    where: { studentId: '11070001000' },
+  });
+
+  assert.ok(createdStudent.passwordHash);
+  assert.notEqual(createdStudent.passwordHash, 'StrongPass1!');
+  assert.equal(await bcrypt.compare('StrongPass1!', createdStudent.passwordHash), true);
+});
+
+test('direct student account creation endpoint persists hashed credentials securely', async () => {
+  const passwordHash = await bcrypt.hash('StrongPass1!', 10);
+  const created = await request('/api/v1/user-database/students', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      studentId: '11070001001',
+      email: 'dbcreate@example.edu',
+      fullName: 'Database Student',
+      passwordHash,
+    }),
+  });
+
+  assert.equal(created.response.status, 201);
+  assert.deepEqual(created.json, {
+    valid: true,
+    userId: created.json.userId,
+    studentId: '11070001001',
+    message: 'Student account created successfully',
+  });
+
+  const storedStudent = await User.findByPk(created.json.userId);
+  assert.equal(storedStudent.studentId, '11070001001');
+  assert.equal(storedStudent.email, 'dbcreate@example.edu');
+  assert.equal(storedStudent.passwordHash, passwordHash);
+  assert.equal(storedStudent.password, null);
+
+  const duplicateStudentId = await request('/api/v1/user-database/students', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      studentId: '11070001001',
+      email: 'other@example.edu',
+      fullName: 'Other Student',
+      passwordHash,
+    }),
+  });
+
+  assert.equal(duplicateStudentId.response.status, 409);
+  assert.equal(duplicateStudentId.json.code, 'ALREADY_REGISTERED');
+
+  const duplicateEmail = await request('/api/v1/user-database/students', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      studentId: '11070001002',
+      email: 'dbcreate@example.edu',
+      fullName: 'Other Student',
+      passwordHash,
+    }),
+  });
+
+  assert.equal(duplicateEmail.response.status, 409);
+  assert.equal(duplicateEmail.json.code, 'DUPLICATE_EMAIL');
 });
 
 test('github linking flow rejects unauthenticated requests and links account after callback', async () => {


### PR DESCRIPTION
## Summary
Implements Issue 5 for student account creation persistence.

## Changes
- Added `POST /api/v1/user-database/students`
- Added student account creation service for persistence flow
- Receives validated student data and creates the student record in the database
- Hashes raw passwords before persistence in the registration flow
- Stores student accounts securely with `passwordHash`
- Returns `valid: true`, `userId`, `studentId`, and success message
- Added tests for direct account creation and secure password storage

## Verification
- Ran backend test suite
- Result: 7/7 tests passed
