### PR TITLE
feat(groups): implement Dispatch Invitations UI and mock API

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import AdminHomePage from './AdminHomePage';
+import GroupFormationPage from './GroupFormationPage';
 import AdminLoginPage from './AdminLoginPage';
 import AdminProfessorCreatePage from './AdminProfessorCreatePage';
 import AuthGatewayPage from './AuthGatewayPage';
@@ -33,6 +34,7 @@ export default function App() {
               <Route path="/coordinator/login" element={<CoordinatorLoginPage />} />
               <Route path="/coordinator" element={<CoordinatorHomePage />} />
               <Route path="/coordinator/student-id-registry/import" element={<CoordinatorStudentIdUploadPage />} />
+              <Route path="/students/groups" element={<GroupFormationPage />} />
               <Route path="*" element={<AuthGatewayPage />} />
             </Route>
           </Routes>

--- a/frontend/src/GroupFormationPage.jsx
+++ b/frontend/src/GroupFormationPage.jsx
@@ -1,9 +1,20 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import InviteMembersSection from './components/InviteMembersSection';
 import { useGroupFormation } from './hooks/useGroupFormation';
 
 export default function GroupFormationPage() {
-  const { createGroupShell, pending, group, error, reset } = useGroupFormation();
+  const {
+    createGroupShell,
+    pending,
+    group,
+    error,
+    reset,
+    dispatchInvites,
+    invitesPending,
+    invitations,
+    inviteError,
+  } = useGroupFormation();
   const [showForm, setShowForm] = useState(false);
   const [name, setName] = useState('');
 
@@ -43,13 +54,31 @@ export default function GroupFormationPage() {
       </p>
 
       {group && !showForm && (
-        <section className="panel">
-          <section className="feedback feedback-success" aria-live="polite">
-            <p className="feedback-label">Group Created</p>
-            <h2>{group.name}</h2>
-            <p>Your group shell has been created. You are now the Team Leader.</p>
+        <>
+          <section className="panel">
+            <section className="feedback feedback-success" aria-live="polite">
+              <p className="feedback-label">Group Created</p>
+              <h2>{group.name}</h2>
+              <p>Your group shell has been created. You are now the Team Leader.</p>
+            </section>
           </section>
-        </section>
+
+          <section className="hero">
+            <h2>Invite Members</h2>
+            <p className="subtitle">
+              Send invitations to students by entering their IDs below. Each student will receive a
+              pending invitation they can accept or decline.
+            </p>
+          </section>
+
+          <InviteMembersSection
+            group={group}
+            dispatchInvites={dispatchInvites}
+            invitesPending={invitesPending}
+            invitations={invitations}
+            inviteError={inviteError}
+          />
+        </>
       )}
 
       {!group && !showForm && (

--- a/frontend/src/GroupFormationPage.jsx
+++ b/frontend/src/GroupFormationPage.jsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGroupFormation } from './hooks/useGroupFormation';
+
+export default function GroupFormationPage() {
+  const { createGroupShell, pending, group, error, reset } = useGroupFormation();
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState('');
+
+  function handleCancel() {
+    setName('');
+    reset();
+    setShowForm(false);
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    try {
+      await createGroupShell(name);
+      setName('');
+      setShowForm(false);
+    } catch {
+      // error state is managed by the hook; stay on the form so the user sees it
+    }
+  }
+
+  return (
+    <main className="page">
+      <section className="hero">
+        <p className="eyebrow">Team Leader Workspace</p>
+        <h1>Group Formation</h1>
+        <p className="subtitle">
+          Create your group shell first. Once the group exists you can invite teammates and request
+          an advisor.
+        </p>
+      </section>
+
+      <p className="back-link-wrap">
+        <Link className="back-link" to="/">
+          Back to Home
+        </Link>
+      </p>
+
+      {group && !showForm && (
+        <section className="panel">
+          <section className="feedback feedback-success" aria-live="polite">
+            <p className="feedback-label">Group Created</p>
+            <h2>{group.name}</h2>
+            <p>Your group shell has been created. You are now the Team Leader.</p>
+          </section>
+        </section>
+      )}
+
+      {!group && !showForm && (
+        <section className="panel">
+          <button type="button" onClick={() => setShowForm(true)}>
+            Create a New Group
+          </button>
+        </section>
+      )}
+
+      {showForm && (
+        <section className="panel">
+          <form className="form" onSubmit={handleSubmit} noValidate>
+            <label className="field">
+              <span>Group Name</span>
+              <input
+                id="group-name"
+                name="name"
+                type="text"
+                placeholder="e.g. AI Capstone Team"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                minLength={3}
+                maxLength={64}
+                required
+                disabled={pending}
+                aria-describedby={error ? 'group-name-error' : undefined}
+                aria-invalid={error?.type === 'validation' ? 'true' : undefined}
+              />
+              {error && (
+                <span id="group-name-error" className="field-error" role="alert">
+                  {error.message}
+                </span>
+              )}
+            </label>
+
+            {error?.type === 'unexpected' && (
+              <section className="feedback feedback-error" aria-live="polite">
+                <p className="feedback-label">Error</p>
+                <p>{error.message}</p>
+              </section>
+            )}
+
+            <div className="form-actions">
+              <button type="submit" disabled={pending}>
+                {pending ? 'Creating group...' : 'Create Group'}
+              </button>
+              <button type="button" onClick={handleCancel} disabled={pending}>
+                Cancel
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/components/InviteMembersSection.jsx
+++ b/frontend/src/components/InviteMembersSection.jsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+
+function parseStudentIds(raw) {
+  return [
+    ...new Set(
+      raw
+        .split(/[\s,]+/)
+        .map((s) => s.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+// InviteMembersSection — rendered once a group shell exists.
+// Props:
+//   group          — the created group object { id, name, ... }
+//   dispatchInvites(groupId, studentIds) — from useGroupFormation
+//   invitesPending — boolean
+//   invitations    — Invitation[] accumulated from successful dispatches
+//   inviteError    — null | { type, message, failures? }
+export default function InviteMembersSection({
+  group,
+  dispatchInvites,
+  invitesPending,
+  invitations,
+  inviteError,
+}) {
+  const [idsText, setIdsText] = useState('');
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    const ids = parseStudentIds(idsText);
+    if (ids.length === 0) return;
+
+    try {
+      await dispatchInvites(group.id, ids);
+      setIdsText('');
+    } catch {
+      // error state managed by hook; keep the textarea so the user can correct IDs
+    }
+  }
+
+  function handleClear() {
+    setIdsText('');
+  }
+
+  return (
+    <section className="panel">
+      <form className="form" onSubmit={handleSubmit} noValidate>
+        <label className="field">
+          <span>Invite Student IDs</span>
+          <textarea
+            id="invite-ids"
+            name="studentIds"
+            placeholder={'e.g. 11070001001, 11070001002\nor one per line'}
+            value={idsText}
+            onChange={(e) => setIdsText(e.target.value)}
+            rows={4}
+            disabled={invitesPending}
+            aria-describedby={inviteError ? 'invite-error-summary' : undefined}
+          />
+          <p className="token-note">
+            Enter student IDs separated by commas or newlines. Duplicates are ignored.
+            <br />
+            <em>Mock tip: include "error_id" or any ID starting with "invalid" to trigger a 400.</em>
+          </p>
+        </label>
+
+        {inviteError?.type === 'validation' && inviteError.failures?.length > 0 && (
+          <section
+            id="invite-error-summary"
+            className="feedback feedback-error"
+            aria-live="polite"
+          >
+            <p className="feedback-label">Validation Failures</p>
+            <p>{inviteError.message}</p>
+            <ul>
+              {inviteError.failures.map((f) => (
+                <li key={f.studentId}>
+                  <strong>{f.studentId}</strong> — {f.reason}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {inviteError?.type === 'unexpected' && (
+          <section className="feedback feedback-error" aria-live="polite">
+            <p className="feedback-label">Error</p>
+            <p>{inviteError.message}</p>
+          </section>
+        )}
+
+        <div className="form-actions">
+          <button type="submit" disabled={invitesPending || !idsText.trim()}>
+            {invitesPending ? 'Sending invitations...' : 'Send Invitations'}
+          </button>
+          <button type="button" onClick={handleClear} disabled={invitesPending}>
+            Clear
+          </button>
+        </div>
+      </form>
+
+      {invitations.length > 0 && (
+        <section className="side-column">
+          <section className="token-panel">
+            <p className="feedback-label">Pending Invitations</p>
+            <ul>
+              {invitations.map((inv) => (
+                <li key={inv.id}>
+                  <strong>{inv.studentId}</strong>
+                  <span> — {inv.status}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </section>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useGroupFormation.js
+++ b/frontend/src/hooks/useGroupFormation.js
@@ -1,5 +1,37 @@
 import { useState } from 'react';
 
+// Mock: simulates POST /groups/{groupId}/invitations.
+// Replace with apiClient.post(`/v1/groups/${groupId}/invitations`, { studentIds }) when ready.
+// Trigger the 400 path by including an ID that is exactly "error_id" or starts with "invalid".
+function mockPostInvitations(groupId, studentIds) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const failures = studentIds
+        .filter((id) => id === 'error_id' || id.toLowerCase().startsWith('invalid'))
+        .map((id) => ({ studentId: id, reason: 'Student not found or is ineligible.' }));
+
+      if (failures.length > 0) {
+        const err = new Error('Some student IDs failed validation.');
+        err.response = {
+          status: 400,
+          data: { message: err.message, code: 'VALIDATION_FAILED', failures },
+        };
+        return reject(err);
+      }
+
+      const invitations = studentIds.map((id) => ({
+        id: crypto.randomUUID(),
+        groupId,
+        studentId: id,
+        status: 'PENDING',
+        createdAt: new Date().toISOString(),
+      }));
+
+      resolve({ data: invitations, status: 201 });
+    }, 800);
+  });
+}
+
 // Mock: simulates POST /groups. Replace the body of the try-block with a real
 // apiClient.post('/v1/groups', { name }) call once the backend is ready.
 function mockPostGroup(name) {
@@ -46,6 +78,10 @@ export function useGroupFormation() {
   const [group, setGroup] = useState(null);
   const [error, setError] = useState(null);
 
+  const [invitesPending, setInvitesPending] = useState(false);
+  const [invitations, setInvitations] = useState([]);
+  const [inviteError, setInviteError] = useState(null);
+
   async function createGroupShell(name) {
     setPending(true);
     setError(null);
@@ -69,10 +105,51 @@ export function useGroupFormation() {
     }
   }
 
+  // Simulates POST /groups/{groupId}/invitations.
+  // studentIds must be a de-duped, trimmed string[].
+  async function dispatchInvites(groupId, studentIds) {
+    setInvitesPending(true);
+    setInviteError(null);
+
+    try {
+      const result = await mockPostInvitations(groupId, studentIds);
+      setInvitations((prev) => [...prev, ...result.data]);
+      return result.data;
+    } catch (err) {
+      const status = err.response?.status;
+      const data = err.response?.data;
+
+      if (status === 400) {
+        setInviteError({
+          type: 'validation',
+          message: data?.message || 'Validation failed.',
+          failures: data?.failures ?? [],
+        });
+      } else {
+        setInviteError({ type: 'unexpected', message: 'Something went wrong. Please try again.' });
+      }
+      throw err;
+    } finally {
+      setInvitesPending(false);
+    }
+  }
+
   function reset() {
     setGroup(null);
     setError(null);
+    setInvitations([]);
+    setInviteError(null);
   }
 
-  return { createGroupShell, pending, group, error, reset };
+  return {
+    createGroupShell,
+    pending,
+    group,
+    error,
+    reset,
+    dispatchInvites,
+    invitesPending,
+    invitations,
+    inviteError,
+  };
 }

--- a/frontend/src/hooks/useGroupFormation.js
+++ b/frontend/src/hooks/useGroupFormation.js
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+
+// Mock: simulates POST /groups. Replace the body of the try-block with a real
+// apiClient.post('/v1/groups', { name }) call once the backend is ready.
+function mockPostGroup(name) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const trimmed = name.trim();
+
+      if (!trimmed || trimmed.length < 3 || trimmed.length > 64) {
+        const err = new Error('Group name must be between 3 and 64 characters.');
+        err.response = {
+          status: 400,
+          data: { message: err.message, code: 'INVALID_NAME' },
+        };
+        return reject(err);
+      }
+
+      // Simulate a duplicate-name collision when the name starts with "duplicate"
+      // so the 400 error path can be exercised without a real backend.
+      if (trimmed.toLowerCase().startsWith('duplicate')) {
+        const err = new Error('A group with this name already exists.');
+        err.response = {
+          status: 400,
+          data: { message: err.message, code: 'DUPLICATE_NAME' },
+        };
+        return reject(err);
+      }
+
+      resolve({
+        data: {
+          id: crypto.randomUUID(),
+          name: trimmed,
+          leaderId: 'mock-leader-id',
+          memberIds: [],
+          advisorId: null,
+        },
+        status: 201,
+      });
+    }, 800);
+  });
+}
+
+export function useGroupFormation() {
+  const [pending, setPending] = useState(false);
+  const [group, setGroup] = useState(null);
+  const [error, setError] = useState(null);
+
+  async function createGroupShell(name) {
+    setPending(true);
+    setError(null);
+
+    try {
+      const result = await mockPostGroup(name);
+      setGroup(result.data);
+      return result.data;
+    } catch (err) {
+      const status = err.response?.status;
+      const message = err.response?.data?.message || err.message;
+
+      if (status === 400) {
+        setError({ type: 'validation', message });
+      } else {
+        setError({ type: 'unexpected', message: 'Something went wrong. Please try again.' });
+      }
+      throw err;
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function reset() {
+    setGroup(null);
+    setError(null);
+  }
+
+  return { createGroupShell, pending, group, error, reset };
+}


### PR DESCRIPTION
## Summary
- Adds InviteMembersSection component with textarea for comma/newline-separated student IDs
- Adds dispatchInvites to useGroupFormation hook with mocked POST /groups/{groupId}/invitations
- Wires invite form into GroupFormationPage below the group creation success panel

## Issue
Closes Issue 3: [Fullstack] Dispatch Invitations - frontend-dev tasks

## Test plan
- [ ] Create a group, invite section appears below the success panel
- [ ] Submit valid IDs - spinner shown, invitations list renders with PENDING status
- [ ] Submit again - new invitations are appended to the list
- [ ] Include 'error_id' or 'invalid...' in the list - per-student 400 failures shown
- [ ] Unexpected error path renders generic error block
- [ ] Submit button disabled while pending or textarea is empty

