### PR TITLE
refresh advisor inbox automatically

### DIFF
--- a/frontend/src/ProfessorAdvisorRequestsPage.jsx
+++ b/frontend/src/ProfessorAdvisorRequestsPage.jsx
@@ -56,10 +56,13 @@ export default function ProfessorAdvisorRequestsPage() {
   const [feedback, setFeedback] = useState({ type: '', message: '' });
 
   useEffect(() => {
-    const controller = new AbortController();
+    let active = true;
+    let timeoutId;
     const token = window.localStorage.getItem('professorToken') || window.localStorage.getItem('authToken');
 
     async function loadRequests() {
+      const controller = new AbortController();
+
       try {
         const response = await fetch('/api/v1/advisors/notifications/advisee-requests', {
           headers: token
@@ -73,30 +76,48 @@ export default function ProfessorAdvisorRequestsPage() {
         const payload = await response.json().catch(() => []);
 
         if (!response.ok) {
+          if (!active) {
+            return;
+          }
+
           setLoadError('Advisor requests could not be loaded.');
           setRequests([]);
           return;
         }
 
+        if (!active) {
+          return;
+        }
+
         const rows = Array.isArray(payload) ? payload : payload.notifications || [];
         setRequests(rows);
-        setSelectedRequestId((current) => current || rows[0]?.id || null);
+        setSelectedRequestId((current) => (
+          rows.some((entry) => entry.id === current) ? current : rows[0]?.id || null
+        ));
         setLoadError('');
       } catch (error) {
-        if (error.name === 'AbortError') {
+        if (error.name === 'AbortError' || !active) {
           return;
         }
 
         setLoadError('Advisor requests could not be loaded.');
         setRequests([]);
       } finally {
+        if (!active) {
+          return;
+        }
+
         setLoading(false);
+        timeoutId = window.setTimeout(loadRequests, 15000);
       }
     }
 
     loadRequests();
 
-    return () => controller.abort();
+    return () => {
+      active = false;
+      window.clearTimeout(timeoutId);
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What changed
This updates the advisor requests page so the advisor inbox really refreshes automatically while the page stays open.

## Why
After the merge, the page text said advisor requests refresh automatically, but the request list was only loaded only once on page open. Group transfer notifications were already polling, so the inbox behavior was inconsistent.

## Impact
Advisors can now see newly arriving advisor request notifications without refreshing the page manually, and the currently selected request stays selected when possible after polling.

## Root cause
The advisor request fetch effect used a one-time load flow instead of the recurring polling pattern already used for transfer notifications.

## Validation
- `npm --prefix backend test`
- `npm --prefix frontend run build`
