### PR TITLE
Fix #192: Bootstrap backend API in Playwright E2E webServer config

### DIFF
--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -5,10 +5,18 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:5173',
   },
-  webServer: {
-    command: 'npm run dev -- --host 127.0.0.1 --port 5173',
-    url: 'http://127.0.0.1:5173',
-    reuseExistingServer: true,
-    timeout: 120000,
-  },
+  webServer: [
+    {
+      command: 'npm --prefix ../backend start',
+      url: 'http://127.0.0.1:3001',
+      reuseExistingServer: true,
+      timeout: 120000,
+    },
+    {
+      command: 'npm run dev -- --host 127.0.0.1 --port 5173',
+      url: 'http://127.0.0.1:5173',
+      reuseExistingServer: true,
+      timeout: 120000,
+    },
+  ],
 });


### PR DESCRIPTION
Closes #192.\n\n## Summary\nConfigures Playwright to start backend (`npm --prefix ../backend start`) and frontend dev servers together, removing API proxy connection-refused failures during login attempts.\n\n## Validation\n- `cd frontend && npx playwright test src/QA.spec.js` no longer shows `ECONNREFUSED 127.0.0.1:3001`.