### PR TITLE
Fix #188: Start Vite web server automatically in Playwright config

### DIFF
--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -5,4 +5,10 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:5173',
   },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 5173',
+    url: 'http://127.0.0.1:5173',
+    reuseExistingServer: true,
+    timeout: 120000,
+  },
 });


### PR DESCRIPTION
Closes #188.\n\n## Summary\nAdds `webServer` configuration to Playwright so QA tests no longer fail with `ERR_CONNECTION_REFUSED` before UI assertions run.\n\n## Validation\n- `cd frontend && npx playwright test src/QA.spec.js` now reaches page-level element assertions instead of connection failure.