### PR TITLE
Fix #194: Seed Playwright E2E student login prerequisites before backend startup

### DIFF
--- a/backend/scripts/seedPlaywrightUsers.js
+++ b/backend/scripts/seedPlaywrightUsers.js
@@ -1,0 +1,45 @@
+const bcrypt = require('bcryptjs');
+const sequelize = require('../db');
+const { User, ValidStudentId } = require('../models');
+
+const students = [
+  { studentId: '11070001000', fullName: 'Leader Student', email: 'leader.student@example.com' },
+  { studentId: '11070001001', fullName: 'Invitee Student', email: 'invitee.student@example.com' },
+  { studentId: '11070001002', fullName: 'Stranger Student', email: 'stranger.student@example.com' },
+];
+
+async function seed() {
+  await sequelize.authenticate();
+  await sequelize.sync();
+
+  const passwordHash = await bcrypt.hash('StrongPass1!', 10);
+
+  for (const student of students) {
+    await ValidStudentId.findOrCreate({
+      where: { studentId: student.studentId },
+      defaults: { studentId: student.studentId },
+    });
+
+    await User.findOrCreate({
+      where: { studentId: student.studentId },
+      defaults: {
+        email: student.email,
+        fullName: student.fullName,
+        studentId: student.studentId,
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        passwordHash,
+      },
+    });
+  }
+}
+
+seed()
+  .then(() => {
+    console.log('[seedPlaywrightUsers] Completed');
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('[seedPlaywrightUsers] Failed', error);
+    process.exit(1);
+  });

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: 'npm --prefix ../backend start',
+      command: 'JWT_SECRET=playwright-e2e-secret node ../backend/scripts/seedPlaywrightUsers.js && JWT_SECRET=playwright-e2e-secret npm --prefix ../backend start',
       url: 'http://127.0.0.1:3001',
       reuseExistingServer: true,
       timeout: 120000,


### PR DESCRIPTION
Closes #194.\n\n## Summary\nAdds deterministic student seed script for Playwright credentials and wires it into backend startup command used by Playwright harness.\n\n## Validation\n- Playwright progressed past backend connection and login data precondition failures.\n- Next surfaced blocker is a strict-mode locator assertion in QA spec.