### PR TITLE
Fix #190: Align QA login selectors and route to current student login page

### DIFF
--- a/frontend/src/QA.spec.js
+++ b/frontend/src/QA.spec.js
@@ -19,11 +19,11 @@ const GROUP_NAME = 'E2E Response Team';
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 async function loginAs(page, studentId, password) {
-  await page.goto('/student/login');
-  await page.getByLabel(/student id/i).fill(studentId);
+  await page.goto('/students/login');
+  await page.getByLabel(/student number|student id/i).fill(studentId);
   await page.getByLabel(/password/i).fill(password);
-  await page.getByRole('button', { name: /log in/i }).click();
-  await page.waitForURL(/\/student\//);
+  await page.getByRole('button', { name: /log in|sign in/i }).click();
+  await expect(page.getByText(/signed in successfully|student login successful/i)).toBeVisible({ timeout: 10000 });
 }
 
 async function logout(page) {


### PR DESCRIPTION
Closes #190.\n\n## Summary\nUpdates QA login helper to use `/students/login`, accepts current label semantics (`Student Number`), and supports `Sign In` button text.\n\n## Validation\n- Playwright no longer fails at initial selector lookup for student ID label.\n- Next surfaced blocker is backend API availability in E2E runtime (`ECONNREFUSED 127.0.0.1:3001`).