### PR TITLE
64 issue 3 dispatch invitations data flow f3 backend

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -9,6 +9,7 @@ const professorRoutes = require('./routes/professors');
 const studentRoutes = require('./routes/students');
 const passwordSetupTokenStoreRoutes = require('./routes/passwordSetupTokenStore');
 const userDatabaseRoutes = require('./routes/userDatabase');
+const groupRoutes = require('./routes/groups');
 
 const app = express();
 const frontendDistPath = path.join(__dirname, '..', 'frontend', 'dist');
@@ -24,6 +25,7 @@ app.use('/api/v1/professors', professorRoutes);
 app.use('/api/v1', studentRoutes);
 app.use('/api/v1/password-setup-token-store', passwordSetupTokenStoreRoutes);
 app.use('/api/v1/user-database', userDatabaseRoutes);
+app.use('/api/v1/groups', groupRoutes);
 
 app.use((err, req, res, next) => {
   console.error(err.stack);

--- a/backend/controllers/groupFormationController.js
+++ b/backend/controllers/groupFormationController.js
@@ -1,0 +1,50 @@
+const { body, validationResult } = require('express-validator');
+const groupService = require('../services/groupService');
+
+const buildErrorResponse = (message, errorCode) => ({ message, errorCode });
+
+const handleDispatchInvites = [
+  body('studentIds')
+    .isArray({ min: 1 })
+    .withMessage('studentIds must be a non-empty array'),
+  body('studentIds.*')
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage('Each studentId must be a non-empty string'),
+
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json(
+        buildErrorResponse('Invalid payload', 'VALIDATION_FAILED')
+      );
+    }
+
+    const { groupId } = req.params;
+    const { studentIds } = req.body;
+
+    try {
+      const invitations = await groupService.dispatchInvitations(groupId, studentIds);
+      return res.status(201).json(invitations);
+    } catch (error) {
+      if (error.code === 'GROUP_NOT_FOUND') {
+        return res.status(404).json(
+          buildErrorResponse('Group not found', 'GROUP_NOT_FOUND')
+        );
+      }
+
+      if (error.code === 'STUDENT_NOT_FOUND') {
+        return res.status(400).json(
+          buildErrorResponse('One or more students not found', 'STUDENT_NOT_FOUND')
+        );
+      }
+
+      return res.status(500).json(
+        buildErrorResponse('Internal Server Error', 'INTERNAL_SERVER_ERROR')
+      );
+    }
+  },
+];
+
+module.exports = { handleDispatchInvites };

--- a/backend/controllers/groupFormationController.js
+++ b/backend/controllers/groupFormationController.js
@@ -35,9 +35,10 @@ const handleDispatchInvites = [
       }
 
       if (error.code === 'STUDENT_NOT_FOUND') {
-        return res.status(400).json(
-          buildErrorResponse('One or more students not found', 'STUDENT_NOT_FOUND')
-        );
+        return res.status(400).json({
+          ...buildErrorResponse('One or more students not found', 'STUDENT_NOT_FOUND'),
+          missingStudentIds: error.missing,
+        });
       }
 
       return res.status(500).json(

--- a/backend/models/Group.js
+++ b/backend/models/Group.js
@@ -1,0 +1,43 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+const User = require('./User');
+
+const Group = sequelize.define('Group', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+  },
+  leaderId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: User,
+      key: 'id',
+    },
+  },
+  memberIds: {
+    type: DataTypes.JSON,
+    allowNull: false,
+    defaultValue: [],
+  },
+  advisorId: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    defaultValue: null,
+    references: {
+      model: User,
+      key: 'id',
+    },
+  },
+});
+
+User.hasMany(Group, { foreignKey: 'leaderId' });
+Group.belongsTo(User, { foreignKey: 'leaderId' });
+
+module.exports = Group;

--- a/backend/models/Invitation.js
+++ b/backend/models/Invitation.js
@@ -1,0 +1,41 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+const Group = require('./Group');
+const User = require('./User');
+
+const Invitation = sequelize.define('Invitation', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  groupId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: {
+      model: Group,
+      key: 'id',
+    },
+  },
+  inviteeId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: User,
+      key: 'id',
+    },
+  },
+  status: {
+    type: DataTypes.ENUM('PENDING', 'ACCEPTED', 'REJECTED'),
+    allowNull: false,
+    defaultValue: 'PENDING',
+  },
+});
+
+Group.hasMany(Invitation, { foreignKey: 'groupId' });
+Invitation.belongsTo(Group, { foreignKey: 'groupId' });
+
+User.hasMany(Invitation, { foreignKey: 'inviteeId' });
+Invitation.belongsTo(User, { foreignKey: 'inviteeId' });
+
+module.exports = Invitation;

