### PR TITLE
Fix #196: Use unique heading locator for login success assertion in Playwright QA

### DIFF
--- a/frontend/src/QA.spec.js
+++ b/frontend/src/QA.spec.js
@@ -23,7 +23,7 @@ async function loginAs(page, studentId, password) {
   await page.getByLabel(/student number|student id/i).fill(studentId);
   await page.getByLabel(/password/i).fill(password);
   await page.getByRole('button', { name: /log in|sign in/i }).click();
-  await expect(page.getByText(/signed in successfully|student login successful/i)).toBeVisible({ timeout: 10000 });
+  await expect(page.getByRole('heading', { name: /signed in successfully/i })).toBeVisible({ timeout: 10000 });
 }
 
 async function logout(page) {


### PR DESCRIPTION
Closes #196.\n\n## Summary\nReplaces ambiguous login success text locator with explicit heading-based selector to satisfy Playwright strict mode.\n\n## Validation\n- Playwright no longer fails on strict locator ambiguity at login success assertion.\n- Next surfaced blocker is missing group-management navigation element expected by QA flow.