### PR TITLE
Implement group membership management for coordinators with audit log…

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,8 +2,9 @@ require('dotenv').config();
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const { User } = require('./models');
+const { User, Group, AuditLog } = require('./models');
 const adminRoutes = require('./routes/admin');
+const coordinatorRoutes = require('./routes/coordinator');
 const professorRoutes = require('./routes/professors');
 const studentRoutes = require('./routes/students');
 const passwordSetupTokenStoreRoutes = require('./routes/passwordSetupTokenStore');
@@ -16,8 +17,9 @@ app.use(express.json());
 if (fs.existsSync(frontendDistPath)) {
   app.use(express.static(frontendDistPath));
 }
-app.locals.models = { User };
+app.locals.models = { User, Group, AuditLog };
 app.use('/api/v1/admin', adminRoutes);
+app.use('/api/v1/coordinator', coordinatorRoutes);
 app.use('/api/v1/professors', professorRoutes);
 app.use('/api/v1', studentRoutes);
 app.use('/api/v1/password-setup-token-store', passwordSetupTokenStoreRoutes);

--- a/backend/controllers/coordinatorController.js
+++ b/backend/controllers/coordinatorController.js
@@ -1,0 +1,45 @@
+const { body, param, validationResult } = require('express-validator');
+const coordinatorGroupService = require('../services/coordinatorGroupService');
+
+const updateGroupMembership = [
+  param('groupId').isUUID(),
+  body('action').isString().trim().custom((value) => ['ADD', 'REMOVE'].includes(String(value).toUpperCase())),
+  body('studentId').isString().trim().matches(/^[0-9]{11}$/),
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        code: 'INVALID_MEMBERSHIP_EDIT_INPUT',
+        message: 'groupId, action (ADD/REMOVE), and studentId are required.',
+      });
+    }
+
+    try {
+      const group = await coordinatorGroupService.updateGroupMembershipByCoordinator({
+        groupId: req.params.groupId,
+        action: req.body.action,
+        studentId: req.body.studentId.trim(),
+        actor: req.user,
+      });
+
+      return res.status(200).json({
+        id: group.id,
+        name: group.name,
+        memberIds: group.memberIds,
+      });
+    } catch (error) {
+      if (error.status && error.code) {
+        return res.status(error.status).json({
+          code: error.code,
+          message: error.message,
+        });
+      }
+      return next(error);
+    }
+  },
+];
+
+module.exports = {
+  updateGroupMembership,
+};
+

--- a/backend/models/AuditLog.js
+++ b/backend/models/AuditLog.js
@@ -1,0 +1,34 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const AuditLog = sequelize.define('AuditLog', {
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true,
+  },
+  actorId: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  action: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  targetId: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  timestamp: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    defaultValue: DataTypes.NOW,
+  },
+  metadata: {
+    type: DataTypes.JSON,
+    allowNull: true,
+  },
+});
+
+module.exports = AuditLog;
+

--- a/backend/models/AuditLog.js
+++ b/backend/models/AuditLog.js
@@ -28,6 +28,8 @@ const AuditLog = sequelize.define('AuditLog', {
     type: DataTypes.JSON,
     allowNull: true,
   },
+}, {
+  timestamps: false,
 });
 
 module.exports = AuditLog;

--- a/backend/models/Group.js
+++ b/backend/models/Group.js
@@ -1,0 +1,22 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const Group = sequelize.define('Group', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  memberIds: {
+    type: DataTypes.JSON,
+    allowNull: false,
+    defaultValue: [],
+  },
+});
+
+module.exports = Group;
+

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -3,6 +3,8 @@ const Professor = require('./Professor');
 const ValidStudentId = require('./ValidStudentId');
 const OAuthState = require('./OAuthState');
 const LinkedGitHubAccount = require('./LinkedGitHubAccount');
