### PR TITLE
Move GitHub linking to student home and add coverage

### DIFF
--- a/backend/controllers/studentController.js
+++ b/backend/controllers/studentController.js
@@ -192,11 +192,34 @@ const loginStudent = [
         fullName: student.fullName,
         email: student.email,
         role: student.role,
+        githubLinked: student.githubLinked,
+        githubUsername: student.githubUsername,
       },
       message: 'Student login successful.',
     });
   },
 ];
+
+async function getCurrentStudent(req, res) {
+  if (!req.user || req.user.role !== 'STUDENT') {
+    return res.status(403).json({
+      code: 'STUDENT_AUTH_REQUIRED',
+      message: 'Active authenticated student account required.',
+    });
+  }
+
+  return res.status(200).json({
+    user: {
+      id: req.user.id,
+      studentId: req.user.studentId,
+      fullName: req.user.fullName,
+      email: req.user.email,
+      role: req.user.role,
+      githubLinked: req.user.githubLinked,
+      githubUsername: req.user.githubUsername,
+    },
+  });
+}
 
 async function getStudentValidation(req, res) {
   const { studentId } = req.params;
@@ -427,6 +450,7 @@ const storeLinkedGitHubAccount = [
 ];
 
 module.exports = {
+  getCurrentStudent,
   getStudentValidation,
   handleGitHubCallback,
   loginStudent,

--- a/backend/routes/students.js
+++ b/backend/routes/students.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { authenticate } = require('../middleware/auth');
 const {
+  getCurrentStudent,
   getStudentValidation,
   handleGitHubCallback,
   loginStudent,
@@ -17,6 +18,7 @@ const router = express.Router();
 router.post('/students/login', loginStudent);
 router.post('/students/registration-validation', registerStudentValidation);
 router.post('/students/register', registerStudent);
+router.get('/students/me', authenticate, getCurrentStudent);
 router.get('/user-database/students/:studentId/validation', getStudentValidation);
 router.patch('/user-database/students/:studentId/github-link', updateStudentGitHubLink);
 router.get('/students/me/github/link', authenticate, startGitHubLink);

--- a/backend/services/githubLinkService.js
+++ b/backend/services/githubLinkService.js
@@ -35,8 +35,24 @@ function buildAuthorizationUrl(state) {
   return `https://github.com/login/oauth/authorize?${params.toString()}`;
 }
 
+function normalizeFrontendReturnUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  if (url.pathname === '/' || url.pathname === '') {
+    url.pathname = '/home';
+  }
+  return url.toString();
+}
+
 function getFrontendUrl() {
-  return process.env.FRONTEND_GITHUB_RETURN_URL || process.env.FRONTEND_URL || 'http://localhost:5173';
+  if (process.env.FRONTEND_GITHUB_RETURN_URL) {
+    return normalizeFrontendReturnUrl(process.env.FRONTEND_GITHUB_RETURN_URL);
+  }
+
+  if (process.env.FRONTEND_URL) {
+    return normalizeFrontendReturnUrl(process.env.FRONTEND_URL);
+  }
+
+  return 'http://localhost:5173/home';
 }
 
 async function createOAuthState(userId) {

--- a/backend/test/QA.test.js
+++ b/backend/test/QA.test.js
@@ -5,6 +5,7 @@ const jwt = require('jsonwebtoken');
 process.env.JWT_SECRET = 'test-secret';
 process.env.SQLITE_STORAGE = ':memory:';
 process.env.FRONTEND_URL = 'http://localhost:5173';
+process.env.FRONTEND_GITHUB_RETURN_URL = 'http://localhost:5173/home';
 process.env.GITHUB_CLIENT_ID = '';
 process.env.GITHUB_CLIENT_SECRET = '';
 

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -16,9 +16,14 @@ const {
   AdvisorRequest,
   AuditLog,
   Notification,
+  ValidStudentId,
   LinkedGitHubAccount,
   OAuthState,
 } = require('../models');
+const StudentRegistrationError = require('../errors/studentRegistrationError');
+const studentRegistrationService = require('../services/studentRegistrationService');
+const { createStudent, ensureValidStudentRegistry } = require('../services/studentService');
+const professorService = require('../services/professorService');
 
 let server;
 let baseUrl;
@@ -54,6 +59,7 @@ async function createProfessorUser({ email, fullName, department = 'Software Eng
 
 test.before(async () => {
   await sequelize.sync({ force: true });
+  await ensureValidStudentRegistry();
   server = app.listen(0);
   await new Promise((resolve) => server.once('listening', resolve));
   const { port } = server.address();
@@ -79,6 +85,215 @@ test.beforeEach(async () => {
   await LinkedGitHubAccount.destroy({ where: {} });
   await OAuthState.destroy({ where: {} });
   await User.destroy({ where: {} });
+});
+
+test('admin can log in with email and password', async () => {
+  const password = 'AdminPass2026!';
+
+  await User.create({
+    email: 'admin@example.com',
+    fullName: 'Admin User',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    password: await bcrypt.hash(password, 10),
+  });
+
+  const successResult = await request('/api/v1/admin/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'admin@example.com',
+      password,
+    }),
+  });
+
+  assert.equal(successResult.response.status, 200);
+  assert.equal(typeof successResult.json.token, 'string');
+  assert.equal(successResult.json.user.role, 'ADMIN');
+
+  const invalidResult = await request('/api/v1/admin/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'admin@example.com',
+      password: 'WrongPass1!',
+    }),
+  });
+
+  assert.equal(invalidResult.response.status, 401);
+  assert.equal(invalidResult.json.code, 'INVALID_CREDENTIALS');
+});
+
+test('coordinator can log in with email and password', async () => {
+  const password = 'CoordinatorPass2026!';
+
+  await User.create({
+    email: 'coordinator-login@example.com',
+    fullName: 'Coordinator Login',
+    role: 'COORDINATOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash(password, 10),
+  });
+
+  const successResult = await request('/api/v1/coordinator/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'coordinator-login@example.com',
+      password,
+    }),
+  });
+
+  assert.equal(successResult.response.status, 200);
+  assert.equal(typeof successResult.json.token, 'string');
+  assert.equal(successResult.json.user.role, 'COORDINATOR');
+
+  const invalidResult = await request('/api/v1/coordinator/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'coordinator-login@example.com',
+      password: 'WrongPass1!',
+    }),
+  });
+
+  assert.equal(invalidResult.response.status, 401);
+  assert.equal(invalidResult.json.code, 'INVALID_CREDENTIALS');
+});
+
+test('student can log in with student ID and password only when the student ID is eligible', async () => {
+  const password = 'StrongPass1!';
+
+  await createStudent({
+    studentId: '11070001000',
+    email: 'student-login@example.edu',
+    fullName: 'Student Login',
+    password,
+  });
+
+  const successResult = await request('/api/v1/students/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      studentId: '11070001000',
+      password,
+    }),
+  });
+
+  assert.equal(successResult.response.status, 200);
+  assert.equal(typeof successResult.json.token, 'string');
+  assert.equal(successResult.json.user.role, 'STUDENT');
+  assert.equal(successResult.json.user.studentId, '11070001000');
+
+  const wrongPassword = await request('/api/v1/students/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      studentId: '11070001000',
+      password: 'WrongPass1!',
+    }),
+  });
+
+  assert.equal(wrongPassword.response.status, 401);
+  assert.equal(wrongPassword.json.code, 'INVALID_CREDENTIALS');
+
+  await User.create({
+    email: 'ineligible-login@example.edu',
+    fullName: 'Ineligible Student',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001999',
+    passwordHash: await bcrypt.hash(password, 10),
+  });
+
+  const ineligibleResult = await request('/api/v1/students/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      studentId: '11070001999',
+      password,
+    }),
+  });
+
+  assert.equal(ineligibleResult.response.status, 403);
+  assert.equal(ineligibleResult.json.code, 'STUDENT_NOT_ELIGIBLE');
+});
+
+test('students/me enforces auth and returns current student profile including github fields', async () => {
+  const password = 'StrongPass1!';
+  const student = await createStudent({
+    studentId: '11070001000',
+    email: 'student-me@example.edu',
+    fullName: 'Student Me',
+    password,
+  });
+
+  student.githubLinked = true;
+  student.githubUsername = 'student-me-gh';
+  await student.save();
+
+  const unauthenticated = await request('/api/v1/students/me');
+  assert.equal(unauthenticated.response.status, 401);
+
+  const authenticated = await request('/api/v1/students/me', {
+    headers: await authHeaderFor(student),
+  });
+
+  assert.equal(authenticated.response.status, 200);
+  assert.deepEqual(authenticated.json, {
+    user: {
+      id: student.id,
+      studentId: '11070001000',
+      fullName: 'Student Me',
+      email: 'student-me@example.edu',
+      role: 'STUDENT',
+      githubLinked: true,
+      githubUsername: 'student-me-gh',
+    },
+  });
+
+  const professor = await User.create({
+    email: 'students-me-prof@example.edu',
+    fullName: 'Professor Me',
+    role: 'PROFESSOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash(password, 10),
+  });
+
+  const forbidden = await request('/api/v1/students/me', {
+    headers: await authHeaderFor(professor),
+  });
+
+  assert.equal(forbidden.response.status, 403);
+  assert.deepEqual(forbidden.json, {
+    code: 'STUDENT_AUTH_REQUIRED',
+    message: 'Active authenticated student account required.',
+  });
+});
+
+test('professor can log in with email and chosen password after setup', async () => {
+  const password = 'StrongPass1!';
+
+  await User.create({
+    email: 'prof-login@example.edu',
+    fullName: 'Professor Login',
+    role: 'PROFESSOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash(password, 10),
+  });
+
+  const successResult = await request('/api/v1/professors/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'prof-login@example.edu',
+      password,
+    }),
+  });
+
+  assert.equal(successResult.response.status, 200);
+  assert.equal(typeof successResult.json.token, 'string');
+  assert.equal(successResult.json.user.role, 'PROFESSOR');
 });
 
 test('DELETE /api/v1/groups/:groupId/advisor-assignment: RBAC, removal, status, log, notification', async () => {

--- a/backend/test/setupTestEnv.js
+++ b/backend/test/setupTestEnv.js
@@ -16,6 +16,9 @@ if (process.env.SQLITE_STORAGE === undefined) {
 if (process.env.FRONTEND_URL === undefined) {
   process.env.FRONTEND_URL = 'http://localhost:5173';
 }
+if (process.env.FRONTEND_GITHUB_RETURN_URL === undefined) {
+  process.env.FRONTEND_GITHUB_RETURN_URL = 'http://localhost:5173/home';
+}
 if (process.env.GITHUB_CLIENT_ID === undefined) {
   process.env.GITHUB_CLIENT_ID = '';
 }

--- a/frontend/src/HomePage.jsx
+++ b/frontend/src/HomePage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useNotification } from './contexts/NotificationContext';
 
 const roleTitles = {
   STUDENT: 'Student',
@@ -47,18 +48,259 @@ function readStudentName() {
   }
 }
 
+function readStudentSession() {
+  const raw = window.localStorage.getItem('studentUser');
+  if (!raw) {
+    return {
+      fullName: 'Student',
+      studentId: '',
+      githubLinked: false,
+      githubUsername: '',
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      fullName: parsed.fullName || parsed.name || parsed.studentId || parsed.email || 'Student',
+      studentId: parsed.studentId || '',
+      githubLinked: Boolean(parsed.githubLinked),
+      githubUsername: parsed.githubUsername || '',
+    };
+  } catch {
+    return {
+      fullName: 'Student',
+      studentId: '',
+      githubLinked: false,
+      githubUsername: '',
+    };
+  }
+}
+
+function mapGitHubCallbackFeedback(params) {
+  const status = params.get('githubLink');
+  if (!status) {
+    return null;
+  }
+
+  const code = params.get('code') || '';
+  const githubUsername = params.get('githubUsername') || '';
+  const usedMockOAuth = params.get('mockOAuth') === '1';
+
+  if (status === 'success') {
+    return {
+      type: usedMockOAuth ? 'info' : 'success',
+      title: usedMockOAuth ? 'GitHub mock flow completed' : 'GitHub linked successfully',
+      message: usedMockOAuth
+        ? 'GitHub OAuth credentials are not configured in the backend, so the local mock callback flow was used.'
+        : `${githubUsername || 'Your GitHub account'} is now linked to this student account.`,
+      githubUsername,
+      githubLinked: true,
+    };
+  }
+
+  if (
+    code === 'GITHUB_ACCOUNT_ALREADY_LINKED_FOR_STUDENT' ||
+    code === 'GITHUB_RELINK_NOT_ALLOWED'
+  ) {
+    return {
+      type: 'warning',
+      title: 'GitHub already linked',
+      message: params.get('message') || 'A GitHub account is already linked for this student.',
+      githubUsername,
+      githubLinked: Boolean(githubUsername),
+    };
+  }
+
+  return {
+    type: 'error',
+    title: 'GitHub link failed',
+    message: params.get('message') || 'GitHub OAuth callback failed.',
+    githubUsername,
+    githubLinked: false,
+  };
+}
+
+function writeStudentSessionGitHubState({ githubLinked, githubUsername }) {
+  const raw = window.localStorage.getItem('studentUser');
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    const updated = {
+      ...parsed,
+      githubLinked,
+      githubUsername: githubUsername || parsed.githubUsername || '',
+    };
+    window.localStorage.setItem('studentUser', JSON.stringify(updated));
+    return updated;
+  } catch {
+    return null;
+  }
+}
+
+function writeStudentSessionUser(user) {
+  const updated = {
+    ...(user || {}),
+  };
+  window.localStorage.setItem('studentUser', JSON.stringify(updated));
+  return updated;
+}
+
+function readGitHubConnection() {
+  const session = readStudentSession();
+  return {
+    linked: Boolean(session.githubLinked),
+    username: session.githubUsername || '',
+  };
+}
+
 export default function HomePage() {
+  const location = useLocation();
   const navigate = useNavigate();
+  const { notify } = useNotification();
   const role = detectSessionRole();
   const title = role ? roleTitles[role] || 'User' : null;
-  const studentName = role === 'STUDENT' ? readStudentName() : null;
+  const [studentSession, setStudentSession] = useState(() => readStudentSession());
   const [studentGroups, setStudentGroups] = useState([]);
+  const [githubLinkPending, setGitHubLinkPending] = useState(false);
+  const [githubConnection, setGitHubConnection] = useState(() => readGitHubConnection());
+
+  const studentName = role === 'STUDENT' ? studentSession.fullName || readStudentName() : null;
 
   useEffect(() => {
     if (!title) {
       navigate('/auth', { replace: true });
     }
   }, [title, navigate]);
+
+  useEffect(() => {
+    if (role === 'STUDENT') {
+      setStudentSession(readStudentSession());
+      setGitHubConnection(readGitHubConnection());
+    }
+  }, [role]);
+
+  useEffect(() => {
+    if (role !== 'STUDENT') {
+      return;
+    }
+
+    const token = window.localStorage.getItem('studentToken') || window.localStorage.getItem('authToken');
+    if (!token) {
+      return;
+    }
+
+    fetch('/api/v1/students/me', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+      .then(async (response) => {
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok || !payload.user) {
+          return;
+        }
+
+        const updatedUser = writeStudentSessionUser(payload.user);
+        setStudentSession({
+          fullName: updatedUser.fullName || updatedUser.name || updatedUser.studentId || updatedUser.email || 'Student',
+          studentId: updatedUser.studentId || '',
+          githubLinked: Boolean(updatedUser.githubLinked),
+          githubUsername: updatedUser.githubUsername || '',
+        });
+        setGitHubConnection({
+          linked: Boolean(updatedUser.githubLinked),
+          username: updatedUser.githubUsername || '',
+        });
+      })
+      .catch(() => {});
+  }, [role]);
+
+  useEffect(() => {
+    if (role !== 'STUDENT') {
+      return;
+    }
+
+    const callbackSearch = location.search;
+    const callbackHandledKey = callbackSearch ? `github-callback-handled:${callbackSearch}` : '';
+    const params = new URLSearchParams(location.search);
+    const feedback = mapGitHubCallbackFeedback(params);
+    if (!feedback) {
+      return;
+    }
+
+    const alreadyHandled = callbackHandledKey
+      ? window.sessionStorage.getItem(callbackHandledKey) === '1'
+      : false;
+
+    if (alreadyHandled) {
+      params.delete('githubLink');
+      params.delete('githubUsername');
+      params.delete('studentId');
+      params.delete('code');
+      params.delete('message');
+      params.delete('mockOAuth');
+
+      const nextQuery = params.toString();
+      const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ''}`;
+      navigate(nextUrl, { replace: true });
+      return;
+    }
+
+    if (callbackHandledKey) {
+      window.sessionStorage.setItem(callbackHandledKey, '1');
+    }
+
+    notify({
+      type: feedback.type,
+      title: feedback.title,
+      message: feedback.message,
+    });
+
+    if (feedback.githubLinked) {
+      const updatedSession = writeStudentSessionGitHubState({
+        githubLinked: true,
+        githubUsername: feedback.githubUsername,
+      });
+
+      if (updatedSession) {
+        setStudentSession({
+          fullName: updatedSession.fullName || updatedSession.name || updatedSession.studentId || updatedSession.email || 'Student',
+          studentId: updatedSession.studentId || '',
+          githubLinked: true,
+          githubUsername: updatedSession.githubUsername || feedback.githubUsername || '',
+        });
+        setGitHubConnection({
+          linked: true,
+          username: updatedSession.githubUsername || feedback.githubUsername || '',
+        });
+      } else {
+        setStudentSession((current) => ({
+          ...current,
+          githubLinked: true,
+          githubUsername: feedback.githubUsername || current.githubUsername || '',
+        }));
+        setGitHubConnection((current) => ({
+          linked: true,
+          username: feedback.githubUsername || current.username || '',
+        }));
+      }
+    }
+
+    params.delete('githubLink');
+    params.delete('githubUsername');
+    params.delete('studentId');
+    params.delete('code');
+    params.delete('message');
+    params.delete('mockOAuth');
+
+    const nextQuery = params.toString();
+    const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ''}`;
+    navigate(nextUrl, { replace: true });
+  }, [location.search, navigate, notify, role]);
 
   useEffect(() => {
     if (role !== 'STUDENT') {
@@ -89,6 +331,52 @@ export default function HomePage() {
       });
   }, [role]);
 
+  async function handleGitHubLink() {
+    const token = window.localStorage.getItem('studentToken') || window.localStorage.getItem('authToken');
+    if (!token) {
+      const feedback = {
+        type: 'warning',
+        title: 'Student session required',
+        message: 'Sign in as a student before starting GitHub linking.',
+      };
+      notify(feedback);
+      return;
+    }
+
+    setGitHubLinkPending(true);
+
+    try {
+      const response = await fetch('/api/v1/students/me/github/link', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const feedback = {
+          type: 'error',
+          title: 'GitHub link could not start',
+          message: payload.message || 'Failed to create the GitHub authorization URL.',
+        };
+        notify(feedback);
+        return;
+      }
+
+      window.location.assign(payload.authorizationUrl);
+    } catch {
+      const feedback = {
+        type: 'error',
+        title: 'GitHub link could not start',
+        message: 'The backend could not be reached while starting GitHub OAuth.',
+      };
+      notify(feedback);
+    } finally {
+      setGitHubLinkPending(false);
+    }
+  }
+
   const leaderGroups = studentGroups.filter((group) => group.membershipRole === 'LEADER');
   const memberGroups = studentGroups.filter((group) => group.membershipRole === 'MEMBER');
 
@@ -104,6 +392,7 @@ export default function HomePage() {
         {role === 'STUDENT' ? (
           <section className="student-home-panel">
             <p><strong>Name:</strong> {studentName}</p>
+            <p><strong>Student ID:</strong> {studentSession.studentId || 'Unavailable'}</p>
             <p><strong>Leader Groups:</strong> {leaderGroups.length}</p>
             <p><strong>Member Groups:</strong> {memberGroups.length}</p>
             <p className="student-home-note">
@@ -111,6 +400,24 @@ export default function HomePage() {
                 ? 'No groups yet. Open Manage Group to create your first group.'
                 : 'Use Manage Group to edit your groups, invite students, or leave member groups.'}
             </p>
+            <section className="gateway-card" aria-label="GitHub connection">
+              <h2>GitHub Connection</h2>
+              <p className="gateway-copy">
+                {githubConnection.linked
+                  ? `Linked as ${githubConnection.username || 'GitHub user'}.`
+                  : 'Your GitHub account is not linked yet.'}
+              </p>
+              {!githubConnection.linked && (
+                <button
+                  type="button"
+                  className="workspace-button workspace-button-primary"
+                  onClick={handleGitHubLink}
+                  disabled={githubLinkPending}
+                >
+                  {githubLinkPending ? 'Redirecting...' : 'Connect GitHub'}
+                </button>
+              )}
+            </section>
             <div className="workspace-actions">
               <Link className="workspace-button workspace-button-primary" to="/students/groups/new">
                 Manage Group

--- a/frontend/src/QA.spec.js
+++ b/frontend/src/QA.spec.js
@@ -183,3 +183,60 @@ test('already-accepted invitation shows ACCEPTED and hides action buttons', asyn
   await expect(page.getByRole('button', { name: /accept/i })).not.toBeVisible();
   await expect(page.getByRole('button', { name: /decline|reject/i })).not.toBeVisible();
 });
+
+test('github callback toast is deduplicated and can be dismissed', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('authToken', 'qa-student-token');
+    window.localStorage.setItem('studentToken', 'qa-student-token');
+    window.localStorage.setItem('studentUser', JSON.stringify({
+      id: 501,
+      studentId: '11070001000',
+      fullName: 'QA Student',
+      email: 'qa-student@example.edu',
+      role: 'STUDENT',
+      githubLinked: false,
+      githubUsername: '',
+    }));
+    window.sessionStorage.clear();
+  });
+
+  await page.route('**/api/v1/students/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: {
+          id: 501,
+          studentId: '11070001000',
+          fullName: 'QA Student',
+          email: 'qa-student@example.edu',
+          role: 'STUDENT',
+          githubLinked: true,
+          githubUsername: 'qa-student-gh',
+        },
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/groups', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [] }),
+    });
+  });
+
+  await page.goto('/home?githubLink=success&githubUsername=qa-student-gh');
+
+  const notifications = page.locator('.notification-stack section.notification');
+  await expect(notifications).toHaveCount(1);
+  await expect(notifications.first()).toContainText('GitHub linked successfully');
+
+  await expect(page.getByText('Linked as qa-student-gh.')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Dismiss notification' }).click();
+  await expect(notifications).toHaveCount(0);
+
+  await page.waitForTimeout(300);
+  await expect(notifications).toHaveCount(0);
+});

