### PR TITLE
feat(invitations): implement Student Invitation Response UI and mock API

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import AdminHomePage from './AdminHomePage';
+import GroupFormationPage from './GroupFormationPage';
 import AdminLoginPage from './AdminLoginPage';
 import AdminProfessorCreatePage from './AdminProfessorCreatePage';
 import AuthGatewayPage from './AuthGatewayPage';
@@ -33,6 +34,7 @@ export default function App() {
               <Route path="/coordinator/login" element={<CoordinatorLoginPage />} />
               <Route path="/coordinator" element={<CoordinatorHomePage />} />
               <Route path="/coordinator/student-id-registry/import" element={<CoordinatorStudentIdUploadPage />} />
+              <Route path="/students/groups" element={<GroupFormationPage />} />
               <Route path="*" element={<AuthGatewayPage />} />
             </Route>
           </Routes>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import CoordinatorStudentIdUploadPage from './CoordinatorStudentIdUploadPage';
 import ProfessorLoginPage from './ProfessorLoginPage';
 import ProfessorPasswordSetupPage from './ProfessorPasswordSetupPage';
 import Register from './Register';
+import StudentInvitationsPage from './StudentInvitationsPage';
 import StudentLoginPage from './StudentLoginPage';
 import AppShell from './components/AppShell';
 import { AuthProvider } from './contexts/AuthContext';
@@ -35,6 +36,7 @@ export default function App() {
               <Route path="/coordinator" element={<CoordinatorHomePage />} />
               <Route path="/coordinator/student-id-registry/import" element={<CoordinatorStudentIdUploadPage />} />
               <Route path="/students/groups" element={<GroupFormationPage />} />
+              <Route path="/students/invitations" element={<StudentInvitationsPage />} />
               <Route path="*" element={<AuthGatewayPage />} />
             </Route>
           </Routes>

--- a/frontend/src/GroupFormationPage.jsx
+++ b/frontend/src/GroupFormationPage.jsx
@@ -1,9 +1,20 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import InviteMembersSection from './components/InviteMembersSection';
 import { useGroupFormation } from './hooks/useGroupFormation';
 
 export default function GroupFormationPage() {
-  const { createGroupShell, pending, group, error, reset } = useGroupFormation();
+  const {
+    createGroupShell,
+    pending,
+    group,
+    error,
+    reset,
+    dispatchInvites,
+    invitesPending,
+    invitations,
+    inviteError,
+  } = useGroupFormation();
   const [showForm, setShowForm] = useState(false);
   const [name, setName] = useState('');
 
@@ -43,13 +54,31 @@ export default function GroupFormationPage() {
       </p>
 
       {group && !showForm && (
-        <section className="panel">
-          <section className="feedback feedback-success" aria-live="polite">
-            <p className="feedback-label">Group Created</p>
-            <h2>{group.name}</h2>
-            <p>Your group shell has been created. You are now the Team Leader.</p>
+        <>
+          <section className="panel">
+            <section className="feedback feedback-success" aria-live="polite">
+              <p className="feedback-label">Group Created</p>
+              <h2>{group.name}</h2>
+              <p>Your group shell has been created. You are now the Team Leader.</p>
+            </section>
           </section>
-        </section>
+
+          <section className="hero">
+            <h2>Invite Members</h2>
+            <p className="subtitle">
+              Send invitations to students by entering their IDs below. Each student will receive a
+              pending invitation they can accept or decline.
+            </p>
+          </section>
+
+          <InviteMembersSection
+            group={group}
+            dispatchInvites={dispatchInvites}
+            invitesPending={invitesPending}
+            invitations={invitations}
+            inviteError={inviteError}
+          />
+        </>
       )}
 
       {!group && !showForm && (

--- a/frontend/src/GroupFormationPage.jsx
+++ b/frontend/src/GroupFormationPage.jsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGroupFormation } from './hooks/useGroupFormation';
+
+export default function GroupFormationPage() {
+  const { createGroupShell, pending, group, error, reset } = useGroupFormation();
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState('');
+
+  function handleCancel() {
+    setName('');
+    reset();
+    setShowForm(false);
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    try {
+      await createGroupShell(name);
+      setName('');
+      setShowForm(false);
+    } catch {
+      // error state is managed by the hook; stay on the form so the user sees it
+    }
+  }
+
+  return (
+    <main className="page">
+      <section className="hero">
+        <p className="eyebrow">Team Leader Workspace</p>
+        <h1>Group Formation</h1>
+        <p className="subtitle">
+          Create your group shell first. Once the group exists you can invite teammates and request
+          an advisor.
+        </p>
+      </section>
+
+      <p className="back-link-wrap">
+        <Link className="back-link" to="/">
+          Back to Home
+        </Link>
+      </p>
+
+      {group && !showForm && (
+        <section className="panel">
+          <section className="feedback feedback-success" aria-live="polite">
+            <p className="feedback-label">Group Created</p>
+            <h2>{group.name}</h2>
+            <p>Your group shell has been created. You are now the Team Leader.</p>
+          </section>
+        </section>
+      )}
+
+      {!group && !showForm && (
+        <section className="panel">
+          <button type="button" onClick={() => setShowForm(true)}>
+            Create a New Group
+          </button>
+        </section>
+      )}
+
+      {showForm && (
+        <section className="panel">
+          <form className="form" onSubmit={handleSubmit} noValidate>
+            <label className="field">
+              <span>Group Name</span>
+              <input
+                id="group-name"
+                name="name"
+                type="text"
+                placeholder="e.g. AI Capstone Team"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                minLength={3}
+                maxLength={64}
+                required
+                disabled={pending}
+                aria-describedby={error ? 'group-name-error' : undefined}
+                aria-invalid={error?.type === 'validation' ? 'true' : undefined}
+              />
+              {error && (
+                <span id="group-name-error" className="field-error" role="alert">
+                  {error.message}
+                </span>
+              )}
+            </label>
+
+            {error?.type === 'unexpected' && (
+              <section className="feedback feedback-error" aria-live="polite">
+                <p className="feedback-label">Error</p>
+                <p>{error.message}</p>
+              </section>
+            )}
+
+            <div className="form-actions">
+              <button type="submit" disabled={pending}>
+                {pending ? 'Creating group...' : 'Create Group'}
+              </button>
+              <button type="button" onClick={handleCancel} disabled={pending}>
+                Cancel
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/StudentInvitationsPage.jsx
+++ b/frontend/src/StudentInvitationsPage.jsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useStudentInvitations } from './hooks/useStudentInvitations';
+
+function InvitationCard({ invitation, respondingId, responseErrors, onRespond }) {
+  const isResponding = respondingId === invitation.id;
+  const error = responseErrors[invitation.id];
+
+  return (
+    <article className="stat-card">
+      <h3>{invitation.groupName}</h3>
+      <p>
+        <span>Status: </span>
+        <strong>{invitation.status}</strong>
+      </p>
+
+      <div className="form-actions">
+        <button
+          type="button"
+          disabled={isResponding}
+          onClick={() => onRespond(invitation.id, 'ACCEPT')}
+        >
+          {isResponding ? 'Accepting...' : 'Accept'}
+        </button>
+        <button
+          type="button"
+          disabled={isResponding}
+          onClick={() => onRespond(invitation.id, 'REJECT')}
+        >
+          {isResponding ? 'Declining...' : 'Decline'}
+        </button>
+      </div>
+
+      {error && (
+        <p className="field-error" role="alert" aria-live="polite">
+          {error}
+        </p>
+      )}
+    </article>
+  );
+}
+
+export default function StudentInvitationsPage() {
+  const {
+    loading,
+    invitations,
+    loadError,
+    respondingId,
+    responseErrors,
+    fetchInvitations,
+    respondToInvitation,
+  } = useStudentInvitations();
+
+  // Transient success banner shown after each resolved invitation.
+  const [lastResolved, setLastResolved] = useState(null);
+
+  useEffect(() => {
+    fetchInvitations();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function handleRespond(invitationId, response) {
+    const invitation = invitations.find((inv) => inv.id === invitationId);
+
+    try {
+      await respondToInvitation(invitationId, response);
+      setLastResolved({ groupName: invitation?.groupName, response });
+    } catch {
+      // error already in responseErrors; keep the banner clear
+      setLastResolved(null);
+    }
+  }
+
+  return (
+    <main className="page">
+      <section className="hero">
+        <p className="eyebrow">Student Workspace</p>
+        <h1>My Invitations</h1>
+        <p className="subtitle">
+          Review your pending group invitations below. Accept to join a group or decline to pass.
+        </p>
+      </section>
+
+      <p className="back-link-wrap">
+        <Link className="back-link" to="/">
+          Back to Home
+        </Link>
+      </p>
+
+      {lastResolved && (
+        <section className="panel">
+          <section className="feedback feedback-success" aria-live="polite">
+            <p className="feedback-label">
+              {lastResolved.response === 'ACCEPT' ? 'Invitation Accepted' : 'Invitation Declined'}
+            </p>
+            <p>
+              {lastResolved.response === 'ACCEPT'
+                ? `You have joined ${lastResolved.groupName}.`
+                : `You have declined the invitation from ${lastResolved.groupName}.`}
+            </p>
+          </section>
+        </section>
+      )}
+
+      <section className="panel">
+        {loading && (
+          <section className="feedback feedback-loading" aria-live="polite">
+            <p className="feedback-label">Loading</p>
+            <p>Loading invitations...</p>
+          </section>
+        )}
+
+        {!loading && loadError && (
+          <section className="feedback feedback-error" aria-live="polite">
+            <p className="feedback-label">Error</p>
+            <p>{loadError}</p>
+          </section>
+        )}
+
+        {!loading && !loadError && invitations.length === 0 && (
+          <section className="feedback feedback-idle" aria-live="polite">
+            <p className="feedback-label">No Invitations</p>
+            <p>You have no pending invitations.</p>
+          </section>
+        )}
+
+        {!loading && invitations.length > 0 && (
+          <div className="stats-grid">
+            {invitations.map((inv) => (
+              <InvitationCard
+                key={inv.id}
+                invitation={inv}
+                respondingId={respondingId}
+                responseErrors={responseErrors}
+                onRespond={handleRespond}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/components/InviteMembersSection.jsx
+++ b/frontend/src/components/InviteMembersSection.jsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+
+function parseStudentIds(raw) {
+  return [
+    ...new Set(
+      raw
+        .split(/[\s,]+/)
+        .map((s) => s.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+// InviteMembersSection — rendered once a group shell exists.
+// Props:
+//   group          — the created group object { id, name, ... }
+//   dispatchInvites(groupId, studentIds) — from useGroupFormation
+//   invitesPending — boolean
+//   invitations    — Invitation[] accumulated from successful dispatches
+//   inviteError    — null | { type, message, failures? }
+export default function InviteMembersSection({
+  group,
+  dispatchInvites,
+  invitesPending,
+  invitations,
+  inviteError,
+}) {
+  const [idsText, setIdsText] = useState('');
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    const ids = parseStudentIds(idsText);
+    if (ids.length === 0) return;
+
+    try {
+      await dispatchInvites(group.id, ids);
+      setIdsText('');
+    } catch {
+      // error state managed by hook; keep the textarea so the user can correct IDs
+    }
+  }
+
+  function handleClear() {
+    setIdsText('');
+  }
+
+  return (
+    <section className="panel">
+      <form className="form" onSubmit={handleSubmit} noValidate>
+        <label className="field">
+          <span>Invite Student IDs</span>
+          <textarea
+            id="invite-ids"
+            name="studentIds"
+            placeholder={'e.g. 11070001001, 11070001002\nor one per line'}
+            value={idsText}
+            onChange={(e) => setIdsText(e.target.value)}
+            rows={4}
+            disabled={invitesPending}
+            aria-describedby={inviteError ? 'invite-error-summary' : undefined}
+          />
+          <p className="token-note">
+            Enter student IDs separated by commas or newlines. Duplicates are ignored.
+            <br />
+            <em>Mock tip: include "error_id" or any ID starting with "invalid" to trigger a 400.</em>
+          </p>
+        </label>
+
+        {inviteError?.type === 'validation' && inviteError.failures?.length > 0 && (
+          <section
+            id="invite-error-summary"
+            className="feedback feedback-error"
+            aria-live="polite"
+          >
+            <p className="feedback-label">Validation Failures</p>
+            <p>{inviteError.message}</p>
+            <ul>
+              {inviteError.failures.map((f) => (
+                <li key={f.studentId}>
+                  <strong>{f.studentId}</strong> — {f.reason}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {inviteError?.type === 'unexpected' && (
+          <section className="feedback feedback-error" aria-live="polite">
+            <p className="feedback-label">Error</p>
+            <p>{inviteError.message}</p>
+          </section>
+        )}
+
+        <div className="form-actions">
+          <button type="submit" disabled={invitesPending || !idsText.trim()}>
+            {invitesPending ? 'Sending invitations...' : 'Send Invitations'}
+          </button>
+          <button type="button" onClick={handleClear} disabled={invitesPending}>
+            Clear
+          </button>
+        </div>
+      </form>
+
+      {invitations.length > 0 && (
+        <section className="side-column">
+          <section className="token-panel">
+            <p className="feedback-label">Pending Invitations</p>
+            <ul>
+              {invitations.map((inv) => (
+                <li key={inv.id}>
+                  <strong>{inv.studentId}</strong>
+                  <span> — {inv.status}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </section>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useGroupFormation.js
+++ b/frontend/src/hooks/useGroupFormation.js
@@ -1,5 +1,37 @@
 import { useState } from 'react';
 
+// Mock: simulates POST /groups/{groupId}/invitations.
+// Replace with apiClient.post(`/v1/groups/${groupId}/invitations`, { studentIds }) when ready.
+// Trigger the 400 path by including an ID that is exactly "error_id" or starts with "invalid".
+function mockPostInvitations(groupId, studentIds) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const failures = studentIds
+        .filter((id) => id === 'error_id' || id.toLowerCase().startsWith('invalid'))
+        .map((id) => ({ studentId: id, reason: 'Student not found or is ineligible.' }));
+
+      if (failures.length > 0) {
+        const err = new Error('Some student IDs failed validation.');
+        err.response = {
+          status: 400,
+          data: { message: err.message, code: 'VALIDATION_FAILED', failures },
+        };
+        return reject(err);
+      }
+
+      const invitations = studentIds.map((id) => ({
+        id: crypto.randomUUID(),
+        groupId,
+        studentId: id,
+        status: 'PENDING',
+        createdAt: new Date().toISOString(),
+      }));
+
+      resolve({ data: invitations, status: 201 });
+    }, 800);
+  });
+}
+
 // Mock: simulates POST /groups. Replace the body of the try-block with a real
 // apiClient.post('/v1/groups', { name }) call once the backend is ready.
 function mockPostGroup(name) {
@@ -46,6 +78,10 @@ export function useGroupFormation() {
   const [group, setGroup] = useState(null);
   const [error, setError] = useState(null);
 
+  const [invitesPending, setInvitesPending] = useState(false);
+  const [invitations, setInvitations] = useState([]);
+  const [inviteError, setInviteError] = useState(null);
+
   async function createGroupShell(name) {
     setPending(true);
     setError(null);
@@ -69,10 +105,51 @@ export function useGroupFormation() {
     }
   }
 
+  // Simulates POST /groups/{groupId}/invitations.
+  // studentIds must be a de-duped, trimmed string[].
+  async function dispatchInvites(groupId, studentIds) {
+    setInvitesPending(true);
+    setInviteError(null);
+
+    try {
+      const result = await mockPostInvitations(groupId, studentIds);
+      setInvitations((prev) => [...prev, ...result.data]);
+      return result.data;
+    } catch (err) {
+      const status = err.response?.status;
+      const data = err.response?.data;
+
+      if (status === 400) {
+        setInviteError({
+          type: 'validation',
+          message: data?.message || 'Validation failed.',
+          failures: data?.failures ?? [],
+        });
+      } else {
+        setInviteError({ type: 'unexpected', message: 'Something went wrong. Please try again.' });
+      }
+      throw err;
+    } finally {
+      setInvitesPending(false);
+    }
+  }
+
   function reset() {
     setGroup(null);
     setError(null);
+    setInvitations([]);
+    setInviteError(null);
   }
 
-  return { createGroupShell, pending, group, error, reset };
+  return {
+    createGroupShell,
+    pending,
+    group,
+    error,
+    reset,
+    dispatchInvites,
+    invitesPending,
+    invitations,
+    inviteError,
+  };
 }

--- a/frontend/src/hooks/useGroupFormation.js
+++ b/frontend/src/hooks/useGroupFormation.js
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+
+// Mock: simulates POST /groups. Replace the body of the try-block with a real
+// apiClient.post('/v1/groups', { name }) call once the backend is ready.
+function mockPostGroup(name) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const trimmed = name.trim();
+
+      if (!trimmed || trimmed.length < 3 || trimmed.length > 64) {
+        const err = new Error('Group name must be between 3 and 64 characters.');
+        err.response = {
+          status: 400,
+          data: { message: err.message, code: 'INVALID_NAME' },
+        };
+        return reject(err);
+      }
+
+      // Simulate a duplicate-name collision when the name starts with "duplicate"
+      // so the 400 error path can be exercised without a real backend.
+      if (trimmed.toLowerCase().startsWith('duplicate')) {
+        const err = new Error('A group with this name already exists.');
+        err.response = {
+          status: 400,
+          data: { message: err.message, code: 'DUPLICATE_NAME' },
+        };
+        return reject(err);
+      }
+
+      resolve({
+        data: {
+          id: crypto.randomUUID(),
+          name: trimmed,
+          leaderId: 'mock-leader-id',
+          memberIds: [],
+          advisorId: null,
+        },
+        status: 201,
+      });
+    }, 800);
+  });
+}
+
+export function useGroupFormation() {
+  const [pending, setPending] = useState(false);
+  const [group, setGroup] = useState(null);
+  const [error, setError] = useState(null);
+
+  async function createGroupShell(name) {
+    setPending(true);
+    setError(null);
+
+    try {
+      const result = await mockPostGroup(name);
+      setGroup(result.data);
+      return result.data;
+    } catch (err) {
+      const status = err.response?.status;
+      const message = err.response?.data?.message || err.message;
+
+      if (status === 400) {
+        setError({ type: 'validation', message });
+      } else {
+        setError({ type: 'unexpected', message: 'Something went wrong. Please try again.' });
+      }
+      throw err;
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function reset() {
+    setGroup(null);
+    setError(null);
+  }
+
+  return { createGroupShell, pending, group, error, reset };
+}

--- a/frontend/src/hooks/useStudentInvitations.js
+++ b/frontend/src/hooks/useStudentInvitations.js
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+
+// Seeded mock invitations returned by the fetch mock.
+// 'error-inv' always triggers a 400 so the error path can be tested without a backend.
+const MOCK_INVITATIONS = [
+  { id: 'inv-1',     groupId: 'grp-1', groupName: 'AI Capstone Team', status: 'PENDING' },
+  { id: 'inv-2',     groupId: 'grp-2', groupName: 'Web Dev Squad',    status: 'PENDING' },
+  { id: 'error-inv', groupId: 'grp-3', groupName: 'Error Group',      status: 'PENDING' },
+];
+
+// Mock: simulates GET /invitations?studentId=me.
+// Replace with apiClient.get('/v1/invitations/me') when the backend is ready.
+function mockFetchInvitations() {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({ data: MOCK_INVITATIONS.map((inv) => ({ ...inv })), status: 200 });
+    }, 600);
+  });
+}
+
+// Mock: simulates PATCH /invitations/{invitationId}/response.
+// Replace with apiClient.patch(`/v1/invitations/${invitationId}/response`, { response })
+// when the backend is ready.
+function mockPatchInvitationResponse(invitationId, response) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (invitationId === 'error-inv') {
+        const err = new Error('This invitation has already been responded to.');
+        err.response = {
+          status: 400,
+          data: { message: err.message, code: 'ALREADY_RESPONDED' },
+        };
+        return reject(err);
+      }
+
+      resolve({
+        data: { id: invitationId, status: response === 'ACCEPT' ? 'ACCEPTED' : 'REJECTED' },
+        status: 200,
+      });
+    }, 800);
+  });
+}
+
+function mapResponseError(err) {
+  const status = err.response?.status;
+  const message = err.response?.data?.message;
+
+  if (status === 400) return message || 'This invitation has already been responded to.';
+  if (status === 403) return 'You are not authorised to respond to this invitation.';
+  if (status === 404) return 'This invitation no longer exists.';
+  return 'Something went wrong. Please try again.';
+}
+
+export function useStudentInvitations() {
+  const [loading, setLoading] = useState(false);
+  const [invitations, setInvitations] = useState([]);
+  const [loadError, setLoadError] = useState(null);
+  const [respondingId, setRespondingId] = useState(null);
+  const [responseErrors, setResponseErrors] = useState({});
+
+  async function fetchInvitations() {
+    setLoading(true);
+    setLoadError(null);
+
+    try {
+      const result = await mockFetchInvitations();
+      setInvitations(result.data);
+    } catch {
+      setLoadError('Could not load your invitations. Please refresh and try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // response: "ACCEPT" | "REJECT"
+  async function respondToInvitation(invitationId, response) {
+    setRespondingId(invitationId);
+    setResponseErrors((prev) => {
+      const next = { ...prev };
+      delete next[invitationId];
+      return next;
+    });
+
+    try {
+      await mockPatchInvitationResponse(invitationId, response);
+      setInvitations((prev) => prev.filter((inv) => inv.id !== invitationId));
+    } catch (err) {
+      setResponseErrors((prev) => ({ ...prev, [invitationId]: mapResponseError(err) }));
+      throw err;
+    } finally {
+      setRespondingId(null);
+    }
+  }
+
+  return {
+    loading,
+    invitations,
+    loadError,
+    respondingId,
+    responseErrors,
+    fetchInvitations,
+    respondToInvitation,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds StudentInvitationsPage to display and manage pending invitations.
- Adds useStudentInvitations hook with mock fetch and patch API endpoints.
- Integrates the route /students/invitations into App.jsx.

## Issue
Closes Issue 7: [Fullstack] Receive Invitee Response - frontend-dev tasks

## Test plan
- [ ] Navigate to /students/invitations - see loading state followed by 3 mock invitations.
- [ ] Click Accept on 'AI Capstone Team' - see loading state, card disappears, success banner appears.
- [ ] Click Decline on 'Web Dev Squad' - see loading state, card disappears, success banner appears.
- [ ] Click Accept/Decline on 'Error Group' - see inline validation error on the card.
