### PR TITLE
Fix #184: Align Group model contract to restore group creation and notification membership flows

### DIFF
--- a/backend/models/Group.js
+++ b/backend/models/Group.js
@@ -7,10 +7,20 @@ const Group = sequelize.define(
     id: {
       type: DataTypes.STRING,
       primaryKey: true,
+      defaultValue: () => `${Date.now()}${Math.floor(Math.random() * 1000)}`,
     },
     name: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    groupName: {
+      type: DataTypes.VIRTUAL,
+      get() {
+        return this.getDataValue('name');
+      },
+      set(value) {
+        this.setDataValue('name', value);
+      },
     },
     leaderId: {
       type: DataTypes.STRING,
@@ -20,6 +30,25 @@ const Group = sequelize.define(
       type: DataTypes.JSON,
       allowNull: false,
       defaultValue: [],
+    },
+    members: {
+      type: DataTypes.VIRTUAL,
+      get() {
+        return this.getDataValue('memberIds') || [];
+      },
+      set(value) {
+        this.setDataValue('memberIds', Array.isArray(value) ? value : []);
+      },
+    },
+    maxMembers: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 4,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'FORMATION',
     },
     advisorId: {
       type: DataTypes.STRING,


### PR DESCRIPTION
## Linked Issue
Closes #184

## What This PR Changes
- Aligns `Group` model field contract used by group service/controller runtime paths.
- Preserves compatibility for existing repository usage patterns.
- Restores successful group creation payload required by notification membership flows.

## Why
Group creation failed with model-field mismatch, which cascaded into membership/notification failures in runtime tests.

## Validation
- Backend tests executed for runtime API paths.
- Frontend build executed.

## Branch Mapping
- Issue: #184
- Branch: `issue/group-create-notification-failures-v2`
- PR: #185