--- a/frontend/src/Register.jsx
+++ b/frontend/src/Register.jsx
@@ -377,8 +377,8 @@ export default function Register() {
             <p className="feedback-label">GitHub Linking</p>
             <h2>Link GitHub</h2>
             <p className="token-copy">
-              This action is available only for authenticated active students. Until a full student auth feature exists,
-              provide a development token to test the linking flow.
+              Student-facing GitHub linking now belongs on Student Home after login. This panel remains only as a
+              development fallback for direct backend flow testing.
             </p>
 
             <label className="field">

--- a/frontend/src/contexts/NotificationContext.jsx
+++ b/frontend/src/contexts/NotificationContext.jsx
@@ -5,6 +5,7 @@ const NotificationContext = createContext(null);
 export function NotificationProvider({ children }) {
   const [notifications, setNotifications] = useState([]);
   const timeoutIds = useRef(new Map());
+  const recentNotificationKeys = useRef(new Map());
 
   useEffect(() => () => {
     timeoutIds.current.forEach((timeoutId) => window.clearTimeout(timeoutId));
@@ -22,12 +23,22 @@ export function NotificationProvider({ children }) {
   }
 
   function notify({ type = 'info', title, message }) {
+    const notificationKey = `${type}::${title || ''}::${message || ''}`;
+    const recentTimestamp = recentNotificationKeys.current.get(notificationKey);
+    if (recentTimestamp && Date.now() - recentTimestamp < 1500) {
+      return null;
+    }
+
+    recentNotificationKeys.current.set(notificationKey, Date.now());
     const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const notification = { id, type, title, message };
     setNotifications((current) => [notification, ...current].slice(0, 3));
 
     const timeoutId = window.setTimeout(() => dismiss(id), 4500);
     timeoutIds.current.set(id, timeoutId);
+    window.setTimeout(() => {
+      recentNotificationKeys.current.delete(notificationKey);
+    }, 1800);
 
     return id;
   }


### PR DESCRIPTION
## Summary

This PR moves the GitHub account linking flow to the authenticated student home experience and adds coverage for the updated behavior.

## What Changed

- Added a GitHub connection section to `HomePage` for logged-in students
- Moved GitHub callback handling to `HomePage`
- Updated the UI so students see either:
  - a `Connect GitHub` action when not linked
  - the linked GitHub username when already linked
- Added backend profile sync with `GET /api/v1/students/me` so the page reflects the latest linked state after callback
- Fixed the GitHub callback redirect so users return to `/home`
- Prevented duplicate callback notifications from appearing multiple times
- Left `Register.jsx` out of the main user flow so Student Home is now the primary GitHub linking path

## Backend Changes

- Added `GET /api/v1/students/me`
- Returned GitHub link fields needed by the frontend:
  - `githubLinked`
  - `githubUsername`
- Updated GitHub redirect URL handling so the frontend return path resolves to Student Home
- Updated test environment defaults to match the new redirect target

## Frontend Changes

- Added GitHub connection UI and callback processing in `HomePage`
- Synced student session state with backend data after callback
- Added duplicate notification protection in `NotificationContext`
- Kept the old register-based path from being the primary GitHub linking experience

## Tests Added

- Backend API coverage for `GET /api/v1/students/me`
  - `401` when unauthenticated
  - `403` for authenticated non-student users
  - `200` with expected student GitHub fields for authenticated students
- Playwright QA scenario covering:
  - GitHub callback success on `/home`
  - single toast rendering
  - toast dismissal
  - no immediate duplicate reappearance

## Verification

- Backend tests passed
- Frontend build passed
- Targeted Playwright test passed

## Notes

- Scope is limited to Student Home GitHub linking and related coverage
- No broader `AuthContext` refactor is included
- Unrelated local changes are not part of this PR
