### PR TITLE
Issue 7: Add advisor request inbox

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -8,6 +8,7 @@ const { User, Group, AuditLog } = require('./models');
 
 const adminRoutes = require('./routes/admin');
 const coordinatorRoutes = require('./routes/coordinator');
+const advisorRoutes = require('./routes/advisors');
 const professorRoutes = require('./routes/professors');
 const studentRoutes = require('./routes/students');
 const authRoutes = require('./routes/auth');
@@ -33,6 +34,7 @@ app.locals.models = { User, Group, AuditLog };
 // Routes
 app.use('/api/v1/admin', adminRoutes);
 app.use('/api/v1/coordinator', coordinatorRoutes);
+app.use('/api/v1/advisors', advisorRoutes);
 app.use('/api/v1/professors', professorRoutes);
 app.use('/api/v1', studentRoutes);
 app.use('/api/v1/auth', authRoutes);

--- a/backend/routes/advisors.js
+++ b/backend/routes/advisors.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const { Op } = require('sequelize');
+const { authenticate, authorize } = require('../middleware/auth');
+const { Notification } = require('../models');
+
+const router = express.Router();
+
+function parsePayload(rawPayload) {
+  try {
+    return JSON.parse(rawPayload || '{}');
+  } catch {
+    return {};
+  }
+}
+
+router.get(
+  '/notifications/advisee-requests',
+  authenticate,
+  authorize(['PROFESSOR']),
+  async (req, res) => {
+    try {
+      const rows = await Notification.findAll({
+        where: {
+          userId: req.user.id,
+          type: {
+            [Op.in]: ['ADVISEE_REQUEST', 'ADVISOR_REQUEST'],
+          },
+        },
+        order: [['createdAt', 'DESC']],
+        limit: 50,
+      });
+
+      const notifications = rows.map((row) => {
+        const payload = parsePayload(row.payload);
+
+        return {
+          id: row.id,
+          type: 'ADVISEE_REQUEST',
+          recipientId: req.user.id,
+          requestId: payload.requestId ?? null,
+          groupId: payload.groupId ?? null,
+          groupName: payload.groupName ?? null,
+          requestStatus: payload.requestStatus || payload.status || 'PENDING',
+          message: payload.message || 'A team leader submitted an advisor request.',
+          read: false,
+          createdAt: row.createdAt,
+          status: row.status,
+        };
+      });
+
+      return res.status(200).json(notifications);
+    } catch (error) {
+      console.error('Error in advisors/notifications/advisee-requests:', error);
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  },
+);
+
+module.exports = router;

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -16,6 +16,7 @@ const {
   OAuthState,
   Group,
   AuditLog,
+  Notification,
 } = require('../models');
 const StudentRegistrationError = require('../errors/studentRegistrationError');
 const studentRegistrationService = require('../services/studentRegistrationService');
@@ -55,6 +56,7 @@ test.after(async () => {
 });
 
 test.beforeEach(async () => {
+  await Notification.destroy({ where: {} });
   await AuditLog.destroy({ where: {} });
   await Group.destroy({ where: {} });
   await LinkedGitHubAccount.destroy({ where: {} });
@@ -229,6 +231,89 @@ test('professor can log in with email and chosen password after setup', async ()
 
   assert.equal(invalidResult.response.status, 401);
   assert.equal(invalidResult.json.errorCode, 'INVALID_CREDENTIALS');
+});
+
+test('advisor notifications endpoint returns only advisee requests for the authenticated professor', async () => {
+  const professor = await User.create({
+    email: 'advisor@example.edu',
+    fullName: 'Advisor Inbox',
+    role: 'PROFESSOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const otherProfessor = await User.create({
+    email: 'other-advisor@example.edu',
+    fullName: 'Other Advisor',
+    role: 'PROFESSOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  await Notification.create({
+    userId: professor.id,
+    type: 'ADVISEE_REQUEST',
+    payload: JSON.stringify({
+      requestId: 'req-1',
+      groupId: 'group-1',
+      groupName: 'Team Atlas',
+      requestStatus: 'PENDING',
+      message: 'Team Atlas requested you as advisor.',
+    }),
+    status: 'SENT',
+  });
+
+  await Notification.create({
+    userId: professor.id,
+    type: 'GROUP_INVITE',
+    payload: JSON.stringify({
+      groupId: 'group-ignore',
+    }),
+    status: 'SENT',
+  });
+
+  await Notification.create({
+    userId: otherProfessor.id,
+    type: 'ADVISEE_REQUEST',
+    payload: JSON.stringify({
+      requestId: 'req-2',
+      groupId: 'group-2',
+      groupName: 'Team Nova',
+      requestStatus: 'PENDING',
+      message: 'Team Nova requested you as advisor.',
+    }),
+    status: 'SENT',
+  });
+
+  const result = await request('/api/v1/advisors/notifications/advisee-requests', {
+    headers: await authHeaderFor(professor),
+  });
+
+  assert.equal(result.response.status, 200);
+  assert.equal(Array.isArray(result.json), true);
+  assert.equal(result.json.length, 1);
+  assert.equal(result.json[0].type, 'ADVISEE_REQUEST');
+  assert.equal(result.json[0].requestId, 'req-1');
+  assert.equal(result.json[0].groupName, 'Team Atlas');
+  assert.equal(result.json[0].requestStatus, 'PENDING');
+});
+
+test('advisor notifications endpoint rejects non-professor users', async () => {
+  const student = await User.create({
+    email: 'student-not-allowed@example.edu',
+    fullName: 'Student Viewer',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001234',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const result = await request('/api/v1/advisors/notifications/advisee-requests', {
+    headers: await authHeaderFor(student),
+  });
+
+  assert.equal(result.response.status, 403);
+  assert.equal(result.json.message, 'Forbidden');
 });
 
 test('admin can register professor and duplicate email returns 409', async () => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import CoordinatorLoginPage from './CoordinatorLoginPage';
 import CoordinatorStudentIdUploadPage from './CoordinatorStudentIdUploadPage';
 import GroupPage from './GroupPage';
 import HomePage from './HomePage';
+import ProfessorAdvisorRequestsPage from './ProfessorAdvisorRequestsPage';
 import ProfessorLoginPage from './ProfessorLoginPage';
 import ProfessorPasswordSetupPage from './ProfessorPasswordSetupPage';
 import Register from './Register';
@@ -36,6 +37,7 @@ export default function App() {
               <Route path="/students/groups/new" element={<StudentGroupShellPage />} />
               <Route path="/students/notifications" element={<StudentInvitationsPage />} />
               <Route path="/professors/login" element={<AuthPage />} />
+              <Route path="/professors/notifications" element={<ProfessorAdvisorRequestsPage />} />
               <Route path="/professors/password-setup" element={<ProfessorPasswordSetupPage />} />
               <Route path="/admin/login" element={<AuthPage />} />
               <Route path="/admin" element={<AdminHomePage />} />

--- a/frontend/src/HomePage.jsx
+++ b/frontend/src/HomePage.jsx
@@ -121,7 +121,26 @@ export default function HomePage() {
             </div>
           </section>
         ) : (
-          <div className="main-empty-canvas" />
+          <>
+            {role === 'PROFESSOR' ? (
+              <section className="student-home-panel">
+                <p><strong>Inbox:</strong> Advisor request notifications</p>
+                <p className="student-home-note">
+                  Review incoming advisor requests from team leaders without leaving the workspace.
+                </p>
+                <div className="workspace-actions">
+                  <Link className="workspace-button workspace-button-primary" to="/professors/notifications">
+                    Advisor Requests
+                  </Link>
+                  <Link className="workspace-button workspace-button-secondary" to="/professors/password-setup">
+                    Password Setup
+                  </Link>
+                </div>
+              </section>
+            ) : (
+              <div className="main-empty-canvas" />
+            )}
+          </>
         )}
       </section>
     </main>

--- a/frontend/src/ProfessorAdvisorRequestsPage.jsx
+++ b/frontend/src/ProfessorAdvisorRequestsPage.jsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react';
+
+function formatDate(value) {
+  if (!value) {
+    return 'Now';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Now';
+  }
+
+  return date.toLocaleString();
+}
+
+function formatStatus(value) {
+  if (!value) {
+    return 'Pending';
+  }
+
+  return value
+    .toString()
+    .toLowerCase()
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function buildSubject(entry) {
+  const groupName = entry.groupName || entry.groupId || 'Unknown group';
+  return `${groupName} advisor request`;
+}
+
+function buildPreview(entry) {
+  return entry.message || 'A team leader submitted an advisor request for your review.';
+}
+
+export default function ProfessorAdvisorRequestsPage() {
+  const [requests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [selectedRequestId, setSelectedRequestId] = useState(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const token = window.localStorage.getItem('professorToken') || window.localStorage.getItem('authToken');
+
+    async function loadRequests() {
+      try {
+        const response = await fetch('/api/v1/advisors/notifications/advisee-requests', {
+          headers: token
+            ? {
+              Authorization: `Bearer ${token}`,
+            }
+            : {},
+          signal: controller.signal,
+        });
+
+        const payload = await response.json().catch(() => []);
+
+        if (!response.ok) {
+          setLoadError('Advisor requests could not be loaded.');
+          setRequests([]);
+          return;
+        }
+
+        const rows = Array.isArray(payload) ? payload : payload.notifications || [];
+        setRequests(rows);
+        setSelectedRequestId((current) => current || rows[0]?.id || null);
+        setLoadError('');
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          return;
+        }
+
+        setLoadError('Advisor requests could not be loaded.');
+        setRequests([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadRequests();
+
+    return () => controller.abort();
+  }, []);
+
+  const selectedRequest = requests.find((entry) => entry.id === selectedRequestId) || null;
+
+  return (
+    <main className="page page-mailbox">
+      <section className="hero">
+        <p className="eyebrow">Advisor Inbox</p>
+        <h1>Incoming advisor requests</h1>
+        <p className="subtitle">
+          Review requests submitted by team leaders. New entries are fetched from the backend when this page opens.
+        </p>
+      </section>
+
+      <section className="single-panel">
+        {loading && (
+          <p className="mail-state" aria-live="polite">Loading advisor requests...</p>
+        )}
+
+        {!loading && loadError && (
+          <p className="mail-state" aria-live="polite">{loadError}</p>
+        )}
+
+        {!loading && !loadError && requests.length === 0 && (
+          <p className="mail-state" aria-live="polite">No incoming advisor requests.</p>
+        )}
+
+        {!loading && !loadError && requests.length > 0 && (
+          <div className="mail-layout">
+            <aside className="mail-sidebar" aria-label="Advisor request list">
+              <div className="mail-sidebar-header">
+                <p className="mailbox-title">Advisor Requests</p>
+                <p className="mailbox-count">{requests.length} requests</p>
+              </div>
+
+              <section className="mail-nav">
+                {requests.map((entry) => {
+                  const isActive = entry.id === selectedRequestId;
+                  return (
+                    <button
+                      key={entry.id}
+                      type="button"
+                      className={`mail-nav-item${isActive ? ' mail-nav-item-active' : ''}`}
+                      onClick={() => setSelectedRequestId(entry.id)}
+                    >
+                      <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
+                      <span className="mail-nav-subject">{buildSubject(entry)}</span>
+                      <span className="mail-nav-preview">{buildPreview(entry)}</span>
+                    </button>
+                  );
+                })}
+              </section>
+            </aside>
+
+            <section className="mail-detail" aria-live="polite">
+              {selectedRequest ? (
+                <>
+                  <div className="mail-detail-header">
+                    <div>
+                      <span className="mail-topic">Advisee Request</span>
+                      <h2 className="mail-subject">{buildSubject(selectedRequest)}</h2>
+                    </div>
+                    <span className="mail-time">{formatDate(selectedRequest.createdAt)}</span>
+                  </div>
+
+                  <p className="mail-preview">{buildPreview(selectedRequest)}</p>
+
+                  <dl className="mail-detail-grid">
+                    <div>
+                      <dt>Group</dt>
+                      <dd>{selectedRequest.groupName || selectedRequest.groupId || 'Not specified'}</dd>
+                    </div>
+                    <div>
+                      <dt>Request Status</dt>
+                      <dd>{formatStatus(selectedRequest.requestStatus)}</dd>
+                    </div>
+                    <div>
+                      <dt>Request ID</dt>
+                      <dd>{selectedRequest.requestId || 'Not provided'}</dd>
+                    </div>
+                    <div>
+                      <dt>Notification State</dt>
+                      <dd>{formatStatus(selectedRequest.status)}</dd>
+                    </div>
+                  </dl>
+                </>
+              ) : (
+                <p className="mail-detail-empty">Select a request to review its details.</p>
+              )}
+            </section>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -17,6 +17,7 @@ const roleMenuSections = {
       title: 'Workspace',
       items: [
         { to: '/home', label: 'Professor Home', icon: 'HM' },
+        { to: '/professors/notifications', label: 'Advisor Requests', icon: 'AR' },
       ],
     },
   ],
@@ -177,14 +178,24 @@ export default function AppShell() {
                       )}
 
                       {authenticatedUser.role === 'Professor' && (
-                        <Link
-                          to="/professors/password-setup"
-                          role="menuitem"
-                          className="app-profile-option"
-                          onClick={() => setOpenProfile(false)}
-                        >
-                          Password Setup
-                        </Link>
+                        <>
+                          <Link
+                            to="/professors/notifications"
+                            role="menuitem"
+                            className="app-profile-option"
+                            onClick={() => setOpenProfile(false)}
+                          >
+                            Advisor Requests
+                          </Link>
+                          <Link
+                            to="/professors/password-setup"
+                            role="menuitem"
+                            className="app-profile-option"
+                            onClick={() => setOpenProfile(false)}
+                          >
+                            Password Setup
+                          </Link>
+                        </>
                       )}
 
                       <button type="button" className="app-profile-option app-login-signout" onClick={handleSignOut}>


### PR DESCRIPTION
## Summary
- add advisor notification endpoint for incoming advisee requests
- add professor inbox UI for advisor requests
- wire the new page into routing, home, and navigation
- add backend coverage for advisor-only notification retrieval

## Verification
- `npm run build` in `frontend/`
- backend advisor endpoint smoke-tested with in-memory sqlite