--- a/backend/models/Invitation.js
+++ b/backend/models/Invitation.js
@@ -30,6 +30,10 @@ const Invitation = sequelize.define('Invitation', {
     allowNull: false,
     defaultValue: 'PENDING',
   },
+}, {
+  indexes: [
+    { unique: true, fields: ['groupId', 'inviteeId'] },
+  ],
 });
 
 Group.hasMany(Invitation, { foreignKey: 'groupId' });

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -3,6 +3,7 @@ const Professor = require('./Professor');
 const ValidStudentId = require('./ValidStudentId');
 const OAuthState = require('./OAuthState');
 const LinkedGitHubAccount = require('./LinkedGitHubAccount');
+const Group = require('./Group');
 
 module.exports = {
   User,
@@ -10,4 +11,5 @@ module.exports = {
   ValidStudentId,
   OAuthState,
   LinkedGitHubAccount,
+  Group,
 };

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -4,6 +4,7 @@ const ValidStudentId = require('./ValidStudentId');
 const OAuthState = require('./OAuthState');
 const LinkedGitHubAccount = require('./LinkedGitHubAccount');
 const Group = require('./Group');
+const Invitation = require('./Invitation');
 
 module.exports = {
   User,
@@ -12,4 +13,5 @@ module.exports = {
   OAuthState,
   LinkedGitHubAccount,
   Group,
+  Invitation,
 };

--- a/backend/routes/groups.js
+++ b/backend/routes/groups.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { authenticate } = require('../middleware/auth');
+const { handleDispatchInvites } = require('../controllers/groupFormationController');
+
+const router = express.Router();
+
+router.post('/:groupId/invitations', authenticate, handleDispatchInvites);
+
+module.exports = router;

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -1,0 +1,42 @@
+const sequelize = require('../db');
+const Group = require('../models/Group');
+
+class GroupService {
+  async createShell(name, leaderId) {
+    const transaction = await sequelize.transaction();
+
+    try {
+      const group = await Group.create({
+        name: name.trim(),
+        leaderId,
+        memberIds: [leaderId],
+        advisorId: null,
+      }, { transaction });
+
+      await transaction.commit();
+
+      return {
+        id: group.id,
+        name: group.name,
+        leaderId: group.leaderId,
+        memberIds: group.memberIds,
+        advisorId: group.advisorId,
+      };
+    } catch (error) {
+      await transaction.rollback();
+
+      if (
+        error.name === 'SequelizeUniqueConstraintError' &&
+        error.errors?.some((entry) => entry.path === 'name')
+      ) {
+        const duplicateError = new Error('Group with this name already exists');
+        duplicateError.code = 'DUPLICATE_GROUP_NAME';
+        throw duplicateError;
+      }
+
+      throw error;
+    }
+  }
+}
+
+module.exports = new GroupService();

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -1,5 +1,8 @@
+const { Op } = require('sequelize');
 const sequelize = require('../db');
 const Group = require('../models/Group');
+const Invitation = require('../models/Invitation');
+const User = require('../models/User');
 
 class GroupService {
   async createShell(name, leaderId) {
@@ -36,6 +39,68 @@ class GroupService {
 
       throw error;
     }
+  }
+
+  async dispatchInvitations(groupId, rawStudentIds) {
+    // De-duplicate incoming student IDs
+    const studentIds = [...new Set(rawStudentIds)];
+
+    // f2 → validate groupId exists in D2
+    const group = await Group.findByPk(groupId);
+    if (!group) {
+      const err = new Error('Group not found');
+      err.code = 'GROUP_NOT_FOUND';
+      throw err;
+    }
+
+    // f4 → fetch D1 profiles for every requested student ID
+    const users = await User.findAll({
+      where: {
+        studentId: { [Op.in]: studentIds },
+        role: 'STUDENT',
+      },
+    });
+
+    const foundStudentIds = users.map((u) => u.studentId);
+    const missing = studentIds.filter((sid) => !foundStudentIds.includes(sid));
+    if (missing.length > 0) {
+      const err = new Error('One or more students not found');
+      err.code = 'STUDENT_NOT_FOUND';
+      err.missing = missing;
+      throw err;
+    }
+
+    // f5 → persist D8 invitations atomically
+    const transaction = await sequelize.transaction();
+    let invitations;
+    try {
+      invitations = await Promise.all(
+        users.map((user) =>
+          Invitation.create(
+            { groupId, inviteeId: user.id, status: 'PENDING' },
+            { transaction }
+          )
+        )
+      );
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+
+    // f6 → trigger notifications only after successful persistence
+    for (const user of users) {
+      console.log(
+        `[Notification] Invitation dispatched → studentId: ${user.studentId}, groupId: ${groupId}`
+      );
+    }
+
+    return invitations.map((inv, i) => ({
+      id: inv.id,
+      groupId: inv.groupId,
+      studentId: users[i].studentId,
+      status: inv.status,
+    }));
   }
 }
 

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -62,7 +62,8 @@ class GroupService {
     });
 
     const foundStudentIds = users.map((u) => u.studentId);
-    const missing = studentIds.filter((sid) => !foundStudentIds.includes(sid));
+    const foundSet = new Set(foundStudentIds);
+    const missing = studentIds.filter((sid) => !foundSet.has(sid));
     if (missing.length > 0) {
       const err = new Error('One or more students not found');
       err.code = 'STUDENT_NOT_FOUND';
@@ -75,12 +76,14 @@ class GroupService {
     let invitations;
     try {
       invitations = await Promise.all(
-        users.map((user) =>
-          Invitation.create(
-            { groupId, inviteeId: user.id, status: 'PENDING' },
-            { transaction }
-          )
-        )
+        users.map(async (user) => {
+          const [inv] = await Invitation.findOrCreate({
+            where: { groupId, inviteeId: user.id },
+            defaults: { status: 'PENDING' },
+            transaction,
+          });
+          return inv;
+        })
       );
       await transaction.commit();
     } catch (error) {


### PR DESCRIPTION
Summary

Implements the dispatch invitations data flow (F3 / P22) for group formation —
the backend path that lets a group leader send membership invitations to students
by student ID. Also includes the Group model and GroupService.createShell (D2
write) required as a foundation.

A follow-up hardening commit addresses three code-review findings: idempotency,
actionable error responses, and an O(n^2) lookup.


What changed

New files:

  backend/models/Group.js
    Sequelize model for the Group entity (UUID PK, unique name, leaderId,
    memberIds JSON, nullable advisorId).

  backend/models/Invitation.js
    Sequelize model for Invitation (groupId + inviteeId FKs,
    PENDING/ACCEPTED/REJECTED enum, composite unique index on
    (groupId, inviteeId)).

  backend/services/groupService.js
    GroupService with createShell and dispatchInvitations.

  backend/controllers/groupFormationController.js
    handleDispatchInvites — express-validator middleware chain + async handler.

  backend/routes/groups.js
    POST /api/v1/groups/:groupId/invitations wired to authenticate + controller.

Modified files:

  backend/models/index.js   — export Group and Invitation
  backend/app.js            — mount /api/v1/groups router


Endpoint

  POST /api/v1/groups/:groupId/invitations
  Authorization: Bearer <token>
  Body: { "studentIds": ["S001", "S002", "S003"] }

  Happy path — 201:
    [{ "id": "<uuid>", "groupId": "<uuid>", "studentId": "S001", "status": "PENDING" }, ...]

  Error responses:
    400 VALIDATION_FAILED    — missing or malformed studentIds field
    404 GROUP_NOT_FOUND      — groupId does not exist
    400 STUDENT_NOT_FOUND    — one or more IDs not found; body includes
                               missingStudentIds: [...]
    500 INTERNAL_SERVER_ERROR


Hardening (code-review fixes)

1. Idempotency — Invitation.js + groupService.js

   The original Invitation.create() had no uniqueness guarantee. Re-dispatching
   to the same student would insert a duplicate row and, once the unique index is
   added, crash with an unhandled SequelizeUniqueConstraintError -> 500.

   Fix: added a composite UNIQUE index on (groupId, inviteeId) in the model, and
   replaced Invitation.create() with Invitation.findOrCreate({ where: { groupId,
   inviteeId }, defaults: { status: 'PENDING' } }). Re-dispatching the same
   student now returns the existing record deterministically instead of failing.

2. Missing-ID detail in error response — groupFormationController.js

   The STUDENT_NOT_FOUND 400 response previously contained only message and
   errorCode. The service already computed and attached err.missing (the array of
   unresolved IDs) but it was silently dropped in the controller. Without it,
   clients could not determine which IDs to correct before retrying.

   Fix: spread missingStudentIds: error.missing into the response body.

3. O(n^2) -> O(n) membership check — groupService.js

   foundStudentIds.includes(sid) inside .filter() iterated the full found array
   for every requested ID — quadratic in the size of the payload.

   Fix: built a Set from foundStudentIds once and used foundSet.has(sid) for O(1)
   lookups, making the overall check linear.


Test plan

  - POST with valid student IDs -> 201, array of invitation objects
  - Same request repeated -> 201 again, same invitation IDs returned (idempotent)
  - Unknown student ID in payload -> 400 with missingStudentIds listing the bad ID(s)
  - Non-existent groupId -> 404
  - Missing / malformed studentIds field -> 400 VALIDATION_FAILED
  - npm test passes in backend/
