### PR TITLE
feat: implement invitation response handling with audit logging

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -7,6 +7,7 @@ const adminRoutes = require('./routes/admin');
 const coordinatorRoutes = require('./routes/coordinator');
 const professorRoutes = require('./routes/professors');
 const studentRoutes = require('./routes/students');
+const invitationRoutes = require('./routes/invitations');
 const passwordSetupTokenStoreRoutes = require('./routes/passwordSetupTokenStore');
 const userDatabaseRoutes = require('./routes/userDatabase');
 
@@ -22,6 +23,7 @@ app.use('/api/v1/admin', adminRoutes);
 app.use('/api/v1/coordinator', coordinatorRoutes);
 app.use('/api/v1/professors', professorRoutes);
 app.use('/api/v1', studentRoutes);
+app.use('/api/v1', invitationRoutes);
 app.use('/api/v1/password-setup-token-store', passwordSetupTokenStoreRoutes);
 app.use('/api/v1/user-database', userDatabaseRoutes);
 

--- a/backend/controllers/groupFormationController.js
+++ b/backend/controllers/groupFormationController.js
@@ -1,0 +1,44 @@
+const { body, validationResult } = require('express-validator');
+const groupFormationService = require('../services/groupFormationService');
+
+const respondToInvitation = [
+  body('response').isString().trim().custom((value) => ['ACCEPT', 'REJECT'].includes(String(value).toUpperCase())),
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        code: 'INVALID_INVITATION_RESPONSE',
+        message: 'Response must be ACCEPT or REJECT.',
+      });
+    }
+
+    try {
+      const invitation = await groupFormationService.processInviteeResponse(
+        req.params.invitationId,
+        req.body.response,
+        req.user,
+      );
+
+      return res.status(200).json({
+        id: invitation.id,
+        groupId: invitation.groupId,
+        studentId: invitation.studentId,
+        status: invitation.status,
+      });
+    } catch (error) {
+      if (error.status && error.code) {
+        return res.status(error.status).json({
+          code: error.code,
+          message: error.message,
+        });
+      }
+
+      return next(error);
+    }
+  },
+];
+
+module.exports = {
+  respondToInvitation,
+};
+

--- a/backend/models/AuditLog.js
+++ b/backend/models/AuditLog.js
@@ -1,0 +1,29 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const AuditLog = sequelize.define('AuditLog', {
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true,
+  },
+  action: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  actorId: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  targetId: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  metadata: {
+    type: DataTypes.JSON,
+    allowNull: true,
+  },
+});
+
+module.exports = AuditLog;
+

--- a/backend/models/Invitation.js
+++ b/backend/models/Invitation.js
@@ -1,0 +1,26 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const Invitation = sequelize.define('Invitation', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  groupId: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  studentId: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  status: {
+    type: DataTypes.ENUM('PENDING', 'ACCEPTED', 'REJECTED'),
+    allowNull: false,
+    defaultValue: 'PENDING',
+  },
+});
+
+module.exports = Invitation;
+

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -3,6 +3,8 @@ const Professor = require('./Professor');
 const ValidStudentId = require('./ValidStudentId');
 const OAuthState = require('./OAuthState');
 const LinkedGitHubAccount = require('./LinkedGitHubAccount');
