### PR TITLE
Sync advisor assignments in user database

### DIFF
--- a/backend/controllers/mentorMatchingController.js
+++ b/backend/controllers/mentorMatchingController.js
@@ -36,6 +36,42 @@ const transferInGroupDatabase = [
   },
 ];
 
+const syncUserDatabaseAssignment = [
+  param('groupId').isString().trim().notEmpty(),
+  body('advisorId').isInt({ min: 1 }).toInt(),
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        code: 'INVALID_ADVISOR_ASSIGNMENT_INPUT',
+        message: 'groupId and advisorId are required.',
+      });
+    }
+
+    try {
+      const assignment = await mentorMatchingService.syncAdvisorAssignmentsForGroup({
+        groupId: req.params.groupId,
+        advisorId: req.body.advisorId,
+      });
+
+      return res.status(200).json(assignment);
+    } catch (error) {
+      if (error.status && error.code) {
+        return res.status(error.status).json({
+          code: error.code,
+          message: error.message,
+        });
+      }
+
+      return res.status(500).json({
+        code: 'USER_DB_ADVISOR_SYNC_FAILED',
+        message: 'Advisor assignment could not be synchronized.',
+      });
+    }
+  },
+];
+
 module.exports = {
+  syncUserDatabaseAssignment,
   transferInGroupDatabase,
 };

--- a/backend/models/GroupAdvisorAssignment.js
+++ b/backend/models/GroupAdvisorAssignment.js
@@ -1,0 +1,60 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+const Group = require('./Group');
+const User = require('./User');
+
+const GroupAdvisorAssignment = sequelize.define(
+  'GroupAdvisorAssignment',
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    groupId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      references: {
+        model: Group,
+        key: 'id',
+      },
+    },
+    studentUserId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: User,
+        key: 'id',
+      },
+    },
+    advisorUserId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: User,
+        key: 'id',
+      },
+    },
+  },
+  {
+    tableName: 'GroupAdvisorAssignments',
+    timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['groupId', 'studentUserId'],
+      },
+    ],
+  },
+);
+
+Group.hasMany(GroupAdvisorAssignment, { foreignKey: 'groupId' });
+GroupAdvisorAssignment.belongsTo(Group, { foreignKey: 'groupId' });
+
+User.hasMany(GroupAdvisorAssignment, { foreignKey: 'studentUserId', as: 'advisorAssignments' });
+GroupAdvisorAssignment.belongsTo(User, { foreignKey: 'studentUserId', as: 'studentUser' });
+
+User.hasMany(GroupAdvisorAssignment, { foreignKey: 'advisorUserId', as: 'assignedGroups' });
+GroupAdvisorAssignment.belongsTo(User, { foreignKey: 'advisorUserId', as: 'advisorUser' });
+
+module.exports = GroupAdvisorAssignment;

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -13,6 +13,7 @@ const OAuthState = require('./OAuthState');
 const LinkedGitHubAccount = require('./LinkedGitHubAccount');
 const Group = require('./Group');
 const AdvisorRequest = require('./AdvisorRequest');
+const GroupAdvisorAssignment = require('./GroupAdvisorAssignment');
 const Invitation = require('./Invitation');
 const AuditLog = require('./AuditLog');
 const Notification = require('./Notification');