+const Group = require('./Group');
+const AuditLog = require('./AuditLog');
 
 module.exports = {
   User,
@@ -10,4 +12,6 @@ module.exports = {
   ValidStudentId,
   OAuthState,
   LinkedGitHubAccount,
+  Group,
+  AuditLog,
 };

--- a/backend/routes/coordinator.js
+++ b/backend/routes/coordinator.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const { authenticate, authorize } = require('../middleware/auth');
+const { updateGroupMembership } = require('../controllers/coordinatorController');
+
+const router = express.Router();
+
+router.patch('/groups/:groupId/members', authenticate, authorize(['COORDINATOR']), updateGroupMembership);
+
+module.exports = router;
+

--- a/backend/services/coordinatorGroupService.js
+++ b/backend/services/coordinatorGroupService.js
@@ -1,0 +1,101 @@
+const sequelize = require('../db');
+const { Group, AuditLog } = require('../models');
+
+function createServiceError(status, code, message) {
+  const error = new Error(message);
+  error.status = status;
+  error.code = code;
+  return error;
+}
+
+function normalizeAction(action) {
+  return String(action || '').trim().toUpperCase();
+}
+
+function assertCoordinatorActor(actor) {
+  if (!actor) {
+    throw createServiceError(401, 'AUTH_REQUIRED', 'Authentication is required.');
+  }
+
+  if (actor.role !== 'COORDINATOR') {
+    throw createServiceError(403, 'FORBIDDEN', 'Coordinator role required.');
+  }
+}
+
+function computeMemberUpdate(memberIds, action, studentId) {
+  const current = Array.isArray(memberIds) ? [...memberIds] : [];
+  const hasStudent = current.includes(studentId);
+
+  if (action === 'ADD') {
+    if (hasStudent) {
+      throw createServiceError(400, 'MEMBERSHIP_NO_CHANGE', 'Student is already a member of this group.');
+    }
+    return [...current, studentId];
+  }
+
+  if (!hasStudent) {
+    throw createServiceError(400, 'MEMBERSHIP_NO_CHANGE', 'Student is not a member of this group.');
+  }
+
+  return current.filter((memberId) => memberId !== studentId);
+}
+
+function getAuditAction(action) {
+  return action === 'ADD' ? 'COORDINATOR_MEMBER_ADDED' : 'COORDINATOR_MEMBER_REMOVED';
+}
+
+async function updateGroupMembershipByCoordinator({ groupId, action, studentId, actor }) {
+  assertCoordinatorActor(actor);
+
+  const normalizedAction = normalizeAction(action);
+  if (!['ADD', 'REMOVE'].includes(normalizedAction)) {
+    throw createServiceError(400, 'INVALID_MEMBERSHIP_ACTION', 'Action must be ADD or REMOVE.');
+  }
+
+  return sequelize.transaction(async (transaction) => {
+    const group = await Group.findByPk(groupId, { transaction });
+    if (!group) {
+      throw createServiceError(404, 'GROUP_NOT_FOUND', 'Group not found.');
+    }
+
+    const previousMemberIds = Array.isArray(group.memberIds) ? [...group.memberIds] : [];
+    const updatedMemberIds = computeMemberUpdate(group.memberIds, normalizedAction, studentId);
+
+    group.memberIds = updatedMemberIds;
+    await group.save({ transaction });
+
+    const auditPayload = {
+      actorId: String(actor.id),
+      action: getAuditAction(normalizedAction),
+      targetId: group.id,
+      timestamp: new Date(),
+      metadata: {
+        groupId: group.id,
+        studentId,
+        membershipAction: normalizedAction,
+        previousMemberIds,
+        updatedMemberIds,
+      },
+    };
+
+    try {
+      await AuditLog.create(auditPayload, { transaction });
+    } catch (error) {
+      console.error('Coordinator group edit audit write failed.', {
+        groupId,
+        actorId: actor.id,
+        action: normalizedAction,
+        studentId,
+        error: error.message,
+      });
+      throw createServiceError(500, 'AUDIT_LOG_WRITE_FAILED', 'Audit log write failed for coordinator membership update.');
+    }
+
+    return group;
+  });
+}
+
+module.exports = {
+  updateGroupMembershipByCoordinator,
+};
+

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -12,7 +12,7 @@ process.env.GITHUB_CLIENT_SECRET = '';
 const sequelize = require('../db');
 const app = require('../app');
 require('../models');
-const { User, Professor, LinkedGitHubAccount, OAuthState } = require('../models');
+const { User, Professor, LinkedGitHubAccount, OAuthState, Group, AuditLog } = require('../models');
 const StudentRegistrationError = require('../errors/studentRegistrationError');
 const studentRegistrationService = require('../services/studentRegistrationService');
 const { createStudent, ensureValidStudentRegistry } = require('../services/studentService');
@@ -53,6 +53,8 @@ test.after(async () => {
 test.beforeEach(async () => {
   await LinkedGitHubAccount.destroy({ where: {} });
   await OAuthState.destroy({ where: {} });
+  await AuditLog.destroy({ where: {} });
+  await Group.destroy({ where: {} });
   await User.destroy({ where: {} });
 });
 
@@ -548,6 +550,148 @@ test('internal professor password update requires admin auth and activates the p
     message: 'Professor not found.',
   });
 });
