### PR TITLE
feat(groups): implement Create Group Shell UI and mock hook

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import AdminHomePage from './AdminHomePage';
+import GroupFormationPage from './GroupFormationPage';
 import AdminLoginPage from './AdminLoginPage';
 import AdminProfessorCreatePage from './AdminProfessorCreatePage';
 import AuthGatewayPage from './AuthGatewayPage';
@@ -33,6 +34,7 @@ export default function App() {
               <Route path="/coordinator/login" element={<CoordinatorLoginPage />} />
               <Route path="/coordinator" element={<CoordinatorHomePage />} />
               <Route path="/coordinator/student-id-registry/import" element={<CoordinatorStudentIdUploadPage />} />
+              <Route path="/students/groups" element={<GroupFormationPage />} />
               <Route path="*" element={<AuthGatewayPage />} />
             </Route>
           </Routes>

--- a/frontend/src/GroupFormationPage.jsx
+++ b/frontend/src/GroupFormationPage.jsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGroupFormation } from './hooks/useGroupFormation';
+
+export default function GroupFormationPage() {
+  const { createGroupShell, pending, group, error, reset } = useGroupFormation();
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState('');
+
+  function handleCancel() {
+    setName('');
+    reset();
+    setShowForm(false);
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    try {
+      await createGroupShell(name);
+      setName('');
+      setShowForm(false);
+    } catch {
+      // error state is managed by the hook; stay on the form so the user sees it
+    }
+  }
+
+  return (
+    <main className="page">
+      <section className="hero">
+        <p className="eyebrow">Team Leader Workspace</p>
+        <h1>Group Formation</h1>
+        <p className="subtitle">
+          Create your group shell first. Once the group exists you can invite teammates and request
+          an advisor.
+        </p>
+      </section>
+
+      <p className="back-link-wrap">
+        <Link className="back-link" to="/">
+          Back to Home
+        </Link>
+      </p>
+
+      {group && !showForm && (
+        <section className="panel">
+          <section className="feedback feedback-success" aria-live="polite">
+            <p className="feedback-label">Group Created</p>
+            <h2>{group.name}</h2>
+            <p>Your group shell has been created. You are now the Team Leader.</p>
+          </section>
+        </section>
+      )}
+
+      {!group && !showForm && (
+        <section className="panel">
+          <button type="button" onClick={() => setShowForm(true)}>
+            Create a New Group
+          </button>
+        </section>
+      )}
+
+      {showForm && (
+        <section className="panel">
+          <form className="form" onSubmit={handleSubmit} noValidate>
+            <label className="field">
+              <span>Group Name</span>
+              <input
+                id="group-name"
+                name="name"
+                type="text"
+                placeholder="e.g. AI Capstone Team"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                minLength={3}
+                maxLength={64}
+                required
+                disabled={pending}
+                aria-describedby={error ? 'group-name-error' : undefined}
+                aria-invalid={error?.type === 'validation' ? 'true' : undefined}
+              />
+              {error && (
+                <span id="group-name-error" className="field-error" role="alert">
+                  {error.message}
+                </span>
+              )}
+            </label>
+
+            {error?.type === 'unexpected' && (
+              <section className="feedback feedback-error" aria-live="polite">
+                <p className="feedback-label">Error</p>
+                <p>{error.message}</p>
+              </section>
+            )}
+
+            <div className="form-actions">
+              <button type="submit" disabled={pending}>
+                {pending ? 'Creating group...' : 'Create Group'}
+              </button>
+              <button type="button" onClick={handleCancel} disabled={pending}>
+                Cancel
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/hooks/useGroupFormation.js
+++ b/frontend/src/hooks/useGroupFormation.js
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+
+// Mock: simulates POST /groups. Replace the body of the try-block with a real
+// apiClient.post('/v1/groups', { name }) call once the backend is ready.
+function mockPostGroup(name) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const trimmed = name.trim();
+
+      if (!trimmed || trimmed.length < 3 || trimmed.length > 64) {
+        const err = new Error('Group name must be between 3 and 64 characters.');
+        err.response = {
+          status: 400,
+          data: { message: err.message, code: 'INVALID_NAME' },
+        };
+        return reject(err);
+      }
+
+      // Simulate a duplicate-name collision when the name starts with "duplicate"
+      // so the 400 error path can be exercised without a real backend.
+      if (trimmed.toLowerCase().startsWith('duplicate')) {
+        const err = new Error('A group with this name already exists.');
+        err.response = {
+          status: 400,
+          data: { message: err.message, code: 'DUPLICATE_NAME' },
+        };
+        return reject(err);
+      }
+
+      resolve({
+        data: {
+          id: crypto.randomUUID(),
+          name: trimmed,
+          leaderId: 'mock-leader-id',
+          memberIds: [],
+          advisorId: null,
+        },
+        status: 201,
+      });
+    }, 800);
+  });
+}
+
+export function useGroupFormation() {
+  const [pending, setPending] = useState(false);
+  const [group, setGroup] = useState(null);
+  const [error, setError] = useState(null);
+
+  async function createGroupShell(name) {
+    setPending(true);
+    setError(null);
+
+    try {
+      const result = await mockPostGroup(name);
+      setGroup(result.data);
+      return result.data;
+    } catch (err) {
+      const status = err.response?.status;
+      const message = err.response?.data?.message || err.message;
+
+      if (status === 400) {
+        setError({ type: 'validation', message });
+      } else {
+        setError({ type: 'unexpected', message: 'Something went wrong. Please try again.' });
+      }
+      throw err;
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function reset() {
+    setGroup(null);
+    setError(null);
+  }
+
+  return { createGroupShell, pending, group, error, reset };
+}


### PR DESCRIPTION
## Summary
- Adds `GroupFormationPage` with a toggleable Create Group form (name input, submit/cancel)
- Adds `useGroupFormation` hook with a mocked `createGroupShell` (setTimeout, 800 ms) that simulates 201 success and 400 validation/duplicate errors
- Wires `/students/groups` route in `App.jsx`

## Issue
Closes Issue 1: [Fullstack] Create Group Shell — `@frontend-dev` tasks

## Test plan
- [ ] Navigate to `/students/groups` — page loads with hero and "Create a New Group" button
- [ ] Click button — form appears with name input, Create Group, and Cancel buttons
- [ ] Submit a valid name — spinner shown during pending, form closes, success panel appears
- [ ] Submit a name starting with `duplicate` — inline 400 error appears under the input
- [ ] Submit a name shorter than 3 chars — inline 400 error appears
- [ ] Click Cancel — form closes, no error shown