@@ -24,6 +25,7 @@ module.exports = {
   OAuthState,
   LinkedGitHubAccount,
   Group,
+  GroupAdvisorAssignment,
   AdvisorRequest,
   Invitation,
   AuditLog,

--- a/backend/routes/userDatabase.js
+++ b/backend/routes/userDatabase.js
@@ -6,6 +6,7 @@ const {
   importValidStudentIds,
   updateProfessorPassword,
 } = require('../controllers/userDatabaseController');
+const { syncUserDatabaseAssignment } = require('../controllers/mentorMatchingController');
 
 const router = express.Router();
 
@@ -17,6 +18,12 @@ router.patch(
   authenticate,
   authorize(['ADMIN']),
   updateProfessorPassword
+);
+router.patch(
+  '/groups/:groupId/advisor-assignment',
+  authenticate,
+  authorize(['COORDINATOR']),
+  syncUserDatabaseAssignment,
 );
 
 module.exports = router;

--- a/backend/services/mentorMatchingService.js
+++ b/backend/services/mentorMatchingService.js
@@ -68,7 +68,6 @@ async function ensureGroupHasValidCurrentAdvisor(group) {
 
   return currentAdvisorUserId;
 }
-
 function serializeAdvisorAssignment(group) {
   return {
     groupId: group.id,

--- a/backend/services/mentorMatchingService.js
+++ b/backend/services/mentorMatchingService.js
@@ -1,4 +1,5 @@
-const { Group, Professor, User } = require('../models');
+const sequelize = require('../db');
+const { Group, GroupAdvisorAssignment, Professor, User } = require('../models');
 
 function createServiceError(status, code, message) {
   const error = new Error(message);
@@ -92,10 +93,57 @@ async function transferAdvisorInGroupDatabase({ groupId, newAdvisorId }) {
   return serializeAdvisorAssignment(group);
 }
 
+async function syncAdvisorAssignmentsForGroup({ groupId, advisorId }) {
+  const group = await loadGroupForTransfer(groupId);
+  const advisorUserId = normalizeAdvisorUserId(advisorId);
+  await findActiveProfessorUser(advisorUserId);
+
+  const memberIds = Array.isArray(group.memberIds) ? group.memberIds.map((id) => String(id)) : [];
+  const userIds = [...new Set([String(group.leaderId || ''), ...memberIds].filter(Boolean))];
+
+  if (userIds.length === 0) {
+    throw createServiceError(400, 'GROUP_HAS_NO_MEMBERS', 'Group has no members to synchronize.');
+  }
+
+  const students = await User.findAll({
+    where: {
+      id: userIds.map((id) => Number(id)),
+      role: 'STUDENT',
+    },
+  });
+
+  if (students.length !== userIds.length) {
+    throw createServiceError(400, 'GROUP_MEMBER_RESOLUTION_FAILED', 'One or more group members could not be resolved.');
+  }
+
+  const rows = students.map((student) => ({
+    groupId: group.id,
+    studentUserId: student.id,
+    advisorUserId,
+  }));
+
+  await sequelize.transaction(async (transaction) => {
+    await GroupAdvisorAssignment.destroy({
+      where: { groupId: group.id },
+      transaction,
+    });
+
+    await GroupAdvisorAssignment.bulkCreate(rows, { transaction });
+  });
+
+  return {
+    groupId: group.id,
+    advisorId: String(advisorUserId),
+    updatedCount: rows.length,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
 module.exports = {
   createServiceError,
   ensureGroupHasValidCurrentAdvisor,
   findActiveProfessorUser,
   serializeAdvisorAssignment,
+  syncAdvisorAssignmentsForGroup,
   transferAdvisorInGroupDatabase,
 };


### PR DESCRIPTION
## Summary

This PR implements the user-database sync slice for mentor matching after advisor transfer.

## What Changed

- Added a new `GroupAdvisorAssignment` model to store mirrored advisor assignments per group member
- Added `PATCH /api/v1/user-database/groups/:groupId/advisor-assignment`
- Extended the mentor matching service to:
  - load the target group
  - validate the advisor as an active professor
  - resolve the full group membership from leader + members
  - replace previous mirrored assignment rows for the group
  - return the updated sync result
- Added controller validation and stable error handling for invalid input, missing group, invalid advisor, and member resolution failures

## Notes

- Scope is intentionally limited to the backend user-db sync layer for Issue #144
- This PR does not include coordinator orchestration, notifications, frontend work, or transfer coverage
- Sync is performed atomically so old rows are not left deleted if the write fails midway

## Verification

- Backend regression suite passed (`25/25`)