+
+test('coordinator can update group membership and writes f21 audit logs', async () => {
+  const coordinator = await User.create({
+    email: 'coord-edit@example.edu',
+    fullName: 'Coordinator Editor',
+    role: 'COORDINATOR',
+    status: 'ACTIVE',
+  });
+
+  const group = await Group.create({
+    name: 'Audit Group',
+    memberIds: ['11070001000'],
+  });
+
+  const addResult = await request(`/api/v1/coordinator/groups/${group.id}/members`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(coordinator)),
+    },
+    body: JSON.stringify({
+      action: 'ADD',
+      studentId: '11070001001',
+    }),
+  });
+
+  assert.equal(addResult.response.status, 200);
+  assert.deepEqual(addResult.json.memberIds, ['11070001000', '11070001001']);
+
+  const addAudit = await AuditLog.findOne({ where: { targetId: group.id, action: 'COORDINATOR_MEMBER_ADDED' } });
+  assert.ok(addAudit);
+  assert.equal(addAudit.actorId, String(coordinator.id));
+  assert.equal(addAudit.metadata.studentId, '11070001001');
+  assert.deepEqual(addAudit.metadata.previousMemberIds, ['11070001000']);
+  assert.deepEqual(addAudit.metadata.updatedMemberIds, ['11070001000', '11070001001']);
+
+  const removeResult = await request(`/api/v1/coordinator/groups/${group.id}/members`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(coordinator)),
+    },
+    body: JSON.stringify({
+      action: 'REMOVE',
+      studentId: '11070001000',
+    }),
+  });
+
+  assert.equal(removeResult.response.status, 200);
+  assert.deepEqual(removeResult.json.memberIds, ['11070001001']);
+
+  const removeAudit = await AuditLog.findOne({ where: { targetId: group.id, action: 'COORDINATOR_MEMBER_REMOVED' } });
+  assert.ok(removeAudit);
+  assert.equal(removeAudit.actorId, String(coordinator.id));
+  assert.equal(removeAudit.metadata.studentId, '11070001000');
+  assert.deepEqual(removeAudit.metadata.previousMemberIds, ['11070001000', '11070001001']);
+  assert.deepEqual(removeAudit.metadata.updatedMemberIds, ['11070001001']);
+});
+
+test('coordinator membership edit enforces auth and surfaces audit failures without silent drops', async () => {
+  const coordinator = await User.create({
+    email: 'coord-guard@example.edu',
+    fullName: 'Coordinator Guard',
+    role: 'COORDINATOR',
+    status: 'ACTIVE',
+  });
+  const admin = await User.create({
+    email: 'coord-admin@example.edu',
+    fullName: 'Admin Guard',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+  });
+
+  const group = await Group.create({
+    name: 'Guard Group',
+    memberIds: ['11070001000'],
+  });
+
+  const unauthenticated = await request(`/api/v1/coordinator/groups/${group.id}/members`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action: 'ADD', studentId: '11070001001' }),
+  });
+  assert.equal(unauthenticated.response.status, 401);
+
+  const forbidden = await request(`/api/v1/coordinator/groups/${group.id}/members`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(admin)),
+    },
+    body: JSON.stringify({ action: 'ADD', studentId: '11070001001' }),
+  });
+  assert.equal(forbidden.response.status, 403);
+
+  const invalidInput = await request(`/api/v1/coordinator/groups/${group.id}/members`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(coordinator)),
+    },
+    body: JSON.stringify({ action: 'MAYBE', studentId: 'abc' }),
+  });
+  assert.equal(invalidInput.response.status, 400);
+  assert.equal(invalidInput.json.code, 'INVALID_MEMBERSHIP_EDIT_INPUT');
+
+  const notFound = await request('/api/v1/coordinator/groups/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa/members', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(coordinator)),
+    },
+    body: JSON.stringify({ action: 'ADD', studentId: '11070001001' }),
+  });
+  assert.equal(notFound.response.status, 404);
+  assert.equal(notFound.json.code, 'GROUP_NOT_FOUND');
+
+  const originalCreate = AuditLog.create;
+  AuditLog.create = async () => {
+    throw new Error('forced audit failure');
+  };
+
+  try {
+    const auditFailure = await request(`/api/v1/coordinator/groups/${group.id}/members`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(await authHeaderFor(coordinator)),
+      },
+      body: JSON.stringify({ action: 'ADD', studentId: '11070001001' }),
+    });
+
+    assert.equal(auditFailure.response.status, 500);
+    assert.equal(auditFailure.json.code, 'AUDIT_LOG_WRITE_FAILED');
+
+    const reloadedGroup = await Group.findByPk(group.id);
+    assert.deepEqual(reloadedGroup.memberIds, ['11070001000']);
+  } finally {
+    AuditLog.create = originalCreate;
+  }
+});
+
 test('student registration validates eligibility, password strength, duplication, and success', async () => {
   const invalidStudentId = await request('/api/v1/students/registration-validation', {
     method: 'POST',

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -551,7 +551,7 @@ test('internal professor password update requires admin auth and activates the p
   });
 });
 
-test('coordinator can update group membership and writes f21 audit logs', async () => {
+test('coordinator can update group membership and creates audit log entries', async () => {
   const coordinator = await User.create({
     email: 'coord-edit@example.edu',
     fullName: 'Coordinator Editor',
@@ -609,7 +609,7 @@ test('coordinator can update group membership and writes f21 audit logs', async 
   assert.deepEqual(removeAudit.metadata.updatedMemberIds, ['11070001001']);
 });
 
-test('coordinator membership edit enforces auth and surfaces audit failures without silent drops', async () => {
+test('coordinator membership edit enforces auth and surfaces audit failures without silent drops', async (t) => {
   const coordinator = await User.create({
     email: 'coord-guard@example.edu',
     fullName: 'Coordinator Guard',
@@ -667,29 +667,24 @@ test('coordinator membership edit enforces auth and surfaces audit failures with
   assert.equal(notFound.response.status, 404);
   assert.equal(notFound.json.code, 'GROUP_NOT_FOUND');
 
-  const originalCreate = AuditLog.create;
-  AuditLog.create = async () => {
+  t.mock.method(AuditLog, 'create', async () => {
     throw new Error('forced audit failure');
-  };
+  });
 
-  try {
-    const auditFailure = await request(`/api/v1/coordinator/groups/${group.id}/members`, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(await authHeaderFor(coordinator)),
-      },
-      body: JSON.stringify({ action: 'ADD', studentId: '11070001001' }),
-    });
+  const auditFailure = await request(`/api/v1/coordinator/groups/${group.id}/members`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(coordinator)),
+    },
+    body: JSON.stringify({ action: 'ADD', studentId: '11070001001' }),
+  });
 
-    assert.equal(auditFailure.response.status, 500);
-    assert.equal(auditFailure.json.code, 'AUDIT_LOG_WRITE_FAILED');
+  assert.equal(auditFailure.response.status, 500);
+  assert.equal(auditFailure.json.code, 'AUDIT_LOG_WRITE_FAILED');
 
-    const reloadedGroup = await Group.findByPk(group.id);
-    assert.deepEqual(reloadedGroup.memberIds, ['11070001000']);
-  } finally {
-    AuditLog.create = originalCreate;
-  }
+  const reloadedGroup = await Group.findByPk(group.id);
+  assert.deepEqual(reloadedGroup.memberIds, ['11070001000']);
 });
 
 test('student registration validates eligibility, password strength, duplication, and success', async () => {


### PR DESCRIPTION
This pull request introduces a new feature allowing coordinators to manage group membership, with robust auditing and error handling. It adds models for `Group` and `AuditLog`, a PATCH API endpoint for group membership edits, and comprehensive tests to ensure correct authorization, auditing, and error propagation.

**New coordinator group membership management:**

* Added a new PATCH endpoint at `/api/v1/coordinator/groups/:groupId/members` allowing coordinators to add or remove students from groups. This endpoint enforces authentication, coordinator role authorization, input validation, and returns informative error codes for invalid operations. [[1]](diffhunk://#diff-57fcf3bf0ff2ec3604e842595d8ac0b6a43665dac4d20b3da0136bd02dc36cd7L5-R7) [[2]](diffhunk://#diff-57fcf3bf0ff2ec3604e842595d8ac0b6a43665dac4d20b3da0136bd02dc36cd7L19-R22) [[3]](diffhunk://#diff-832ce8702e3f432e1b98ab49cc7f983bc39be57a444cb582849af102796c3b57R1-R10) [[4]](diffhunk://#diff-be673ca2cc134c2ef35074e4d387c11db214491251838cf605538831d7165010R1-R45)
* Implemented `Group` and `AuditLog` Sequelize models to persist group membership and audit membership changes, respectively. [[1]](diffhunk://#diff-5d712df32aa912f92fb9bfd58c53e5d2c5c82e2fefefe3321bf0e61a9d5dc601R1-R22) [[2]](diffhunk://#diff-dfedc5d855ed2b7898dd264864e37f7d1488ac54f6d73c3fb4bb94ee15b1a177R1-R34) [[3]](diffhunk://#diff-f0f26d6fa1075e0068de7f84e9d9ae5080a81ed3571e4a3b2b560318988e27daR6-R16)
* Created a `coordinatorGroupService` that handles membership updates transactionally, including detailed audit logging and error handling if audit logs cannot be written.

**Testing and reliability improvements:**

* Added thorough tests for the coordinator group membership endpoint, covering successful membership changes, audit log creation, authorization enforcement, input validation, group not found, and audit log failure scenarios.
* Updated test setup/teardown to include cleanup for the new `Group` and `AuditLog` tables. [[1]](diffhunk://#diff-8ab0af5e7364c9c177ea848f1c27b79977d182a160c788db969240894787c612L15-R15) [[2]](diffhunk://#diff-8ab0af5e7364c9c177ea848f1c27b79977d182a160c788db969240894787c612R56-R57)…ging