### PR TITLE
Apply advisor transfer in group database

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -18,6 +18,7 @@ const notificationsRoutes = require('./routes/notifications');
 const passwordSetupTokenStoreRoutes = require('./routes/passwordSetupTokenStore');
 const userDatabaseRoutes = require('./routes/userDatabase');
 const groupRoutes = require('./routes/groups');
+const groupDatabaseRoutes = require('./routes/groupDatabase');
 
 const app = express();
 const frontendDistPath = path.join(__dirname, '..', 'frontend', 'dist');
@@ -44,6 +45,7 @@ app.use('/api/v1', invitationRoutes);
 app.use('/api/v1/notifications', notificationsRoutes);
 app.use('/api/v1/password-setup-token-store', passwordSetupTokenStoreRoutes);
 app.use('/api/v1/user-database', userDatabaseRoutes);
+app.use('/api/v1/group-database', groupDatabaseRoutes);
 app.use('/api/v1/groups', groupRoutes);
 
 // Global error handler

--- a/backend/controllers/mentorMatchingController.js
+++ b/backend/controllers/mentorMatchingController.js
@@ -1,0 +1,41 @@
+const { body, param, validationResult } = require('express-validator');
+const mentorMatchingService = require('../services/mentorMatchingService');
+
+const transferInGroupDatabase = [
+  param('groupId').isString().trim().notEmpty(),
+  body('newAdvisorId').isInt({ min: 1 }).toInt(),
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        code: 'INVALID_TRANSFER_INPUT',
+        message: 'groupId and newAdvisorId are required.',
+      });
+    }
+
+    try {
+      const assignment = await mentorMatchingService.transferAdvisorInGroupDatabase({
+        groupId: req.params.groupId,
+        newAdvisorId: req.body.newAdvisorId,
+      });
+
+      return res.status(200).json(assignment);
+    } catch (error) {
+      if (error.status && error.code) {
+        return res.status(error.status).json({
+          code: error.code,
+          message: error.message,
+        });
+      }
+
+      return res.status(500).json({
+        code: 'GROUP_TRANSFER_FAILED',
+        message: 'Advisor transfer could not be applied in Group DB.',
+      });
+    }
+  },
+];
+
+module.exports = {
+  transferInGroupDatabase,
+};

--- a/backend/routes/groupDatabase.js
+++ b/backend/routes/groupDatabase.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const { authenticate, authorize } = require('../middleware/auth');
+const { transferInGroupDatabase } = require('../controllers/mentorMatchingController');
+
+const router = express.Router();
+
+router.patch(
+  '/groups/:groupId/advisor-transfer',
+  authenticate,
+  authorize(['COORDINATOR']),
+  transferInGroupDatabase,
+);
+
+module.exports = router;

--- a/backend/services/mentorMatchingService.js
+++ b/backend/services/mentorMatchingService.js
@@ -1,0 +1,102 @@
+const { Group, Professor, User } = require('../models');
+
+function createServiceError(status, code, message) {
+  const error = new Error(message);
+  error.status = status;
+  error.code = code;
+  return error;
+}
+
+function normalizeAdvisorUserId(value) {
+  const parsed = Number.parseInt(String(value || '').trim(), 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createServiceError(400, 'INVALID_ADVISOR_ID', 'Advisor ID must be a positive integer.');
+  }
+  return parsed;
+}
+
+async function loadGroupForTransfer(groupId) {
+  const group = await Group.findByPk(String(groupId).trim());
+  if (!group) {
+    throw createServiceError(404, 'GROUP_NOT_FOUND', 'Group not found.');
+  }
+  return group;
+}
+
+async function findActiveProfessorUser(advisorUserId) {
+  const professor = await Professor.findOne({
+    where: { userId: advisorUserId },
+    include: [
+      {
+        model: User,
+        where: {
+          id: advisorUserId,
+          role: 'PROFESSOR',
+          status: 'ACTIVE',
+        },
+      },
+    ],
+  });
+
+  if (!professor || !professor.User) {
+    throw createServiceError(404, 'ADVISOR_NOT_FOUND', 'Target advisor was not found.');
+  }
+
+  return professor.User;
+}
+
+async function ensureGroupHasValidCurrentAdvisor(group) {
+  if (!group.advisorId) {
+    throw createServiceError(400, 'GROUP_HAS_NO_ADVISOR', 'Group does not currently have an advisor.');
+  }
+
+  let currentAdvisorUserId;
+  try {
+    currentAdvisorUserId = normalizeAdvisorUserId(group.advisorId);
+  } catch (_error) {
+    throw createServiceError(400, 'GROUP_HAS_INVALID_ADVISOR', 'Group has an invalid current advisor assignment.');
+  }
+
+  try {
+    await findActiveProfessorUser(currentAdvisorUserId);
+  } catch (error) {
+    if (error.code === 'ADVISOR_NOT_FOUND') {
+      throw createServiceError(400, 'GROUP_HAS_INVALID_ADVISOR', 'Group has an invalid current advisor assignment.');
+    }
+    throw error;
+  }
+
+  return currentAdvisorUserId;
+}
+
+function serializeAdvisorAssignment(group) {
+  return {
+    groupId: group.id,
+    advisorId: group.advisorId,
+    updatedAt: group.updatedAt,
+  };
+}
+
+async function transferAdvisorInGroupDatabase({ groupId, newAdvisorId }) {
+  const group = await loadGroupForTransfer(groupId);
+  const advisorUserId = normalizeAdvisorUserId(newAdvisorId);
+  await findActiveProfessorUser(advisorUserId);
+  const currentAdvisorUserId = await ensureGroupHasValidCurrentAdvisor(group);
+
+  if (String(currentAdvisorUserId) === String(advisorUserId)) {
+    throw createServiceError(400, 'SAME_ADVISOR_TRANSFER', 'Group is already assigned to this advisor.');
+  }
+
+  group.advisorId = String(advisorUserId);
+  await group.save();
+
+  return serializeAdvisorAssignment(group);
+}
+
+module.exports = {
+  createServiceError,
+  ensureGroupHasValidCurrentAdvisor,
+  findActiveProfessorUser,
+  serializeAdvisorAssignment,
+  transferAdvisorInGroupDatabase,
+};


### PR DESCRIPTION
## Summary

This PR implements the Group DB transfer slice for mentor matching.

## What Changed

- added `PATCH /api/v1/group-database/groups/:groupId/advisor-transfer`
- added backend controller and service logic for updating `Group.advisorId`
- validated:
  - existing group
  - valid active professor target
  - current advisor exists
  - transfer target differs from current advisor
- returned the updated advisor assignment payload

## Notes

- scope is intentionally limited to Group DB transfer persistence for Issue #143
- user-db sync, coordinator orchestration, frontend flow, and transfer coverage will follow in later issues
