### PR TITLE
Issue 15: Verify professor password setup tokens

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -6,6 +6,7 @@ const { User } = require('./models');
 const adminRoutes = require('./routes/admin');
 const professorRoutes = require('./routes/professors');
 const studentRoutes = require('./routes/students');
+const passwordSetupTokenStoreRoutes = require('./routes/passwordSetupTokenStore');
 
 const app = express();
 const frontendDistPath = path.join(__dirname, '..', 'frontend', 'dist');
@@ -18,6 +19,7 @@ app.locals.models = { User };
 app.use('/api/v1/admin', adminRoutes);
 app.use('/api/v1/professors', professorRoutes);
 app.use('/api/v1', studentRoutes);
+app.use('/api/v1/password-setup-token-store', passwordSetupTokenStoreRoutes);
 
 app.use((err, req, res, next) => {
   console.error(err.stack);

--- a/backend/controllers/passwordSetupTokenController.js
+++ b/backend/controllers/passwordSetupTokenController.js
@@ -1,0 +1,31 @@
+const { body, validationResult } = require('express-validator');
+const professorService = require('../services/professorService');
+
+const verifySetupToken = [
+  body('setupToken').isString().trim().notEmpty(),
+
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        valid: false,
+        message: 'Invalid request body',
+      });
+    }
+
+    const { setupToken } = req.body;
+
+    try {
+      const result = await professorService.verifySetupToken(setupToken);
+
+      return res.status(200).json(result);
+    } catch (error) {
+      return res.status(500).json({
+        valid: false,
+        message: 'Internal Server Error',
+      });
+    }
+  },
+];
+
+module.exports = { verifySetupToken };

--- a/backend/routes/passwordSetupTokenStore.js
+++ b/backend/routes/passwordSetupTokenStore.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { verifySetupToken } = require('../controllers/passwordSetupTokenController');
+
+const router = express.Router();
+
+router.post('/verify', verifySetupToken);
+
+module.exports = router;

--- a/backend/services/professorService.js
+++ b/backend/services/professorService.js
@@ -29,6 +29,51 @@ class ProfessorService {
     return passwordPolicy.test(password);
   }
 
+  async verifySetupToken(setupToken) {
+    if (!setupToken || typeof setupToken !== 'string') {
+      return {
+        valid: false,
+        message: 'Setup token is invalid, expired, or already used',
+      };
+    }
+
+    const passwordSetupTokenHash = this.hashToken(setupToken);
+
+    const user = await User.findOne({
+      where: {
+        role: 'PROFESSOR',
+        status: 'PASSWORD_SETUP_REQUIRED',
+        passwordSetupTokenHash,
+        passwordSetupTokenExpiresAt: {
+          [Op.gt]: new Date(),
+        },
+      },
+    });
+
+    if (!user) {
+      return {
+        valid: false,
+        message: 'Setup token is invalid, expired, or already used',
+      };
+    }
+
+    const professor = await Professor.findOne({
+      where: { userId: user.id },
+    });
+
+    if (!professor) {
+      return {
+        valid: false,
+        message: 'Setup token is invalid, expired, or already used',
+      };
+    }
+
+    return {
+      valid: true,
+      professorId: professor.id,
+      message: 'Setup token verified',
+    };
+  }
   async registerProfessor(email, fullName, department) {
     const transaction = await sequelize.transaction();
 


### PR DESCRIPTION
## Summary
This PR implements Issue 15 by adding the backend endpoint for verifying professor password setup tokens.

The new endpoint checks whether a setup token exists, is still unused, and has not expired. If the token is valid, it returns the associated `professorId`.

## Implemented Endpoint
`POST /api/v1/password-setup-token-store/verify`

## Request Body
```json
{
  "setupToken": "pst_xxx"
}
