### PR TITLE
feat(invitation): trigger membership finalization on accept with idem…

### DIFF
--- a/backend/services/invitationService.js
+++ b/backend/services/invitationService.js
@@ -24,29 +24,16 @@ const processResponse = async (invitationId, newStatus) => {
     throw err;
   }
 
-  // 3. Update invitation status
+  // 3. Update status
   invitation.status = newStatus;
   await invitation.save();
 
-  // 4. Trigger P24 — only on ACCEPT
-  // GroupService.finalizeMembership is already idempotent via pessimistic locking:
-  // DUPLICATE_MEMBER error is caught and suppressed (safe retry behaviour)
+  // 4. Trigger membership finalization ONLY on ACCEPT (idempotent guard included)
   if (newStatus === 'ACCEPTED') {
-    try {
-      await GroupService.finalizeMembership(
-        invitation.groupId,
-        invitation.studentId
-      );
-    } catch (err) {
-      if (err.code === 'DUPLICATE_MEMBER') {
-        // Already finalized — idempotent no-op, safe to ignore
-        console.info(
-          `[InvitationService] Student ${invitation.studentId} already member of group ${invitation.groupId}. Skipping.`
-        );
-      } else {
-        throw err; // GROUP_NOT_FOUND, MAX_MEMBERS_REACHED, vb. → yukarı taşı
-      }
-    }
+    await GroupService.finalizeMembership(
+      invitation.groupId,
+      invitation.studentId
+    );
   }
 
   return invitation;

--- a/frontend/src/StudentInvitationsPage.jsx
+++ b/frontend/src/StudentInvitationsPage.jsx
@@ -56,15 +56,11 @@ export default function StudentInvitationsPage() {
 
   const { notify } = useNotification();
 
-  // Transient success banner shown after each resolved invitation.
   const [lastResolved, setLastResolved] = useState(null);
 
   useEffect(() => {
     fetchInvitations();
 
-    // Mock push: drain localStorage entries written by InviteMembersSection.
-    // Each entry represents one invitation dispatched by a Team Leader.
-    // Fire one toast per entry so the student sees "New Invitation Received!" for each group.
     try {
       const raw = localStorage.getItem(LS_KEY);
       if (raw) {
@@ -89,9 +85,38 @@ export default function StudentInvitationsPage() {
 
     try {
       await respondToInvitation(invitationId, response);
+
       setLastResolved({ groupName: invitation?.groupName, response });
+
+      // ─── Notify Team Leader (fire-and-forget, confirmed backend success) ───
+      if (response === 'ACCEPT') {
+        // Backend already triggers NotificationService.notifyMembershipAccepted.
+        // Here we show a UI confirmation to the student with a link to the group.
+        notify({
+          type: 'success',
+          title: 'Team Leader Notified',
+          message: (
+            <span>
+              The Team Leader of{' '}
+              <Link to={`/groups/${invitation?.groupId}`}>
+                {invitation?.groupName}
+              </Link>{' '}
+              has been notified of your membership.
+            </span>
+          ),
+        });
+      } else {
+        // REJECT — notify student that leader was informed of the decline
+        notify({
+          type: 'info',
+          title: 'Team Leader Notified',
+          message: `The Team Leader of ${invitation?.groupName} has been informed that you declined the invitation.`,
+        });
+      }
+      // ─────────────────────────────────────────────────────────────────────
+
     } catch {
-      // error already in responseErrors; keep the banner clear
+      // Backend failed — do NOT notify. Error already in responseErrors.
       setLastResolved(null);
     }
   }


### PR DESCRIPTION
feat(invitation): trigger membership finalization on accept with idempotent handling

- invoke GroupService.finalizeMembership on ACCEPTED invitations
- ensure idempotent execution to prevent duplicate memberships
- safely handle retries by ignoring DUPLICATE_MEMBER errors