### PR TITLE
feat: implement Group model and GroupService.createShell (D2 write)

### DIFF
--- a/backend/models/Group.js
+++ b/backend/models/Group.js
@@ -11,6 +11,10 @@ const Group = sequelize.define('Group', {
   name: {
     type: DataTypes.STRING,
     allowNull: false,
+  },
+  normalizedName: {
+    type: DataTypes.STRING,
+    allowNull: false,
     unique: true,
   },
   leaderId: {

--- a/backend/models/Group.js
+++ b/backend/models/Group.js
@@ -1,0 +1,43 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+const User = require('./User');
+
+const Group = sequelize.define('Group', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+  },
+  leaderId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: User,
+      key: 'id',
+    },
+  },
+  memberIds: {
+    type: DataTypes.JSON,
+    allowNull: false,
+    defaultValue: [],
+  },
+  advisorId: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    defaultValue: null,
+    references: {
+      model: User,
+      key: 'id',
+    },
+  },
+});
+
+User.hasMany(Group, { foreignKey: 'leaderId' });
+Group.belongsTo(User, { foreignKey: 'leaderId' });
+
+module.exports = Group;

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -3,6 +3,7 @@ const Professor = require('./Professor');
 const ValidStudentId = require('./ValidStudentId');
 const OAuthState = require('./OAuthState');
 const LinkedGitHubAccount = require('./LinkedGitHubAccount');
+const Group = require('./Group');
 
 module.exports = {
   User,
@@ -10,4 +11,5 @@ module.exports = {
   ValidStudentId,
   OAuthState,
   LinkedGitHubAccount,
+  Group,
 };

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -1,0 +1,42 @@
+const sequelize = require('../db');
+const Group = require('../models/Group');
+
+class GroupService {
+  async createShell(name, leaderId) {
+    const transaction = await sequelize.transaction();
+
+    try {
+      const group = await Group.create({
+        name: name.trim(),
+        leaderId,
+        memberIds: [leaderId],
+        advisorId: null,
+      }, { transaction });
+
+      await transaction.commit();
+
+      return {
+        id: group.id,
+        name: group.name,
+        leaderId: group.leaderId,
+        memberIds: group.memberIds,
+        advisorId: group.advisorId,
+      };
+    } catch (error) {
+      await transaction.rollback();
+
+      if (
+        error.name === 'SequelizeUniqueConstraintError' &&
+        error.errors?.some((entry) => entry.path === 'name')
+      ) {
+        const duplicateError = new Error('Group with this name already exists');
+        duplicateError.code = 'DUPLICATE_GROUP_NAME';
+        throw duplicateError;
+      }
+
+      throw error;
+    }
+  }
+}
+
+module.exports = new GroupService();

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -3,11 +3,21 @@ const Group = require('../models/Group');
 
 class GroupService {
   async createShell(name, leaderId) {
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      const err = new Error('Group name must be a non-empty string');
+      err.code = 'INVALID_GROUP_NAME';
+      throw err;
+    }
+
+    const trimmedName = name.trim();
+    const normalizedName = trimmedName.toLowerCase();
+
     const transaction = await sequelize.transaction();
 
     try {
       const group = await Group.create({
-        name: name.trim(),
+        name: trimmedName,
+        normalizedName,
         leaderId,
         memberIds: [leaderId],
         advisorId: null,
@@ -27,11 +37,19 @@ class GroupService {
 
       if (
         error.name === 'SequelizeUniqueConstraintError' &&
-        error.errors?.some((entry) => entry.path === 'name')
+        error.errors?.some((entry) =>
+          entry.path === 'name' || entry.path === 'normalizedName'
+        )
       ) {
         const duplicateError = new Error('Group with this name already exists');
         duplicateError.code = 'DUPLICATE_GROUP_NAME';
         throw duplicateError;
+      }
+
+      if (error.name === 'SequelizeForeignKeyConstraintError') {
+        const fkError = new Error('Leader not found');
+        fkError.code = 'LEADER_NOT_FOUND';
+        throw fkError;
       }
 
       throw error;


### PR DESCRIPTION
Summary

Hardens GroupService.createShell (D2 write) against three runtime and
correctness issues identified in code review: a crash on invalid name input,
case-variant duplicate groups slipping past the unique constraint, and FK
violations surfacing as opaque 500 errors.


What changed

backend/models/Group.js
  - Removed the unique constraint from the raw `name` column.
  - Added a new `normalizedName` column (STRING, allowNull: false, unique: true)
    that stores the lowercase form of the trimmed name. Uniqueness is now
    enforced on this column so it is deterministic regardless of DB collation.

backend/services/groupService.js
  - Added an input guard at the top of createShell. If `name` is not a string
    or trims to an empty string, a domain error is thrown immediately with code
    INVALID_GROUP_NAME before any DB work begins. This prevents a TypeError
    from name.trim() crashing the process when the caller passes undefined,
    null, or a non-string value.
  - name.trim() is now called once, stored in `trimmedName`, and
    `normalizedName` is derived from it via .toLowerCase(). Both are passed
    to Group.create().
  - The SequelizeUniqueConstraintError handler now covers both the `name` and
    `normalizedName` paths so duplicate detection works correctly after the
    schema change.
  - Added a catch branch for SequelizeForeignKeyConstraintError that maps the
    error to a stable domain error code LEADER_NOT_FOUND. Previously an invalid
    leaderId caused an unhandled FK error to bubble up as a generic 500.


Error codes introduced / affected

  INVALID_GROUP_NAME  — name is missing, not a string, or blank
  DUPLICATE_GROUP_NAME — a group with the same name (case-insensitive) exists
  LEADER_NOT_FOUND    — leaderId references a user that does not exist


Behavior notes

  - "Team Alpha", "team alpha", and "TEAM ALPHA" are now treated as the same
    group name and will all produce DUPLICATE_GROUP_NAME after the first one
    is created.
  - The `name` column still stores the original trimmed casing supplied by the
    caller for display purposes.
  - No changes to the public return shape of createShell.
