### PR TITLE
69 issue 5 store pending invitations data flow f5 backend

### DIFF
--- a/backend/controllers/groupFormationController.js
+++ b/backend/controllers/groupFormationController.js
@@ -40,6 +40,15 @@ const handleDispatchInvites = [
         );
       }
 
+      if (error.code === 'DUPLICATE_INVITATION') {
+        return res.status(400).json(
+          buildErrorResponse(
+            'One or more students already have a pending invitation for this group',
+            'DUPLICATE_INVITATION'
+          )
+        );
+      }
+
       return res.status(500).json(
         buildErrorResponse('Internal Server Error', 'INTERNAL_SERVER_ERROR')
       );

--- a/backend/controllers/groupFormationController.js
+++ b/backend/controllers/groupFormationController.js
@@ -25,7 +25,7 @@ const handleDispatchInvites = [
     const { studentIds } = req.body;
 
     try {
-      const invitations = await groupService.dispatchInvitations(groupId, studentIds);
+      const invitations = await groupService.dispatchInvitations(groupId, studentIds, req.user);
       return res.status(201).json(invitations);
     } catch (error) {
       if (error.code === 'GROUP_NOT_FOUND') {
@@ -34,10 +34,17 @@ const handleDispatchInvites = [
         );
       }
 
-      if (error.code === 'STUDENT_NOT_FOUND') {
-        return res.status(400).json(
-          buildErrorResponse('One or more students not found', 'STUDENT_NOT_FOUND')
+      if (error.code === 'FORBIDDEN') {
+        return res.status(403).json(
+          buildErrorResponse('Not authorized to dispatch invitations for this group', 'FORBIDDEN')
         );
+      }
+
+      if (error.code === 'STUDENT_NOT_FOUND') {
+        return res.status(400).json({
+          ...buildErrorResponse('One or more students not found', 'STUDENT_NOT_FOUND'),
+          missingStudentIds: error.missing,
+        });
       }
 
       if (error.code === 'DUPLICATE_INVITATION') {

--- a/backend/models/Invitation.js
+++ b/backend/models/Invitation.js
@@ -3,34 +3,50 @@ const sequelize = require('../db');
 const Group = require('./Group');
 const User = require('./User');
 
-const Invitation = sequelize.define('Invitation', {
-  id: {
-    type: DataTypes.UUID,
-    defaultValue: DataTypes.UUIDV4,
-    primaryKey: true,
-  },
-  groupId: {
-    type: DataTypes.UUID,
-    allowNull: false,
-    references: {
-      model: Group,
-      key: 'id',
+const Invitation = sequelize.define(
+  'Invitation',
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    groupId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: Group,
+        key: 'id',
+      },
+    },
+    inviteeId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: User,
+        key: 'id',
+      },
+    },
+    status: {
+      type: DataTypes.ENUM('PENDING', 'ACCEPTED', 'REJECTED'),
+      allowNull: false,
+      defaultValue: 'PENDING',
     },
   },
-  inviteeId: {
-    type: DataTypes.INTEGER,
-    allowNull: false,
-    references: {
-      model: User,
-      key: 'id',
-    },
-  },
-  status: {
-    type: DataTypes.ENUM('PENDING', 'ACCEPTED', 'REJECTED'),
-    allowNull: false,
-    defaultValue: 'PENDING',
-  },
-});
+  {
+    indexes: [
+      {
+        // Duplicate-prevention: one active invitation per (group, invitee) pair.
+        // Strategy: DB unique constraint → SequelizeUniqueConstraintError → 400.
+        // Chosen over pre-check to avoid TOCTOU races; over ignore-duplicates to
+        // give callers a deterministic, actionable error.
+        unique: true,
+        fields: ['groupId', 'inviteeId'],
+        name: 'invitations_groupId_inviteeId_unique',
+      },
+    ],
+  }
+);
 
 Group.hasMany(Invitation, { foreignKey: 'groupId' });
 Invitation.belongsTo(Group, { foreignKey: 'groupId' });

--- a/backend/repositories/invitationsRepository.js
+++ b/backend/repositories/invitationsRepository.js
@@ -1,0 +1,52 @@
+const Invitation = require('../models/Invitation');
+
+/**
+ * InvitationsRepository
+ *
+ * Owns all D8 (Pending Invitations) write/read operations.
+ *
+ * Duplicate strategy: DB unique constraint on (groupId, inviteeId).
+ * bulkCreate catches SequelizeUniqueConstraintError and re-throws a
+ * domain error with code DUPLICATE_INVITATION so the service/controller
+ * can return a deterministic 400 without relying on pre-checks that
+ * are vulnerable to TOCTOU races.
+ */
+class InvitationsRepository {
+  /**
+   * Persist one PENDING Invitation row per inviteeId.
+   * Must be called inside an existing transaction so the caller controls
+   * atomicity together with any sibling writes.
+   *
+   * @param {string}   groupId     - UUID of the target group (D2 key)
+   * @param {number[]} inviteeIds  - Array of User PKs (integers) to invite
+   * @param {object}   transaction - Active Sequelize transaction
+   * @returns {Promise<Invitation[]>} Created records with stable UUIDs
+   */
+  async bulkCreate(groupId, inviteeIds, transaction) {
+    try {
+      const invitations = await Promise.all(
+        inviteeIds.map((inviteeId) =>
+          Invitation.create(
+            { groupId, inviteeId, status: 'PENDING' },
+            { transaction }
+          )
+        )
+      );
+      return invitations;
+    } catch (error) {
+      if (
+        error.name === 'SequelizeUniqueConstraintError' &&
+        error.errors?.some((e) => e.path === 'invitations_groupId_inviteeId_unique')
+      ) {
+        const duplicateError = new Error(
+          'One or more students already have a pending invitation for this group'
+        );
+        duplicateError.code = 'DUPLICATE_INVITATION';
+        throw duplicateError;
+      }
+      throw error;
+    }
+  }
+}
+
+module.exports = new InvitationsRepository();

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -1,8 +1,8 @@
 const { Op } = require('sequelize');
 const sequelize = require('../db');
 const Group = require('../models/Group');
-const Invitation = require('../models/Invitation');
 const User = require('../models/User');
+const invitationsRepository = require('../repositories/invitationsRepository');
 
 class GroupService {
   async createShell(name, leaderId) {
@@ -70,18 +70,12 @@ class GroupService {
       throw err;
     }
 
-    // f5 → persist D8 invitations atomically
+    // f5 → persist D8 invitations atomically via repository
+    const inviteeIds = users.map((u) => u.id);
     const transaction = await sequelize.transaction();
     let invitations;
     try {
-      invitations = await Promise.all(
-        users.map((user) =>
-          Invitation.create(
-            { groupId, inviteeId: user.id, status: 'PENDING' },
-            { transaction }
-          )
-        )
-      );
+      invitations = await invitationsRepository.bulkCreate(groupId, inviteeIds, transaction);
       await transaction.commit();
     } catch (error) {
       await transaction.rollback();

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -41,7 +41,7 @@ class GroupService {
     }
   }
 
-  async dispatchInvitations(groupId, rawStudentIds) {
+  async dispatchInvitations(groupId, rawStudentIds, caller) {
     // De-duplicate incoming student IDs
     const studentIds = [...new Set(rawStudentIds)];
 
@@ -50,6 +50,16 @@ class GroupService {
     if (!group) {
       const err = new Error('Group not found');
       err.code = 'GROUP_NOT_FOUND';
+      throw err;
+    }
+
+    // f3 → enforce ownership/role: only the group leader, a coordinator, or an
+    // admin may dispatch invitations on behalf of a group.
+    const isLeader = group.leaderId === caller.id;
+    const isPrivileged = ['COORDINATOR', 'ADMIN'].includes(caller.role);
+    if (!isLeader && !isPrivileged) {
+      const err = new Error('Not authorized to dispatch invitations for this group');
+      err.code = 'FORBIDDEN';
       throw err;
     }
 
@@ -62,7 +72,8 @@ class GroupService {
     });
 
     const foundStudentIds = users.map((u) => u.studentId);
-    const missing = studentIds.filter((sid) => !foundStudentIds.includes(sid));
+    const foundSet = new Set(foundStudentIds);
+    const missing = studentIds.filter((sid) => !foundSet.has(sid));
     if (missing.length > 0) {
       const err = new Error('One or more students not found');
       err.code = 'STUDENT_NOT_FOUND';


### PR DESCRIPTION
Summary

Addresses four code-review findings on POST /groups/:groupId/invitations.
Duplicate-invitation protection was already in place via the DB unique index
on (groupId, inviteeId) in Invitation.js and the invitationsRepository mapping
SequelizeUniqueConstraintError to the DUPLICATE_INVITATION domain error. The
remaining three items — authorization, missing error detail, and a quadratic
lookup — are fixed in this commit.


What changed

backend/services/groupService.js

  Authorization check (new, blocking)
    dispatchInvitations now accepts a third parameter `caller` (the
    authenticated User record forwarded from the controller). After the group
    is fetched, the service checks whether the caller is the group leader
    (group.leaderId === caller.id) or holds a COORDINATOR or ADMIN role. If
    neither condition is true, a FORBIDDEN domain error is thrown before any
    further work is done. No extra DB round-trip is needed because the group
    record is already in memory at this point.

  O(n) membership check
    Replaced foundStudentIds.includes(sid) inside .filter() with a Set built
    once from foundStudentIds. Each lookup is now O(1); the overall check is
    linear instead of quadratic for large payloads.

backend/controllers/groupFormationController.js

  - Forwards req.user as the third argument to groupService.dispatchInvitations.
  - Added a FORBIDDEN branch that returns 403 with errorCode FORBIDDEN when
    the service throws that domain error.
  - The STUDENT_NOT_FOUND 400 response now spreads missingStudentIds:
    error.missing into the response body so clients can identify exactly which
    IDs to correct before retrying a bulk request.


Already-implemented items (no change needed)

  Duplicate invitation protection
    Invitation.js carries a named composite unique index on (groupId, inviteeId)
    (invitations_groupId_inviteeId_unique). invitationsRepository.bulkCreate
    catches SequelizeUniqueConstraintError on that constraint and re-throws a
    domain error with code DUPLICATE_INVITATION. The controller already returns
    a deterministic 400 for this code. No TOCTOU-vulnerable pre-check is needed.


Error codes introduced / affected

  FORBIDDEN           — caller is not the group leader, coordinator, or admin (403)
  DUPLICATE_INVITATION — one or more invitees already have an active invitation
                         for this group (400, pre-existing)
  STUDENT_NOT_FOUND   — one or more student IDs not found; body now includes
                         missingStudentIds array (400)
  GROUP_NOT_FOUND     — groupId does not exist (404, unchanged)
