### PR TITLE
Add coordinator advisor transfer flow

### DIFF
--- a/backend/controllers/groupController.js
+++ b/backend/controllers/groupController.js
@@ -1,7 +1,7 @@
 const { body, param, validationResult } = require('express-validator');
 const { Op } = require('sequelize');
 const GroupService = require('../services/groupService');
-const { Group, User, Invitation } = require('../models');
+const { Group, User, Invitation, Professor } = require('../models');
 
 /**
  * Validation middleware for creating a group
@@ -262,6 +262,10 @@ exports.listGroups = async (req, res) => {
         userIds.add(Number(group.leaderId));
       }
 
+      if (group.advisorId) {
+        userIds.add(Number(group.advisorId));
+      }
+
       if (Array.isArray(group.memberIds)) {
         group.memberIds.forEach((id) => userIds.add(Number(id)));
       }
@@ -277,9 +281,20 @@ exports.listGroups = async (req, res) => {
       : [];
 
     const usersById = new Map(users.map((user) => [String(user.id), user]));
+    const professorRows = userIds.size > 0
+      ? await Professor.findAll({
+        where: {
+          userId: { [Op.in]: [...userIds] },
+        },
+        attributes: ['userId', 'department', 'fullName'],
+      })
+      : [];
+    const professorsByUserId = new Map(professorRows.map((professor) => [String(professor.userId), professor]));
 
     const data = visibleGroups.map((group) => {
       const leader = usersById.get(String(group.leaderId || ''));
+      const advisorUser = usersById.get(String(group.advisorId || ''));
+      const advisorProfessor = professorsByUserId.get(String(group.advisorId || ''));
       const memberIds = Array.isArray(group.memberIds) ? group.memberIds : [];
       const currentUserId = String(req.user?.id || '');
       const isLeader = String(group.leaderId || '') === currentUserId;
@@ -296,6 +311,14 @@ exports.listGroups = async (req, res) => {
             fullName: leader.fullName,
             studentId: leader.studentId,
             email: leader.email,
+          }
+          : null,
+        advisor: advisorUser
+          ? {
+            id: advisorUser.id,
+            fullName: advisorProfessor?.fullName || advisorUser.fullName,
+            email: advisorUser.email,
+            department: advisorProfessor?.department || null,
           }
           : null,
         members: memberIds.map((id) => {

--- a/backend/controllers/mentorMatchingController.js
+++ b/backend/controllers/mentorMatchingController.js
@@ -71,7 +71,57 @@ const syncUserDatabaseAssignment = [
   },
 ];
 
+const transferByCoordinator = [
+  param('groupId').isString().trim().notEmpty(),
+  body('newAdvisorId').isInt({ min: 1 }).toInt(),
+  body('reason').optional().isString().trim(),
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        code: 'INVALID_COORDINATOR_TRANSFER_INPUT',
+        message: 'groupId and newAdvisorId are required.',
+      });
+    }
+
+    try {
+      const assignment = await mentorMatchingService.transferAdvisorByCoordinator({
+        groupId: req.params.groupId,
+        newAdvisorId: req.body.newAdvisorId,
+      });
+
+      return res.status(200).json(assignment);
+    } catch (error) {
+      if (error.status && error.code) {
+        return res.status(error.status).json({
+          code: error.code,
+          message: error.message,
+        });
+      }
+
+      return res.status(500).json({
+        code: 'COORDINATOR_TRANSFER_FAILED',
+        message: 'Advisor transfer could not be completed.',
+      });
+    }
+  },
+];
+
+const listCoordinatorAdvisors = async (_req, res) => {
+  try {
+    const advisors = await mentorMatchingService.listActiveAdvisors();
+    return res.status(200).json({ data: advisors });
+  } catch (_error) {
+    return res.status(500).json({
+      code: 'ADVISOR_LIST_FAILED',
+      message: 'Advisor list could not be loaded.',
+    });
+  }
+};
+
 module.exports = {
+  listCoordinatorAdvisors,
   syncUserDatabaseAssignment,
+  transferByCoordinator,
   transferInGroupDatabase,
 };

--- a/backend/routes/coordinator.js
+++ b/backend/routes/coordinator.js
@@ -3,6 +3,10 @@ const { authenticate, authorize } = require('../middleware/auth');
 const { coordinatorLogin } = require('../controllers/adminController');
 const { importValidStudentIds } = require('../controllers/userDatabaseController');
 const { updateGroupMembership } = require('../controllers/coordinatorController');
+const {
+  listCoordinatorAdvisors,
+  transferByCoordinator,
+} = require('../controllers/mentorMatchingController');
 const groupController = require('../controllers/groupController');
 
 const router = express.Router();
@@ -14,7 +18,9 @@ router.post(
   authorize(['COORDINATOR']),
   importValidStudentIds,
 );
+router.get('/advisors', authenticate, authorize(['COORDINATOR']), listCoordinatorAdvisors);
 router.get('/groups', authenticate, authorize(['COORDINATOR']), groupController.listGroups);
+router.patch('/groups/:groupId/advisor-transfer', authenticate, authorize(['COORDINATOR']), transferByCoordinator);
 router.patch('/groups/:groupId/members', authenticate, authorize(['COORDINATOR']), updateGroupMembership);
 router.patch('/groups/:groupId/membership/coordinator', authenticate, authorize(['COORDINATOR']), updateGroupMembership);
 

--- a/backend/services/mentorMatchingService.js
+++ b/backend/services/mentorMatchingService.js
@@ -16,8 +16,10 @@ function normalizeAdvisorUserId(value) {
   return parsed;
 }
 
-async function loadGroupForTransfer(groupId) {
-  const group = await Group.findByPk(String(groupId).trim());
+async function loadGroupForTransfer(groupId, options = {}) {
+  const group = await Group.findByPk(String(groupId).trim(), {
+    transaction: options.transaction,
+  });
   if (!group) {
     throw createServiceError(404, 'GROUP_NOT_FOUND', 'Group not found.');
   }
@@ -77,8 +79,8 @@ function serializeAdvisorAssignment(group) {
   };
 }
 
-async function transferAdvisorInGroupDatabase({ groupId, newAdvisorId }) {
-  const group = await loadGroupForTransfer(groupId);
+async function transferAdvisorInGroupDatabase({ groupId, newAdvisorId, transaction }) {
+  const group = await loadGroupForTransfer(groupId, { transaction });
   const advisorUserId = normalizeAdvisorUserId(newAdvisorId);
   await findActiveProfessorUser(advisorUserId);
   const currentAdvisorUserId = await ensureGroupHasValidCurrentAdvisor(group);
@@ -88,13 +90,13 @@ async function transferAdvisorInGroupDatabase({ groupId, newAdvisorId }) {
   }
 
   group.advisorId = String(advisorUserId);
-  await group.save();
+  await group.save({ transaction });
 
   return serializeAdvisorAssignment(group);
 }
 
-async function syncAdvisorAssignmentsForGroup({ groupId, advisorId }) {
-  const group = await loadGroupForTransfer(groupId);
+async function syncAdvisorAssignmentsForGroup({ groupId, advisorId, transaction }) {
+  const group = await loadGroupForTransfer(groupId, { transaction });
   const advisorUserId = normalizeAdvisorUserId(advisorId);
   await findActiveProfessorUser(advisorUserId);
 
@@ -122,14 +124,22 @@ async function syncAdvisorAssignmentsForGroup({ groupId, advisorId }) {
     advisorUserId,
   }));
 
-  await sequelize.transaction(async (transaction) => {
+  const applySync = async (activeTransaction) => {
     await GroupAdvisorAssignment.destroy({
       where: { groupId: group.id },
-      transaction,
+      transaction: activeTransaction,
     });
 
-    await GroupAdvisorAssignment.bulkCreate(rows, { transaction });
-  });
+    await GroupAdvisorAssignment.bulkCreate(rows, { transaction: activeTransaction });
+  };
+
+  if (transaction) {
+    await applySync(transaction);
+  } else {
+    await sequelize.transaction(async (managedTransaction) => {
+      await applySync(managedTransaction);
+    });
+  }
 
   return {
     groupId: group.id,
@@ -139,11 +149,60 @@ async function syncAdvisorAssignmentsForGroup({ groupId, advisorId }) {
   };
 }
 
+async function transferAdvisorByCoordinator({ groupId, newAdvisorId }) {
+  return sequelize.transaction(async (transaction) => {
+    const assignment = await transferAdvisorInGroupDatabase({
+      groupId,
+      newAdvisorId,
+      transaction,
+    });
+    const syncResult = await syncAdvisorAssignmentsForGroup({
+      groupId,
+      advisorId: newAdvisorId,
+      transaction,
+    });
+
+    return {
+      groupId: assignment.groupId,
+      advisorId: assignment.advisorId,
+      updatedAt: assignment.updatedAt,
+      updatedCount: syncResult.updatedCount,
+    };
+  });
+}
+
+async function listActiveAdvisors() {
+  const professors = await Professor.findAll({
+    include: [
+      {
+        model: User,
+        where: {
+          role: 'PROFESSOR',
+          status: 'ACTIVE',
+        },
+        attributes: ['id', 'fullName', 'email'],
+      },
+    ],
+    order: [['fullName', 'ASC']],
+  });
+
+  return professors
+    .filter((professor) => professor.User)
+    .map((professor) => ({
+      id: professor.User.id,
+      fullName: professor.fullName || professor.User.fullName,
+      email: professor.User.email,
+      department: professor.department || null,
+    }));
+}
+
 module.exports = {
   createServiceError,
   ensureGroupHasValidCurrentAdvisor,
   findActiveProfessorUser,
+  listActiveAdvisors,
   serializeAdvisorAssignment,
   syncAdvisorAssignmentsForGroup,
+  transferAdvisorByCoordinator,
   transferAdvisorInGroupDatabase,
 };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import AdminLoginPage from './AdminLoginPage';
 import AdminProfessorCreatePage from './AdminProfessorCreatePage';
 import AuthPage from './AuthPage';
 import CoordinatorGroupMembershipPage from './CoordinatorGroupMembershipPage';
+import CoordinatorAdvisorTransferPage from './CoordinatorAdvisorTransferPage';
 import CoordinatorHomePage from './CoordinatorHomePage';
 import CoordinatorLoginPage from './CoordinatorLoginPage';
 import CoordinatorStudentIdUploadPage from './CoordinatorStudentIdUploadPage';
@@ -47,6 +48,7 @@ export default function App() {
               <Route path="/coordinator" element={<CoordinatorHomePage />} />
               <Route path="/coordinator/student-id-registry/import" element={<CoordinatorStudentIdUploadPage />} />
               <Route path="/coordinator/groups/manage" element={<CoordinatorGroupMembershipPage />} />
+              <Route path="/coordinator/groups/transfer" element={<CoordinatorAdvisorTransferPage />} />
               <Route path="/groups/:groupId" element={<GroupPage />} />
               <Route path="*" element={<HomePage />} />
             </Route>

--- a/frontend/src/CoordinatorAdvisorTransferPage.jsx
+++ b/frontend/src/CoordinatorAdvisorTransferPage.jsx
@@ -1,0 +1,305 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useNotification } from './contexts/NotificationContext';
+
+const initialFeedback = {
+  type: 'idle',
+  title: 'Ready',
+  message: 'Select a group and choose the advisor you want to assign.',
+};
+
+function normalizeGroups(payload) {
+  return Array.isArray(payload?.data) ? payload.data : [];
+}
+
+function normalizeAdvisors(payload) {
+  return Array.isArray(payload?.data) ? payload.data : [];
+}
+
+export default function CoordinatorAdvisorTransferPage() {
+  const [groups, setGroups] = useState([]);
+  const [advisors, setAdvisors] = useState([]);
+  const [selectedGroupId, setSelectedGroupId] = useState('');
+  const [selectedAdvisorId, setSelectedAdvisorId] = useState('');
+  const [reason, setReason] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState(initialFeedback);
+
+  const navigate = useNavigate();
+  const { notify } = useNotification();
+  const token = window.localStorage.getItem('coordinatorToken') || '';
+
+  useEffect(() => {
+    if (token) {
+      return;
+    }
+
+    notify({
+      type: 'warning',
+      title: 'Coordinator login required',
+      message: 'Please sign in before opening advisor transfer.',
+    });
+    navigate('/coordinator/login', { replace: true });
+  }, [navigate, notify, token]);
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    async function loadTransferData() {
+      setLoading(true);
+      try {
+        const [groupsResponse, advisorsResponse] = await Promise.all([
+          fetch('/api/v1/coordinator/groups', {
+            headers: { Authorization: `Bearer ${token}` },
+          }),
+          fetch('/api/v1/coordinator/advisors', {
+            headers: { Authorization: `Bearer ${token}` },
+          }),
+        ]);
+
+        const groupsPayload = await groupsResponse.json().catch(() => ({}));
+        const advisorsPayload = await advisorsResponse.json().catch(() => ({}));
+
+        if (!groupsResponse.ok) {
+          throw new Error(groupsPayload.message || 'Could not load coordinator groups.');
+        }
+
+        if (!advisorsResponse.ok) {
+          throw new Error(advisorsPayload.message || 'Could not load advisor list.');
+        }
+
+        const nextGroups = normalizeGroups(groupsPayload);
+        const nextAdvisors = normalizeAdvisors(advisorsPayload);
+
+        setGroups(nextGroups);
+        setAdvisors(nextAdvisors);
+        setSelectedGroupId((current) => {
+          if (current && nextGroups.some((group) => String(group.groupId) === String(current))) {
+            return current;
+          }
+          return nextGroups[0]?.groupId || '';
+        });
+      } catch (error) {
+        setGroups([]);
+        setAdvisors([]);
+        setSelectedGroupId('');
+        setFeedback({
+          type: 'error',
+          title: 'Load failed',
+          message: error.message || 'Could not load transfer data.',
+        });
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadTransferData();
+  }, [token]);
+
+  const selectedGroup = useMemo(
+    () => groups.find((group) => String(group.groupId) === String(selectedGroupId)) || null,
+    [groups, selectedGroupId],
+  );
+
+  useEffect(() => {
+    if (!selectedGroup) {
+      setSelectedAdvisorId('');
+      return;
+    }
+
+    setSelectedAdvisorId((current) => {
+      if (current && advisors.some((advisor) => String(advisor.id) === String(current))) {
+        return current;
+      }
+      return '';
+    });
+  }, [advisors, selectedGroup]);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    if (!selectedGroupId || !selectedAdvisorId) {
+      setFeedback({
+        type: 'warning',
+        title: 'Selection required',
+        message: 'Please select both a group and a target advisor.',
+      });
+      return;
+    }
+
+    if (String(selectedGroup?.advisor?.id || '') === String(selectedAdvisorId)) {
+      const message = 'The selected group is already assigned to this advisor.';
+      setFeedback({
+        type: 'warning',
+        title: 'Same advisor selected',
+        message,
+      });
+      notify({
+        type: 'warning',
+        title: 'Transfer rejected',
+        message,
+      });
+      return;
+    }
+
+    setSubmitting(true);
+    setFeedback({
+      type: 'loading',
+      title: 'Applying transfer',
+      message: 'Updating advisor assignment for the selected group.',
+    });
+
+    try {
+      const response = await fetch(`/api/v1/coordinator/groups/${selectedGroupId}/advisor-transfer`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          newAdvisorId: Number(selectedAdvisorId),
+          reason: reason.trim() || undefined,
+        }),
+      });
+
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(payload.message || 'Advisor transfer failed.');
+      }
+
+      const advisor = advisors.find((entry) => String(entry.id) === String(selectedAdvisorId)) || null;
+      setGroups((current) => current.map((group) => (
+        String(group.groupId) === String(selectedGroupId)
+          ? {
+            ...group,
+            advisor: advisor
+              ? {
+                id: advisor.id,
+                fullName: advisor.fullName,
+                email: advisor.email,
+                department: advisor.department || null,
+              }
+              : group.advisor,
+          }
+          : group
+      )));
+
+      setFeedback({
+        type: 'success',
+        title: 'Advisor transferred',
+        message: 'The selected group now shows the updated advisor assignment.',
+      });
+      notify({
+        type: 'success',
+        title: 'Transfer completed',
+        message: 'Advisor assignment updated successfully.',
+      });
+      setReason('');
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        title: 'Transfer failed',
+        message: error.message || 'Advisor transfer failed.',
+      });
+      notify({
+        type: 'error',
+        title: 'Transfer failed',
+        message: error.message || 'Advisor transfer failed.',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="page">
+      <section className="hero">
+        <p className="eyebrow">Coordinator Workspace</p>
+        <h1>Transfer Group Advisor</h1>
+        <p className="subtitle">
+          Move a group from its current advisor to another active advisor without leaving the coordinator workspace.
+        </p>
+      </section>
+
+      <p className="back-link-wrap">
+        <Link className="back-link" to="/coordinator">
+          Back to Coordinator Workspace
+        </Link>
+      </p>
+
+      <section className="panel">
+        <form className="form" onSubmit={handleSubmit}>
+          <label className="field">
+            <span>Group</span>
+            <select
+              value={selectedGroupId}
+              onChange={(event) => setSelectedGroupId(event.target.value)}
+              disabled={loading || groups.length === 0}
+              required
+            >
+              {groups.length === 0 && <option value="">No groups found</option>}
+              {groups.map((group) => (
+                <option key={group.groupId} value={group.groupId}>
+                  {group.groupName}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="field">
+            <span>Target Advisor</span>
+            <select
+              value={selectedAdvisorId}
+              onChange={(event) => setSelectedAdvisorId(event.target.value)}
+              disabled={loading || advisors.length === 0}
+              required
+            >
+              <option value="">{advisors.length === 0 ? 'No advisors found' : 'Select an advisor'}</option>
+              {advisors.map((advisor) => (
+                <option key={advisor.id} value={advisor.id}>
+                  {advisor.fullName || advisor.email}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="field">
+            <span>Reason (optional)</span>
+            <textarea
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              rows={4}
+              placeholder="Optional transfer reason"
+            />
+          </label>
+
+          <button type="submit" disabled={submitting || loading || groups.length === 0 || advisors.length === 0}>
+            {submitting ? 'Applying...' : 'Apply Advisor Transfer'}
+          </button>
+        </form>
+
+        <div className="side-column">
+          <section className="token-panel">
+            <p className="feedback-label">Selected Group</p>
+            <h2>{selectedGroup?.groupName || 'No Group Selected'}</h2>
+            <p className="token-copy">
+              Current Advisor: {selectedGroup?.advisor?.fullName || selectedGroup?.advisor?.email || 'Unassigned'}
+            </p>
+            <p className="token-copy">
+              Members: {(selectedGroup?.members || []).length}
+            </p>
+          </section>
+
+          <section className={`feedback feedback-${feedback.type}`} aria-live="polite">
+            <p className="feedback-label">Current Status</p>
+            <h2>{feedback.title}</h2>
+            <p>{feedback.message}</p>
+          </section>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/CoordinatorHomePage.jsx
+++ b/frontend/src/CoordinatorHomePage.jsx
@@ -33,6 +33,14 @@ const coordinatorTools = [
     cta: 'Open Membership Manager',
     status: 'Ready',
   },
+  {
+    eyebrow: 'Groups',
+    title: 'Advisor Transfer',
+    description: 'Transfer a group from its current advisor to another active advisor.',
+    href: '/coordinator/groups/transfer',
+    cta: 'Open Transfer Tool',
+    status: 'Ready',
+  },
 ];
 
 export default function CoordinatorHomePage() {

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -33,6 +33,7 @@ const roleMenuSections = {
       items: [
         { to: '/coordinator/student-id-registry/import', label: 'Student ID Import', icon: 'OP' },
         { to: '/coordinator/groups/manage', label: 'Group Membership Edit', icon: 'GM' },
+        { to: '/coordinator/groups/transfer', label: 'Advisor Transfer', icon: 'AT' },
       ],
     },
   ],


### PR DESCRIPTION
## Summary

This PR implements the coordinator transfer flow for mentor matching.

## What Changed

- Added `PATCH /api/v1/coordinator/groups/:groupId/advisor-transfer`
- Added `GET /api/v1/coordinator/advisors` for advisor selection
- Reused the existing Group DB transfer and user-db sync services from the previous stacked issues
- Extended coordinator group data with current advisor information
- Added a dedicated `/coordinator/groups/transfer` page
- Added minimal navigation entry points from the coordinator workspace

## Notes

- Scope is intentionally limited to the coordinator transfer API and UI for Issue #142
- Notifications are intentionally not included in this PR
- Existing membership manager behavior was kept separate

## Verification

- Backend regression suite passed (`25/25`)
- Frontend build passed
