### PR TITLE
Issue 16: Update professor password in user database

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -6,6 +6,7 @@ const { User } = require('./models');
 const adminRoutes = require('./routes/admin');
 const professorRoutes = require('./routes/professors');
 const studentRoutes = require('./routes/students');
+const userDatabaseRoutes = require('./routes/userDatabase');
 
 const app = express();
 const frontendDistPath = path.join(__dirname, '..', 'frontend', 'dist');
@@ -18,6 +19,7 @@ app.locals.models = { User };
 app.use('/api/v1/admin', adminRoutes);
 app.use('/api/v1/professors', professorRoutes);
 app.use('/api/v1', studentRoutes);
+app.use('/api/v1/user-database', userDatabaseRoutes);
 
 app.use((err, req, res, next) => {
   console.error(err.stack);

--- a/backend/controllers/userDatabaseController.js
+++ b/backend/controllers/userDatabaseController.js
@@ -1,0 +1,40 @@
+const { body, param, validationResult } = require('express-validator');
+const professorService = require('../services/professorService');
+
+const updateProfessorPassword = [
+  param('professorId').isInt({ min: 1 }).toInt(),
+  body('passwordHash').isString().trim().notEmpty(),
+
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        message: 'Invalid request body',
+      });
+    }
+
+    const { professorId } = req.params;
+    const { passwordHash } = req.body;
+
+    try {
+      const result = await professorService.updateProfessorPassword(
+        Number(professorId),
+        passwordHash
+      );
+
+      return res.status(200).json(result);
+    } catch (error) {
+      if (error.message === 'PROFESSOR_NOT_FOUND') {
+        return res.status(404).json({
+          message: 'Professor not found',
+        });
+      }
+
+      return res.status(500).json({
+        message: 'Internal Server Error',
+      });
+    }
+  },
+];
+
+module.exports = { updateProfessorPassword };

--- a/backend/routes/userDatabase.js
+++ b/backend/routes/userDatabase.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { updateProfessorPassword } = require('../controllers/userDatabaseController');
+
+const router = express.Router();
+
+router.patch('/professors/:professorId/password', updateProfessorPassword);
+
+module.exports = router;

--- a/backend/services/professorService.js
+++ b/backend/services/professorService.js
@@ -29,6 +29,28 @@ class ProfessorService {
     return passwordPolicy.test(password);
   }
 
+  async updateProfessorPassword(professorId, passwordHash) {
+    const professor = await Professor.findByPk(professorId, {
+      include: [{ model: User }],
+    });
+
+    if (!professor || !professor.User) {
+      throw new Error('PROFESSOR_NOT_FOUND');
+    }
+
+    await professor.User.update({
+      password: passwordHash,
+      passwordHash,
+      status: 'ACTIVE',
+      passwordSetupTokenHash: null,
+      passwordSetupTokenExpiresAt: null,
+    });
+
+    return {
+      professorId: professor.id,
+      message: 'Professor password updated successfully',
+    };
+  }
   async registerProfessor(email, fullName, department) {
     const transaction = await sequelize.transaction();
 


### PR DESCRIPTION
## Summary
This PR implements Issue 16 by adding the internal endpoint for updating a professor password in the User Database after successful setup-token verification.

The new endpoint accepts a hashed password value, stores it for the related professor account, marks the account as active, and clears any remaining setup token data.

## Implemented Endpoint
`PATCH /api/v1/user-database/professors/{professorId}/password`

## Request Body
```json
{
  "passwordHash": "hashed_new_password_value"
}
