### PR TITLE
add advisor decision notifications for team leaders

### DIFF
--- a/backend/routes/advisorRequests.js
+++ b/backend/routes/advisorRequests.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const { body, validationResult } = require('express-validator');
 const { authenticate, authorize } = require('../middleware/auth');
+const NotificationService = require('../services/notificationService');
 const {
   getPendingAdvisorRequest,
   updatePendingAdvisorRequestStatus,
 } = require('../controllers/advisorRequestController');
-const { AdvisorRequest, AuditLog, Group } = require('../models');
+const { AdvisorRequest, AuditLog, Group, User } = require('../models');
 
 const router = express.Router();
 
@@ -75,9 +76,9 @@ router.patch(
       const normalizedDecision = String(req.body.decision).toUpperCase();
       const nextStatus = normalizedDecision === 'APPROVE' ? 'APPROVED' : 'REJECTED';
       const note = typeof req.body.note === 'string' ? req.body.note.trim() : null;
+      const group = await Group.findByPk(request.groupId);
 
       if (normalizedDecision === 'APPROVE') {
-        const group = await Group.findByPk(request.groupId);
         if (!group) {
           return res.status(404).json(
             buildErrorResponse('Group not found for this advisor request.', 'GROUP_NOT_FOUND'),
@@ -94,6 +95,26 @@ router.patch(
         note: note || null,
         decidedAt: new Date(),
       });
+
+      const advisorUser = await User.findByPk(req.user.id, {
+        attributes: ['id', 'fullName', 'email'],
+      });
+
+      if (request.teamLeaderId) {
+        await NotificationService.notifyTeamLeaderAdvisorDecision({
+          leaderId: request.teamLeaderId,
+          requestId: request.id,
+          groupId: request.groupId,
+          groupName: group?.name || null,
+          advisorDecision: nextStatus,
+          advisorId: advisorUser?.id ?? req.user.id,
+          advisorName: advisorUser?.fullName ?? null,
+          advisorEmail: advisorUser?.email ?? null,
+          message: group?.name
+            ? `Advisor request for ${group.name} was ${nextStatus.toLowerCase()}.`
+            : `Your advisor request was ${nextStatus.toLowerCase()}.`,
+        });
+      }
 
       await AuditLog.create({
         action: nextStatus === 'APPROVED' ? 'ADVISOR_REQUEST_APPROVED' : 'ADVISOR_REQUEST_REJECTED',

--- a/backend/routes/teamLeader.js
+++ b/backend/routes/teamLeader.js
@@ -109,4 +109,70 @@ router.get(
   },
 );
 
+router.get(
+  '/notifications/advisor-decisions',
+  authenticate,
+  authorize(['STUDENT']),
+  async (req, res) => {
+    try {
+      const rows = await Notification.findAll({
+        where: {
+          userId: req.user.id,
+          type: 'ADVISOR_DECISION',
+        },
+        order: [['createdAt', 'DESC']],
+        limit: 50,
+      });
+
+      const groupIds = rows
+        .map((row) => parsePayload(row.payload).groupId)
+        .filter(Boolean);
+
+      const groups = groupIds.length > 0
+        ? await Group.findAll({
+          where: {
+            id: {
+              [Op.in]: groupIds,
+            },
+          },
+        })
+        : [];
+
+      const groupMap = new Map(groups.map((group) => [String(group.id), group]));
+
+      const notifications = rows.map((row) => {
+        const payload = parsePayload(row.payload);
+        const group = payload.groupId ? groupMap.get(String(payload.groupId)) : null;
+        const advisorDecision = String(payload.advisorDecision || '').toUpperCase();
+
+        return {
+          id: row.id,
+          type: 'ADVISOR_DECISION',
+          recipientId: req.user.id,
+          requestId: payload.requestId ?? null,
+          groupId: payload.groupId ?? null,
+          groupName: payload.groupName ?? group?.name ?? null,
+          advisorDecision: advisorDecision || null,
+          message: payload.message
+            || (advisorDecision === 'APPROVED'
+              ? 'Your advisor request has been approved.'
+              : 'Your advisor request has been rejected.'),
+          createdAt: row.createdAt,
+          status: row.status,
+          advisor: {
+            id: payload.advisorId ?? null,
+            fullName: payload.advisorName ?? null,
+            email: payload.advisorEmail ?? null,
+          },
+        };
+      });
+
+      return res.status(200).json(notifications);
+    } catch (error) {
+      console.error('Error in team-leader/notifications/advisor-decisions:', error);
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  },
+);
+
 module.exports = router;

--- a/backend/services/notificationService.js
+++ b/backend/services/notificationService.js
@@ -1,6 +1,56 @@
 const { Notification } = require('../models');
 
 class NotificationService {
+  static async notifyTeamLeaderAdvisorDecision({
+    leaderId,
+    requestId,
+    groupId,
+    groupName,
+    advisorDecision,
+    advisorId = null,
+    advisorName = null,
+    advisorEmail = null,
+    message,
+  }) {
+    const normalizedDecision = String(advisorDecision || '').toUpperCase();
+    const fallbackMessage = normalizedDecision === 'APPROVED'
+      ? 'Your advisor request has been approved.'
+      : 'Your advisor request has been rejected.';
+    let row;
+
+    try {
+      row = await Notification.create({
+        userId: leaderId,
+        type: 'ADVISOR_DECISION',
+        payload: JSON.stringify({
+          requestId,
+          groupId,
+          groupName,
+          advisorDecision: normalizedDecision || null,
+          advisorId,
+          advisorName,
+          advisorEmail,
+          message: message || fallbackMessage,
+        }),
+        status: 'PENDING',
+      });
+    } catch (error) {
+      console.error('[NotificationService] Failed to persist team leader advisor decision notification', error);
+      return;
+    }
+
+    await NotificationService.#pushAndMark(row, `user:${leaderId}`, {
+      requestId,
+      groupId,
+      groupName,
+      advisorDecision: normalizedDecision || null,
+      advisorId,
+      advisorName,
+      advisorEmail,
+      message: message || fallbackMessage,
+    });
+  }
+
   static async notifyAdvisorTransferredGroup({
     advisorId,
     groupId,

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -823,6 +823,91 @@ test('team leader advisor transfer notifications endpoint returns an empty list 
   assert.deepEqual(result.json, []);
 });
 
+test('team leader can view advisor decision notifications relevant only to the authenticated student', async () => {
+  const leader = await User.create({
+    email: 'team-leader-decision@example.edu',
+    fullName: 'Team Leader Decision',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001780',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const otherLeader = await User.create({
+    email: 'other-team-leader-decision@example.edu',
+    fullName: 'Other Team Leader Decision',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001781',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  await Group.create({
+    id: 'team-leader-group-decision-1',
+    name: 'Team Hermes',
+    leaderId: String(leader.id),
+    memberIds: [String(leader.id)],
+  });
+
+  await Notification.create({
+    userId: leader.id,
+    type: 'ADVISOR_DECISION',
+    payload: JSON.stringify({
+      requestId: 'advisor-request-decision-1',
+      groupId: 'team-leader-group-decision-1',
+      groupName: 'Team Hermes',
+      advisorDecision: 'APPROVED',
+      advisorName: 'Decision Advisor',
+      message: 'Advisor request for Team Hermes was approved.',
+    }),
+    status: 'SENT',
+  });
+
+  await Notification.create({
+    userId: otherLeader.id,
+    type: 'ADVISOR_DECISION',
+    payload: JSON.stringify({
+      requestId: 'advisor-request-decision-2',
+      groupId: 'team-leader-group-decision-2',
+      groupName: 'Team Iris',
+      advisorDecision: 'REJECTED',
+      message: 'Advisor request for Team Iris was rejected.',
+    }),
+    status: 'SENT',
+  });
+
+  const result = await request('/api/v1/team-leader/notifications/advisor-decisions', {
+    headers: await authHeaderFor(leader),
+  });
+
+  assert.equal(result.response.status, 200);
+  assert.equal(Array.isArray(result.json), true);
+  assert.equal(result.json.length, 1);
+  assert.equal(result.json[0].type, 'ADVISOR_DECISION');
+  assert.equal(result.json[0].requestId, 'advisor-request-decision-1');
+  assert.equal(result.json[0].groupId, 'team-leader-group-decision-1');
+  assert.equal(result.json[0].groupName, 'Team Hermes');
+  assert.equal(result.json[0].advisorDecision, 'APPROVED');
+});
+
+test('team leader advisor decision notifications endpoint returns an empty list when there are no relevant notifications', async () => {
+  const leader = await User.create({
+    email: 'empty-team-leader-decision@example.edu',
+    fullName: 'Empty Team Leader Decision',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001782',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const result = await request('/api/v1/team-leader/notifications/advisor-decisions', {
+    headers: await authHeaderFor(leader),
+  });
+
+  assert.equal(result.response.status, 200);
+  assert.deepEqual(result.json, []);
+});
+
 test('coordinator advisor transfer persists notifications for both advisor and team leader', async () => {
   const coordinator = await User.create({
     email: 'coordinator-transfer-notify@example.edu',
@@ -978,8 +1063,26 @@ test('assigned advisor can approve a pending advisor request', async () => {
 
   const updatedRequest = await AdvisorRequest.findByPk('advisor-request-1');
   const updatedGroup = await Group.findByPk(group.id);
+  const leaderNotification = await Notification.findOne({
+    where: {
+      userId: leader.id,
+      type: 'ADVISOR_DECISION',
+    },
+    order: [['createdAt', 'DESC']],
+  });
+
   assert.equal(updatedRequest.status, 'APPROVED');
   assert.equal(updatedGroup.advisorId, String(professor.id));
+  assert.equal(Boolean(leaderNotification), true);
+
+  const leaderPayload = JSON.parse(leaderNotification.payload);
+  assert.equal(leaderPayload.requestId, 'advisor-request-1');
+  assert.equal(leaderPayload.groupId, group.id);
+  assert.equal(leaderPayload.groupName, 'Team Atlas');
+  assert.equal(leaderPayload.advisorDecision, 'APPROVED');
+  assert.equal(leaderPayload.advisorId, professor.id);
+  assert.equal(leaderPayload.advisorName, 'Approve Advisor');
+  assert.equal(leaderPayload.advisorEmail, 'approve-advisor@example.edu');
 });
 
 test('advisor request cannot be decided twice', async () => {

--- a/frontend/src/StudentInvitationsPage.jsx
+++ b/frontend/src/StudentInvitationsPage.jsx
@@ -57,6 +57,12 @@ function formatPreview(entry) {
       ? `${groupLabel} is now assigned to ${advisorName}${advisorEmail ? ` (${advisorEmail})` : ''}.`
       : `Your group is now assigned to ${advisorName}${advisorEmail ? ` (${advisorEmail})` : ''}.`;
   }
+  if (entry.type === 'ADVISOR_DECISION') {
+    const decision = String(entry.advisorDecision || entry.payload?.advisorDecision || '').toUpperCase();
+    return groupLabel
+      ? `Advisor request for ${groupLabel} was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`
+      : `Your advisor request was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`;
+  }
   return 'Notification received from local mailbox.';
 }
 
@@ -72,6 +78,21 @@ function formatAdvisorTransferPreview(entry) {
   return groupLabel
     ? `${groupLabel} has been transferred to ${advisorName}${advisorEmail ? ` (${advisorEmail})` : ''}.`
     : `Your group has been transferred to ${advisorName}${advisorEmail ? ` (${advisorEmail})` : ''}.`;
+}
+
+function formatAdvisorDecisionSubject(entry) {
+  const groupLabel = getGroupLabel(entry);
+  const decision = String(entry.advisorDecision || entry.payload?.advisorDecision || '').toUpperCase();
+  const decisionLabel = decision === 'APPROVED' ? 'Approved' : 'Rejected';
+  return groupLabel ? `${decisionLabel}: ${groupLabel}` : `Advisor request ${decisionLabel.toLowerCase()}`;
+}
+
+function formatAdvisorDecisionPreview(entry) {
+  const groupLabel = getGroupLabel(entry);
+  const decision = String(entry.advisorDecision || entry.payload?.advisorDecision || '').toUpperCase();
+  return groupLabel
+    ? `${groupLabel} advisor request was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`
+    : `Your advisor request was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`;
 }
 
 function formatDate(value) {
@@ -102,9 +123,12 @@ export default function StudentInvitationsPage() {
 
   const [mailbox, setMailbox] = useState([]);
   const [advisorTransfers, setAdvisorTransfers] = useState([]);
+  const [advisorDecisions, setAdvisorDecisions] = useState([]);
   const [selectedMailId, setSelectedMailId] = useState(null);
   const [loadingTransfers, setLoadingTransfers] = useState(true);
   const [transferLoadError, setTransferLoadError] = useState('');
+  const [loadingDecisions, setLoadingDecisions] = useState(true);
+  const [decisionLoadError, setDecisionLoadError] = useState('');
 
   useEffect(() => {
     fetchInvitations();
@@ -182,6 +206,57 @@ export default function StudentInvitationsPage() {
     };
   }, []);
 
+  useEffect(() => {
+    let active = true;
+    let timeoutId;
+    const token = window.localStorage.getItem('studentToken') || window.localStorage.getItem('authToken');
+
+    async function loadAdvisorDecisions() {
+      try {
+        const response = await fetch('/api/v1/team-leader/notifications/advisor-decisions', {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        const payload = await response.json().catch(() => []);
+        if (!active) {
+          return;
+        }
+
+        if (!response.ok) {
+          setDecisionLoadError('Advisor decision notifications could not be loaded.');
+          setAdvisorDecisions([]);
+        } else {
+          const rows = Array.isArray(payload) ? payload : payload.notifications || [];
+          setAdvisorDecisions(rows);
+          setDecisionLoadError('');
+        }
+      } catch {
+        if (!active) {
+          return;
+        }
+
+        setDecisionLoadError('Advisor decision notifications could not be loaded.');
+        setAdvisorDecisions([]);
+      } finally {
+        if (!active) {
+          return;
+        }
+
+        setLoadingDecisions(false);
+        timeoutId = window.setTimeout(loadAdvisorDecisions, 15000);
+      }
+    }
+
+    loadAdvisorDecisions();
+
+    return () => {
+      active = false;
+      window.clearTimeout(timeoutId);
+    };
+  }, []);
+
   async function handleRespond(invitationId, response) {
     const invitation = invitations.find((inv) => inv.id === invitationId);
 
@@ -231,6 +306,37 @@ export default function StudentInvitationsPage() {
 
   return (
     <main className="page page-mailbox">
+      <section className="panel">
+        <div className="mail-sidebar-header">
+          <p className="mailbox-title">Advisor Decision Notifications</p>
+          <p className="mailbox-count">{advisorDecisions.length} notifications</p>
+        </div>
+
+        {loadingDecisions && (
+          <p className="mail-state" aria-live="polite">Loading advisor decision notifications...</p>
+        )}
+
+        {!loadingDecisions && decisionLoadError && (
+          <p className="mail-state" aria-live="polite">{decisionLoadError}</p>
+        )}
+
+        {!loadingDecisions && !decisionLoadError && advisorDecisions.length === 0 && (
+          <p className="mail-state" aria-live="polite">No advisor decision notifications yet.</p>
+        )}
+
+        {!loadingDecisions && !decisionLoadError && advisorDecisions.length > 0 && (
+          <section className="mail-nav" aria-label="Advisor decision notification list">
+            {advisorDecisions.map((entry) => (
+              <article key={entry.id} className="mail-nav-item">
+                <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
+                <span className="mail-nav-subject">{formatAdvisorDecisionSubject(entry)}</span>
+                <span className="mail-nav-preview">{formatAdvisorDecisionPreview(entry)}</span>
+              </article>
+            ))}
+          </section>
+        )}
+      </section>
+
       <section className="panel">
         <div className="mail-sidebar-header">
           <p className="mailbox-title">Advisor Transfer Notifications</p>


### PR DESCRIPTION
## What changed
This adds advisor decision notifications for team leaders.

## Why
Team leaders needed to see whether submitted advisor requests were approved or rejected without manually checking request state elsewhere.

## Impact
Team leaders can now view advisor decision notifications in the notifications UI.
Each notification clearly shows whether the request was approved or rejected.
Only notifications for the authenticated team leader are returned.
Notifications refresh automatically while the page stays open.

## Backend
- Added advisor decision notification persistence when an advisor processes a decision
- Added `GET /api/v1/team-leader/notifications/advisor-decisions`
- Returned advisor decision notification data for the authenticated team leader only

## Frontend
- Added advisor decision notification list to `StudentInvitationsPage`
- Displayed decision status clearly as approved/rejected
- Added automatic polling so notifications render without page refresh

## Validation
- `npm --prefix backend test`
- `npm --prefix frontend run build`
