### PR TITLE
fix: harden github link flow and token handling

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,11 @@
+
+// This is an example .env file for the backend. Copy this to .env and fill in the values before running the application.
+// Do not commit your actual .env file to GitHub, as it may contain sensitive information.
+
 PORT=3001
 JWT_SECRET=replace-with-jwt-secret
 GITHUB_CLIENT_ID=replace-with-github-client-id
 GITHUB_CLIENT_SECRET=replace-with-github-client-secret
 FRONTEND_URL=http://localhost:5173
+FRONTEND_GITHUB_RETURN_URL=http://localhost:5173/students/register
 VALID_STUDENT_IDS=11070001000,11070001001,11070001002

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,7 +1,7 @@
-require('dotenv').config();
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') }); // Load environment variables from .env file
 const { User } = require('./models');
 const adminRoutes = require('./routes/admin');
 const coordinatorRoutes = require('./routes/coordinator');

--- a/backend/controllers/studentController.js
+++ b/backend/controllers/studentController.js
@@ -345,7 +345,8 @@ async function handleGitHubCallback(req, res) {
   } catch (error) {
     const status = (
       error.code === 'GITHUB_ACCOUNT_ALREADY_LINKED' ||
-      error.code === 'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT'
+      error.code === 'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT' ||
+      error.code === 'GITHUB_RELINK_NOT_ALLOWED'
     ) ? 409 : 500;
 
     if (shouldRedirectToFrontend(req)) {
@@ -404,6 +405,13 @@ const storeLinkedGitHubAccount = [
       }
 
       if (error.code === 'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT') {
+        return res.status(409).json({
+          code: error.code,
+          message: error.message,
+        });
+      }
+
+      if (error.code === 'GITHUB_RELINK_NOT_ALLOWED') {
         return res.status(409).json({
           code: error.code,
           message: error.message,

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,8 +1,20 @@
+  const path = require('path');
   const { Sequelize } = require('sequelize');
+
+  const configuredStorage = process.env.SQLITE_STORAGE;
+  const resolvedStorage = configuredStorage
+    ? (
+      configuredStorage === ':memory:' || configuredStorage.startsWith('file:')
+        ? configuredStorage
+        : (path.isAbsolute(configuredStorage)
+          ? configuredStorage
+          : path.join(__dirname, configuredStorage))
+    )
+    : path.join(__dirname, 'database.sqlite');
 
   const sequelize = new Sequelize({
     dialect: 'sqlite',
-    storage: process.env.SQLITE_STORAGE || 'database.sqlite',
+    storage: resolvedStorage,
     logging: false,
   });
 

--- a/backend/generateStudentToken.js
+++ b/backend/generateStudentToken.js
@@ -4,7 +4,9 @@
 // For only development/testing purposes. Do not use in production.
 
 const jwt = require('jsonwebtoken');
-require('dotenv').config();
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env'), quiet: true });
+const { User } = require('./models');
 
 const userId = Number(process.argv[2]);
 
@@ -18,9 +20,30 @@ if (!process.env.JWT_SECRET) {
   process.exit(1);
 }
 
-const token = jwt.sign(
-  { id: userId, role: 'STUDENT' },
-  process.env.JWT_SECRET,
-);
+async function run() {
+  const user = await User.findByPk(userId);
 
-console.log(token);
+  if (!user) {
+    console.error(`User not found for id=${userId}`);
+    process.exit(1);
+  }
+
+  if (user.role !== 'STUDENT' || user.status !== 'ACTIVE' || !user.studentId) {
+    console.error(
+      `User id=${userId} is not an active student account. role=${user.role}, status=${user.status}, studentId=${user.studentId || '-'}`,
+    );
+    process.exit(1);
+  }
+
+  const token = jwt.sign(
+    { id: userId, role: 'STUDENT' },
+    process.env.JWT_SECRET,
+  );
+
+  console.log(token);
+}
+
+run().catch((error) => {
+  console.error('Failed to generate token:', error.message);
+  process.exit(1);
+});

--- a/backend/services/githubLinkService.js
+++ b/backend/services/githubLinkService.js
@@ -36,7 +36,7 @@ function buildAuthorizationUrl(state) {
 }
 
 function getFrontendUrl() {
-  return process.env.FRONTEND_URL || 'http://localhost:5173';
+  return process.env.FRONTEND_GITHUB_RETURN_URL || process.env.FRONTEND_URL || 'http://localhost:5173';
 }
 
 async function createOAuthState(userId) {
@@ -175,20 +175,18 @@ async function storeLinkedGitHubAccount({ studentId, githubId, githubUsername })
       throw error;
     }
 
-    let linkedAccount;
     if (existingLinkedAccount) {
-      // Re-linking the same student updates the stored GitHub identity instead of
-      // creating duplicate rows for the same user.
-      existingLinkedAccount.githubId = githubId;
-      existingLinkedAccount.githubUsername = githubUsername;
-      linkedAccount = await existingLinkedAccount.save({ transaction });
-    } else {
-      linkedAccount = await LinkedGitHubAccount.create({
-        userId: student.id,
-        githubId,
-        githubUsername,
-      }, { transaction });
+      const error = new Error('A GitHub account is already linked for this student. Unlink is required before linking a different account.');
+      error.code = 'GITHUB_RELINK_NOT_ALLOWED';
+      throw error;
     }
+
+    let linkedAccount;
+    linkedAccount = await LinkedGitHubAccount.create({
+      userId: student.id,
+      githubId,
+      githubUsername,
+    }, { transaction });
 
     student.githubUsername = githubUsername;
     student.githubLinked = true;

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -1204,6 +1204,19 @@ test('manual linked account store and github patch endpoint update student statu
   assert.equal(storeResult.response.status, 200);
   assert.equal(storeResult.json.linked, true);
 
+  const relinkAttempt = await request('/api/v1/linked-github-account-store/links', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      studentId: '11070001001',
+      githubId: '87654321',
+      githubUsername: 'student-gh-second',
+    }),
+  });
+
+  assert.equal(relinkAttempt.response.status, 409);
+  assert.equal(relinkAttempt.json.code, 'GITHUB_RELINK_NOT_ALLOWED');
+
   const patchResult = await request('/api/v1/user-database/students/11070001001/github-link', {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/Register.jsx
+++ b/frontend/src/Register.jsx
@@ -33,6 +33,8 @@ function mapErrorResponse(payload) {
       return { type: 'error', title: 'Student not eligible', result: 'Rejected' };
     case 'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT':
       return { type: 'warning', title: 'GitHub already linked', result: 'Already linked' };
+    case 'GITHUB_RELINK_NOT_ALLOWED':
+      return { type: 'warning', title: 'Re-link not allowed', result: 'Already linked' };
     default:
       return { type: 'error', title: 'Validation failed', result: 'Failed' };
   }
@@ -189,7 +191,9 @@ export default function Register() {
   }
 
   async function handleGitHubLink() {
-    if (!studentToken.trim()) {
+    const trimmedStudentToken = studentToken.trim();
+
+    if (!trimmedStudentToken) {
       setFeedback({
         type: 'warning',
         title: 'Student token required',
@@ -221,10 +225,15 @@ export default function Register() {
     });
 
     try {
-      const response = await apiClient.get('/v1/students/me/github/link');
-      const result = response.data;
+      const response = await fetch('/api/v1/students/me/github/link', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${trimmedStudentToken}`,
+        },
+      });
+      const result = await response.json();
 
-      if (response.status >= 400) {
+      if (!response.ok) {
         setFeedback({
           type: 'error',
           title: 'GitHub link could not start',


### PR DESCRIPTION
## Summary

- Fixes GitHub link start to use the student token provided in the UI.
- Hardens backend env/db resolution to avoid token validation mismatches.
- Prevents linking a second different GitHub account to the same student.
- Adds/updates error mappings for link conflict cases.
- Extends backend tests for re-link prevention.
- Hardened generateStudentToken.js to only generate tokens for active student accounts and to load env deterministically from backend/.env.

## Notes

- This PR is intentionally separate from `createCoordinator` changes.