+const Invitation = require('./Invitation');
+const AuditLog = require('./AuditLog');
 
 module.exports = {
   User,
@@ -10,4 +12,6 @@ module.exports = {
   ValidStudentId,
   OAuthState,
   LinkedGitHubAccount,
+  Invitation,
+  AuditLog,
 };

--- a/backend/routes/invitations.js
+++ b/backend/routes/invitations.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { authenticate } = require('../middleware/auth');
+const { respondToInvitation } = require('../controllers/groupFormationController');
+
+const router = express.Router();
+
+// Keep both spellings for compatibility with existing docs while backend converges.
+router.patch('/invitations/:invitationId/respond', authenticate, respondToInvitation);
+router.patch('/invitations/:invitationId/response', authenticate, respondToInvitation);
+
+module.exports = router;
+

--- a/backend/services/groupFormationService.js
+++ b/backend/services/groupFormationService.js
@@ -1,0 +1,80 @@
+const sequelize = require('../db');
+const { Invitation, AuditLog } = require('../models');
+
+function createServiceError(status, code, message) {
+  const error = new Error(message);
+  error.status = status;
+  error.code = code;
+  return error;
+}
+
+function normalizeResponse(response) {
+  return String(response || '').trim().toUpperCase();
+}
+
+function toAuditAction(response) {
+  return response === 'ACCEPT' ? 'INVITE_ACCEPTED' : 'INVITE_REJECTED';
+}
+
+async function processInviteeResponse(invitationId, response, actor) {
+  if (!actor) {
+    throw createServiceError(401, 'AUTH_REQUIRED', 'Authentication is required.');
+  }
+
+  if (actor.role !== 'STUDENT' || !actor.studentId) {
+    throw createServiceError(403, 'STUDENT_AUTH_REQUIRED', 'Active authenticated student account required.');
+  }
+
+  const normalizedResponse = normalizeResponse(response);
+  if (!['ACCEPT', 'REJECT'].includes(normalizedResponse)) {
+    throw createServiceError(400, 'INVALID_INVITATION_RESPONSE', 'Response must be ACCEPT or REJECT.');
+  }
+
+  return sequelize.transaction(async (transaction) => {
+    const invitation = await Invitation.findByPk(invitationId, { transaction });
+
+    if (!invitation) {
+      throw createServiceError(404, 'INVITATION_NOT_FOUND', 'Invitation not found.');
+    }
+
+    if (invitation.studentId !== actor.studentId) {
+      throw createServiceError(403, 'INVITATION_FORBIDDEN', 'This invitation does not belong to the authenticated student.');
+    }
+
+    if (invitation.status !== 'PENDING') {
+      throw createServiceError(400, 'INVITATION_ALREADY_RESPONDED', 'Invitation has already been processed.');
+    }
+
+    invitation.status = normalizedResponse === 'ACCEPT' ? 'ACCEPTED' : 'REJECTED';
+    await invitation.save({ transaction });
+
+    try {
+      await AuditLog.create(
+        {
+          action: toAuditAction(normalizedResponse),
+          actorId: actor.studentId,
+          targetId: invitation.id,
+          metadata: {
+            groupId: invitation.groupId,
+          },
+        },
+        { transaction },
+      );
+    } catch (error) {
+      console.error('Audit log write failed for invitation response.', {
+        invitationId,
+        actorId: actor.studentId,
+        action: toAuditAction(normalizedResponse),
+        error: error.message,
+      });
+      throw createServiceError(500, 'AUDIT_LOG_WRITE_FAILED', 'Audit log write failed for invitation response.');
+    }
+
+    return invitation;
+  });
+}
+
+module.exports = {
+  processInviteeResponse,
+};
+

--- a/backend/services/groupFormationService.js
+++ b/backend/services/groupFormationService.js
@@ -41,12 +41,17 @@ async function processInviteeResponse(invitationId, response, actor) {
       throw createServiceError(403, 'INVITATION_FORBIDDEN', 'This invitation does not belong to the authenticated student.');
     }
 
-    if (invitation.status !== 'PENDING') {
-      throw createServiceError(400, 'INVITATION_ALREADY_RESPONDED', 'Invitation has already been processed.');
+    const newStatus = normalizedResponse === 'ACCEPT' ? 'ACCEPTED' : 'REJECTED';
+    const [affectedRows] = await Invitation.update(
+      { status: newStatus },
+      { where: { id: invitationId, studentId: actor.studentId, status: 'PENDING' }, transaction },
+    );
+
+    if (affectedRows === 0) {
+      throw createServiceError(409, 'INVITATION_ALREADY_RESPONDED', 'Invitation has already been processed.');
     }
 
-    invitation.status = normalizedResponse === 'ACCEPT' ? 'ACCEPTED' : 'REJECTED';
-    await invitation.save({ transaction });
+    await invitation.reload({ transaction });
 
     try {
       await AuditLog.create(

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -886,6 +886,33 @@ test('invitation response validates auth/ownership/input and surfaces audit writ
   assert.equal(forbidden.response.status, 403);
   assert.equal(forbidden.json.code, 'INVITATION_FORBIDDEN');
 
+  const notFound = await request('/api/v1/invitations/00000000-0000-0000-0000-000000000000/respond', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(invitee)),
+    },
+    body: JSON.stringify({ response: 'ACCEPT' }),
+  });
+  assert.equal(notFound.response.status, 404);
+  assert.equal(notFound.json.code, 'INVITATION_NOT_FOUND');
+
+  const alreadyProcessed = await Invitation.create({
+    groupId: 'grp_guard_002',
+    studentId: invitee.studentId,
+    status: 'ACCEPTED',
+  });
+  const alreadyResponded = await request(`/api/v1/invitations/${alreadyProcessed.id}/respond`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(invitee)),
+    },
+    body: JSON.stringify({ response: 'REJECT' }),
+  });
+  assert.equal(alreadyResponded.response.status, 409);
+  assert.equal(alreadyResponded.json.code, 'INVITATION_ALREADY_RESPONDED');
+
   const originalCreate = AuditLog.create;
   AuditLog.create = async () => {
     throw new Error('forced audit failure');

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -12,7 +12,15 @@ process.env.GITHUB_CLIENT_SECRET = '';
 const sequelize = require('../db');
 const app = require('../app');
 require('../models');
-const { User, Professor, ValidStudentId, LinkedGitHubAccount, OAuthState } = require('../models');
+const {
+  User,
+  Professor,
+  ValidStudentId,
+  LinkedGitHubAccount,
+  OAuthState,
+  Invitation,
+  AuditLog,
+} = require('../models');
 const StudentRegistrationError = require('../errors/studentRegistrationError');
 const studentRegistrationService = require('../services/studentRegistrationService');
 const { createStudent, ensureValidStudentRegistry } = require('../services/studentService');
@@ -53,6 +61,8 @@ test.after(async () => {
 test.beforeEach(async () => {
   await LinkedGitHubAccount.destroy({ where: {} });
   await OAuthState.destroy({ where: {} });
+  await AuditLog.destroy({ where: {} });
+  await Invitation.destroy({ where: {} });
   await User.destroy({ where: {} });
 });
 
@@ -773,6 +783,132 @@ test('coordinator import endpoint requires coordinator role and stores valid stu
   });
 
   assert.equal(forbidden.response.status, 403);
+});
+
+test('invitation response updates status and writes a D6 audit event for accept/reject', async () => {
+  const invitee = await createStudent({
+    studentId: '11070001000',
+    email: 'invitee@example.edu',
+    fullName: 'Invitee Student',
+    password: 'StrongPass1!',
+  });
+
+  const acceptedInvitation = await Invitation.create({
+    groupId: 'grp_accept_001',
+    studentId: invitee.studentId,
+  });
+
+  const acceptResult = await request(`/api/v1/invitations/${acceptedInvitation.id}/respond`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(invitee)),
+    },
+    body: JSON.stringify({ response: 'ACCEPT' }),
+  });
+
+  assert.equal(acceptResult.response.status, 200);
+  assert.equal(acceptResult.json.status, 'ACCEPTED');
+
+  const acceptAudit = await AuditLog.findOne({ where: { targetId: acceptedInvitation.id } });
+  assert.equal(acceptAudit.action, 'INVITE_ACCEPTED');
+  assert.equal(acceptAudit.actorId, invitee.studentId);
+  assert.equal(acceptAudit.metadata.groupId, 'grp_accept_001');
+
+  const rejectedInvitation = await Invitation.create({
+    groupId: 'grp_reject_001',
+    studentId: invitee.studentId,
+  });
+
+  const rejectResult = await request(`/api/v1/invitations/${rejectedInvitation.id}/response`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(invitee)),
+    },
+    body: JSON.stringify({ response: 'REJECT' }),
+  });
+
+  assert.equal(rejectResult.response.status, 200);
+  assert.equal(rejectResult.json.status, 'REJECTED');
+
+  const rejectAudit = await AuditLog.findOne({ where: { targetId: rejectedInvitation.id } });
+  assert.equal(rejectAudit.action, 'INVITE_REJECTED');
+  assert.equal(rejectAudit.actorId, invitee.studentId);
+  assert.equal(rejectAudit.metadata.groupId, 'grp_reject_001');
+});
+
+test('invitation response validates auth/ownership/input and surfaces audit write failures', async () => {
+  const invitee = await createStudent({
+    studentId: '11070001000',
+    email: 'invitee-2@example.edu',
+    fullName: 'Invitee Two',
+    password: 'StrongPass1!',
+  });
+  const otherStudent = await createStudent({
+    studentId: '11070001001',
+    email: 'other-student@example.edu',
+    fullName: 'Other Student',
+    password: 'StrongPass1!',
+  });
+
+  const invitation = await Invitation.create({
+    groupId: 'grp_guard_001',
+    studentId: invitee.studentId,
+  });
+
+  const unauthenticated = await request(`/api/v1/invitations/${invitation.id}/respond`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ response: 'ACCEPT' }),
+  });
+  assert.equal(unauthenticated.response.status, 401);
+
+  const invalidInput = await request(`/api/v1/invitations/${invitation.id}/respond`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(invitee)),
+    },
+    body: JSON.stringify({ response: 'MAYBE' }),
+  });
+  assert.equal(invalidInput.response.status, 400);
+  assert.equal(invalidInput.json.code, 'INVALID_INVITATION_RESPONSE');
+
+  const forbidden = await request(`/api/v1/invitations/${invitation.id}/respond`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(otherStudent)),
+    },
+    body: JSON.stringify({ response: 'ACCEPT' }),
+  });
+  assert.equal(forbidden.response.status, 403);
+  assert.equal(forbidden.json.code, 'INVITATION_FORBIDDEN');
+
+  const originalCreate = AuditLog.create;
+  AuditLog.create = async () => {
+    throw new Error('forced audit failure');
+  };
+
+  try {
+    const auditFailureResult = await request(`/api/v1/invitations/${invitation.id}/respond`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(await authHeaderFor(invitee)),
+      },
+      body: JSON.stringify({ response: 'ACCEPT' }),
+    });
+
+    assert.equal(auditFailureResult.response.status, 500);
+    assert.equal(auditFailureResult.json.code, 'AUDIT_LOG_WRITE_FAILED');
+
+    const reloadedInvitation = await Invitation.findByPk(invitation.id);
+    assert.equal(reloadedInvitation.status, 'PENDING');
+  } finally {
+    AuditLog.create = originalCreate;
+  }
 });
 
 test('student registration validates eligibility, password strength, duplication, and success', async () => {


### PR DESCRIPTION
This pull request introduces a new backend feature for handling group invitation responses, including both the API and supporting infrastructure. It adds models and endpoints for students to accept or reject group invitations, ensures proper validation and authorization, and logs all responses for auditing purposes. Comprehensive tests are included to verify correct behavior and error handling.

**API and Routing Enhancements:**
- Added new invitation response endpoints at `/api/v1/invitations/:invitationId/respond` and `/api/v1/invitations/:invitationId/response` to allow students to accept or reject group invitations, with both spellings supported for compatibility. [[1]](diffhunk://#diff-55c36604881ea5e1ac918563fcd6b40004fdec9e230e30fd111e31e82de32afaR1-R12) [[2]](diffhunk://#diff-57fcf3bf0ff2ec3604e842595d8ac0b6a43665dac4d20b3da0136bd02dc36cd7R10) [[3]](diffhunk://#diff-57fcf3bf0ff2ec3604e842595d8ac0b6a43665dac4d20b3da0136bd02dc36cd7R26)

**Models and Database:**
- Introduced new Sequelize models: `Invitation` for tracking group invitations and their statuses, and `AuditLog` for recording audit events such as invitation responses. These are registered in the main models index. [[1]](diffhunk://#diff-e17e78141ddd87457453b45fb5237c003f64bfa1b806e1606fe0cd36fcdbfcebR1-R26) [[2]](diffhunk://#diff-dfedc5d855ed2b7898dd264864e37f7d1488ac54f6d73c3fb4bb94ee15b1a177R1-R29) [[3]](diffhunk://#diff-f0f26d6fa1075e0068de7f84e9d9ae5080a81ed3571e4a3b2b560318988e27daR6-R16) [[4]](diffhunk://#diff-8ab0af5e7364c9c177ea848f1c27b79977d182a160c788db969240894787c612L15-R23)

**Business Logic and Validation:**
- Added `groupFormationService.processInviteeResponse` to handle invitation responses, including input validation, authentication, status updates, and audit logging. Ensures only the invited student can respond and only to pending invitations.
- Implemented controller logic in `groupFormationController.respondToInvitation` to validate requests and return appropriate error codes/messages for invalid input, unauthorized access, or audit log failures.

**Testing:**
- Added thorough tests to verify invitation response handling, including status updates, audit log creation, input validation, authentication/authorization, and error handling for audit log failures. Test setup/teardown updated to clean up new models. [[1]](diffhunk://#diff-8ab0af5e7364c9c177ea848f1c27b79977d182a160c788db969240894787c612R64-R65) [[2]](diffhunk://#diff-8ab0af5e7364c9c177ea848f1c27b79977d182a160c788db969240894787c612R788-R913)

These changes collectively enable robust, auditable handling of group invitation responses in the backend.