### PR TITLE
Arda gurkan48/issue132

### DIFF
--- a/backend/routes/advisorRequests.js
+++ b/backend/routes/advisorRequests.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const { body, validationResult } = require('express-validator');
 const { authenticate, authorize } = require('../middleware/auth');
+const NotificationService = require('../services/notificationService');
 const {
   getPendingAdvisorRequest,
   updatePendingAdvisorRequestStatus,
 } = require('../controllers/advisorRequestController');
-const { AdvisorRequest, AuditLog, Group } = require('../models');
+const { AdvisorRequest, AuditLog, Group, User } = require('../models');
 
 const router = express.Router();
 
@@ -75,9 +76,9 @@ router.patch(
       const normalizedDecision = String(req.body.decision).toUpperCase();
       const nextStatus = normalizedDecision === 'APPROVE' ? 'APPROVED' : 'REJECTED';
       const note = typeof req.body.note === 'string' ? req.body.note.trim() : null;
+      const group = await Group.findByPk(request.groupId);
 
       if (normalizedDecision === 'APPROVE') {
-        const group = await Group.findByPk(request.groupId);
         if (!group) {
           return res.status(404).json(
             buildErrorResponse('Group not found for this advisor request.', 'GROUP_NOT_FOUND'),
@@ -94,6 +95,26 @@ router.patch(
         note: note || null,
         decidedAt: new Date(),
       });
+
+      const advisorUser = await User.findByPk(req.user.id, {
+        attributes: ['id', 'fullName', 'email'],
+      });
+
+      if (request.teamLeaderId) {
+        await NotificationService.notifyTeamLeaderAdvisorDecision({
+          leaderId: request.teamLeaderId,
+          requestId: request.id,
+          groupId: request.groupId,
+          groupName: group?.name || null,
+          advisorDecision: nextStatus,
+          advisorId: advisorUser?.id ?? req.user.id,
+          advisorName: advisorUser?.fullName ?? null,
+          advisorEmail: advisorUser?.email ?? null,
+          message: group?.name
+            ? `Advisor request for ${group.name} was ${nextStatus.toLowerCase()}.`
+            : `Your advisor request was ${nextStatus.toLowerCase()}.`,
+        });
+      }
 
       await AuditLog.create({
         action: nextStatus === 'APPROVED' ? 'ADVISOR_REQUEST_APPROVED' : 'ADVISOR_REQUEST_REJECTED',

--- a/backend/routes/teamLeader.js
+++ b/backend/routes/teamLeader.js
@@ -109,4 +109,70 @@ router.get(
   },
 );
 
+router.get(
+  '/notifications/advisor-decisions',
+  authenticate,
+  authorize(['STUDENT']),
+  async (req, res) => {
+    try {
+      const rows = await Notification.findAll({
+        where: {
+          userId: req.user.id,
+          type: 'ADVISOR_DECISION',
+        },
+        order: [['createdAt', 'DESC']],
+        limit: 50,
+      });
+
+      const groupIds = rows
+        .map((row) => parsePayload(row.payload).groupId)
+        .filter(Boolean);
+
+      const groups = groupIds.length > 0
+        ? await Group.findAll({
+          where: {
+            id: {
+              [Op.in]: groupIds,
+            },
+          },
+        })
+        : [];
+
+      const groupMap = new Map(groups.map((group) => [String(group.id), group]));
+
+      const notifications = rows.map((row) => {
+        const payload = parsePayload(row.payload);
+        const group = payload.groupId ? groupMap.get(String(payload.groupId)) : null;
+        const advisorDecision = String(payload.advisorDecision || '').toUpperCase();
+
+        return {
+          id: row.id,
+          type: 'ADVISOR_DECISION',
+          recipientId: req.user.id,
+          requestId: payload.requestId ?? null,
+          groupId: payload.groupId ?? null,
+          groupName: payload.groupName ?? group?.name ?? null,
+          advisorDecision: advisorDecision || null,
+          message: payload.message
+            || (advisorDecision === 'APPROVED'
+              ? 'Your advisor request has been approved.'
+              : 'Your advisor request has been rejected.'),
+          createdAt: row.createdAt,
+          status: row.status,
+          advisor: {
+            id: payload.advisorId ?? null,
+            fullName: payload.advisorName ?? null,
+            email: payload.advisorEmail ?? null,
+          },
+        };
+      });
+
+      return res.status(200).json(notifications);
+    } catch (error) {
+      console.error('Error in team-leader/notifications/advisor-decisions:', error);
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  },
+);
+
 module.exports = router;

--- a/backend/routes/teamLeader.js
+++ b/backend/routes/teamLeader.js
@@ -175,4 +175,64 @@ router.get(
   },
 );
 
+router.get(
+  '/notifications/advisor-releases',
+  authenticate,
+  authorize(['STUDENT']),
+  async (req, res) => {
+    try {
+      const rows = await Notification.findAll({
+        where: {
+          userId: req.user.id,
+          type: 'ADVISOR_RELEASE',
+        },
+        order: [['createdAt', 'DESC']],
+        limit: 50,
+      });
+
+      const groupIds = rows
+        .map((row) => parsePayload(row.payload).groupId)
+        .filter(Boolean);
+
+      const groups = groupIds.length > 0
+        ? await Group.findAll({
+          where: {
+            id: {
+              [Op.in]: groupIds,
+            },
+          },
+        })
+        : [];
+
+      const groupMap = new Map(groups.map((group) => [String(group.id), group]));
+
+      const notifications = rows.map((row) => {
+        const payload = parsePayload(row.payload);
+        const group = payload.groupId ? groupMap.get(String(payload.groupId)) : null;
+
+        return {
+          id: row.id,
+          type: 'ADVISOR_RELEASE',
+          recipientId: req.user.id,
+          groupId: payload.groupId ?? null,
+          groupName: payload.groupName ?? group?.name ?? null,
+          message: payload.message || 'Your group advisor has been released from the group.',
+          createdAt: row.createdAt,
+          status: row.status,
+          previousAdvisor: {
+            id: payload.previousAdvisorId ?? null,
+            fullName: payload.previousAdvisorName ?? null,
+            email: payload.previousAdvisorEmail ?? null,
+          },
+        };
+      });
+
+      return res.status(200).json(notifications);
+    } catch (error) {
+      console.error('Error in team-leader/notifications/advisor-releases:', error);
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  },
+);
+
 module.exports = router;

--- a/backend/services/mentorMatchingService.js
+++ b/backend/services/mentorMatchingService.js
@@ -209,7 +209,7 @@ async function transferAdvisorByCoordinator({ groupId, newAdvisorId }) {
 }
 
 async function removeAdvisorAssignmentFromGroup({ groupId }) {
-  return sequelize.transaction(async (transaction) => {
+  const result = await sequelize.transaction(async (transaction) => {
     const group = await loadGroupForTransfer(groupId, { transaction });
 
     const removedAssignmentCount = await GroupAdvisorAssignment.destroy({
@@ -227,6 +227,8 @@ async function removeAdvisorAssignmentFromGroup({ groupId }) {
 
     return {
       groupId: group.id,
+      leaderId: group.leaderId || null,
+      groupName: group.name || null,
       advisorId: group.advisorId,
       previousAdvisorId: previousAdvisorId || null,
       removed: true,
@@ -234,6 +236,36 @@ async function removeAdvisorAssignmentFromGroup({ groupId }) {
       updatedAt: group.updatedAt,
     };
   });
+
+  const normalizedPreviousAdvisorId = Number.parseInt(String(result.previousAdvisorId || ''), 10);
+  const previousAdvisorUser = Number.isInteger(normalizedPreviousAdvisorId) && normalizedPreviousAdvisorId > 0
+    ? await User.findByPk(normalizedPreviousAdvisorId, {
+      attributes: ['id', 'fullName', 'email'],
+    })
+    : null;
+
+  if (result.leaderId) {
+    await NotificationService.notifyTeamLeaderAdvisorReleased({
+      leaderId: Number.parseInt(String(result.leaderId), 10),
+      groupId: result.groupId,
+      groupName: result.groupName,
+      previousAdvisorId: previousAdvisorUser?.id ?? result.previousAdvisorId,
+      previousAdvisorName: previousAdvisorUser?.fullName ?? null,
+      previousAdvisorEmail: previousAdvisorUser?.email ?? null,
+      message: result.groupName
+        ? `${result.groupName} is no longer assigned to advisor ${previousAdvisorUser?.fullName || 'the previous advisor'}.`
+        : 'Your group advisor has been released from the group.',
+    });
+  }
+
+  return {
+    groupId: result.groupId,
+    advisorId: result.advisorId,
+    previousAdvisorId: result.previousAdvisorId,
+    removed: result.removed,
+    removedAssignmentCount: result.removedAssignmentCount,
+    updatedAt: result.updatedAt,
+  };
 }
 
 async function listActiveAdvisors() {

--- a/backend/services/notificationService.js
+++ b/backend/services/notificationService.js
@@ -1,6 +1,56 @@
 const { Notification } = require('../models');
 
 class NotificationService {
+  static async notifyTeamLeaderAdvisorDecision({
+    leaderId,
+    requestId,
+    groupId,
+    groupName,
+    advisorDecision,
+    advisorId = null,
+    advisorName = null,
+    advisorEmail = null,
+    message,
+  }) {
+    const normalizedDecision = String(advisorDecision || '').toUpperCase();
+    const fallbackMessage = normalizedDecision === 'APPROVED'
+      ? 'Your advisor request has been approved.'
+      : 'Your advisor request has been rejected.';
+    let row;
+
+    try {
+      row = await Notification.create({
+        userId: leaderId,
+        type: 'ADVISOR_DECISION',
+        payload: JSON.stringify({
+          requestId,
+          groupId,
+          groupName,
+          advisorDecision: normalizedDecision || null,
+          advisorId,
+          advisorName,
+          advisorEmail,
+          message: message || fallbackMessage,
+        }),
+        status: 'PENDING',
+      });
+    } catch (error) {
+      console.error('[NotificationService] Failed to persist team leader advisor decision notification', error);
+      return;
+    }
+
+    await NotificationService.#pushAndMark(row, `user:${leaderId}`, {
+      requestId,
+      groupId,
+      groupName,
+      advisorDecision: normalizedDecision || null,
+      advisorId,
+      advisorName,
+      advisorEmail,
+      message: message || fallbackMessage,
+    });
+  }
+
   static async notifyAdvisorTransferredGroup({
     advisorId,
     groupId,

--- a/backend/services/notificationService.js
+++ b/backend/services/notificationService.js
@@ -125,6 +125,46 @@ class NotificationService {
     });
   }
 
+  static async notifyTeamLeaderAdvisorReleased({
+    leaderId,
+    groupId,
+    groupName,
+    previousAdvisorId,
+    previousAdvisorName,
+    previousAdvisorEmail,
+    message = 'Your group advisor has been released from the group.',
+  }) {
+    let row;
+
+    try {
+      row = await Notification.create({
+        userId: leaderId,
+        type: 'ADVISOR_RELEASE',
+        payload: JSON.stringify({
+          groupId,
+          groupName,
+          previousAdvisorId,
+          previousAdvisorName,
+          previousAdvisorEmail,
+          message,
+        }),
+        status: 'PENDING',
+      });
+    } catch (error) {
+      console.error('[NotificationService] Failed to persist team leader advisor release notification', error);
+      return;
+    }
+
+    await NotificationService.#pushAndMark(row, `user:${leaderId}`, {
+      groupId,
+      groupName,
+      previousAdvisorId,
+      previousAdvisorName,
+      previousAdvisorEmail,
+      message,
+    });
+  }
+
   static async queueInviteAlert(targetId, groupId, invitationId) {
     let row;
 

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -908,6 +908,98 @@ test('team leader advisor decision notifications endpoint returns an empty list 
   assert.deepEqual(result.json, []);
 });
 
+test('team leader can view advisor release notifications relevant only to the authenticated student', async () => {
+  const leader = await User.create({
+    email: 'team-leader-release@example.edu',
+    fullName: 'Team Leader Release',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001783',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const otherLeader = await User.create({
+    email: 'other-team-leader-release@example.edu',
+    fullName: 'Other Team Leader Release',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001784',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const advisor = await User.create({
+    email: 'released-advisor@example.edu',
+    fullName: 'Released Advisor',
+    role: 'PROFESSOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  await Group.create({
+    id: 'team-leader-group-release-1',
+    name: 'Team Apollo',
+    leaderId: String(leader.id),
+    memberIds: [String(leader.id)],
+  });
+
+  await Notification.create({
+    userId: leader.id,
+    type: 'ADVISOR_RELEASE',
+    payload: JSON.stringify({
+      groupId: 'team-leader-group-release-1',
+      groupName: 'Team Apollo',
+      previousAdvisorId: advisor.id,
+      previousAdvisorName: 'Released Advisor',
+      previousAdvisorEmail: 'released-advisor@example.edu',
+      message: 'Team Apollo is no longer assigned to advisor Released Advisor.',
+    }),
+    status: 'SENT',
+  });
+
+  await Notification.create({
+    userId: otherLeader.id,
+    type: 'ADVISOR_RELEASE',
+    payload: JSON.stringify({
+      groupId: 'team-leader-group-release-2',
+      groupName: 'Team Aurora',
+      previousAdvisorName: 'Released Advisor',
+      message: 'Team Aurora is no longer assigned to advisor Released Advisor.',
+    }),
+    status: 'SENT',
+  });
+
+  const result = await request('/api/v1/team-leader/notifications/advisor-releases', {
+    headers: await authHeaderFor(leader),
+  });
+
+  assert.equal(result.response.status, 200);
+  assert.equal(Array.isArray(result.json), true);
+  assert.equal(result.json.length, 1);
+  assert.equal(result.json[0].type, 'ADVISOR_RELEASE');
+  assert.equal(result.json[0].groupId, 'team-leader-group-release-1');
+  assert.equal(result.json[0].groupName, 'Team Apollo');
+  assert.equal(result.json[0].previousAdvisor.fullName, 'Released Advisor');
+  assert.equal(result.json[0].previousAdvisor.email, 'released-advisor@example.edu');
+});
+
+test('team leader advisor release notifications endpoint returns an empty list when there are no relevant notifications', async () => {
+  const leader = await User.create({
+    email: 'empty-team-leader-release@example.edu',
+    fullName: 'Empty Team Leader Release',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001785',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const result = await request('/api/v1/team-leader/notifications/advisor-releases', {
+    headers: await authHeaderFor(leader),
+  });
+
+  assert.equal(result.response.status, 200);
+  assert.deepEqual(result.json, []);
+});
+
 test('coordinator advisor transfer persists notifications for both advisor and team leader', async () => {
   const coordinator = await User.create({
     email: 'coordinator-transfer-notify@example.edu',
@@ -1009,6 +1101,75 @@ test('coordinator advisor transfer persists notifications for both advisor and t
   assert.equal(leaderPayload.newAdvisorId, newAdvisor.id);
   assert.equal(leaderPayload.newAdvisorName, 'New Advisor Transfer Notify');
   assert.equal(leaderPayload.newAdvisorEmail, 'new-advisor-transfer-notify@example.edu');
+});
+
+test('coordinator advisor release persists a notification for the team leader', async () => {
+  const coordinator = await User.create({
+    email: 'coordinator-release-notify@example.edu',
+    fullName: 'Coordinator Release Notify',
+    role: 'COORDINATOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const leader = await User.create({
+    email: 'leader-release-notify@example.edu',
+    fullName: 'Leader Release Notify',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001889',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const advisor = await User.create({
+    email: 'advisor-release-notify@example.edu',
+    fullName: 'Advisor Release Notify',
+    role: 'PROFESSOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const group = await Group.create({
+    id: 'group-release-notify-1',
+    name: 'Team Zephyr',
+    leaderId: String(leader.id),
+    memberIds: [String(leader.id)],
+    advisorId: String(advisor.id),
+  });
+
+  await GroupAdvisorAssignment.create({
+    groupId: group.id,
+    studentUserId: leader.id,
+    advisorUserId: advisor.id,
+  });
+
+  const result = await request('/api/v1/group-database/groups/group-release-notify-1/advisor-assignment', {
+    method: 'DELETE',
+    headers: {
+      ...(await authHeaderFor(coordinator)),
+    },
+  });
+
+  assert.equal(result.response.status, 200);
+  assert.equal(result.json.groupId, 'group-release-notify-1');
+  assert.equal(result.json.removed, true);
+
+  const leaderNotification = await Notification.findOne({
+    where: {
+      userId: leader.id,
+      type: 'ADVISOR_RELEASE',
+    },
+    order: [['createdAt', 'DESC']],
+  });
+
+  assert.equal(Boolean(leaderNotification), true);
+
+  const leaderPayload = JSON.parse(leaderNotification.payload);
+  assert.equal(leaderPayload.groupId, 'group-release-notify-1');
+  assert.equal(leaderPayload.groupName, 'Team Zephyr');
+  assert.equal(leaderPayload.previousAdvisorId, advisor.id);
+  assert.equal(leaderPayload.previousAdvisorName, 'Advisor Release Notify');
+  assert.equal(leaderPayload.previousAdvisorEmail, 'advisor-release-notify@example.edu');
 });
 
 test('assigned advisor can approve a pending advisor request', async () => {

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -823,6 +823,91 @@ test('team leader advisor transfer notifications endpoint returns an empty list 
   assert.deepEqual(result.json, []);
 });
 
+test('team leader can view advisor decision notifications relevant only to the authenticated student', async () => {
+  const leader = await User.create({
+    email: 'team-leader-decision@example.edu',
+    fullName: 'Team Leader Decision',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001780',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const otherLeader = await User.create({
+    email: 'other-team-leader-decision@example.edu',
+    fullName: 'Other Team Leader Decision',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001781',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  await Group.create({
+    id: 'team-leader-group-decision-1',
+    name: 'Team Hermes',
+    leaderId: String(leader.id),
+    memberIds: [String(leader.id)],
+  });
+
+  await Notification.create({
+    userId: leader.id,
+    type: 'ADVISOR_DECISION',
+    payload: JSON.stringify({
+      requestId: 'advisor-request-decision-1',
+      groupId: 'team-leader-group-decision-1',
+      groupName: 'Team Hermes',
+      advisorDecision: 'APPROVED',
+      advisorName: 'Decision Advisor',
+      message: 'Advisor request for Team Hermes was approved.',
+    }),
+    status: 'SENT',
+  });
+
+  await Notification.create({
+    userId: otherLeader.id,
+    type: 'ADVISOR_DECISION',
+    payload: JSON.stringify({
+      requestId: 'advisor-request-decision-2',
+      groupId: 'team-leader-group-decision-2',
+      groupName: 'Team Iris',
+      advisorDecision: 'REJECTED',
+      message: 'Advisor request for Team Iris was rejected.',
+    }),
+    status: 'SENT',
+  });
+
+  const result = await request('/api/v1/team-leader/notifications/advisor-decisions', {
+    headers: await authHeaderFor(leader),
+  });
+
+  assert.equal(result.response.status, 200);
+  assert.equal(Array.isArray(result.json), true);
+  assert.equal(result.json.length, 1);
+  assert.equal(result.json[0].type, 'ADVISOR_DECISION');
+  assert.equal(result.json[0].requestId, 'advisor-request-decision-1');
+  assert.equal(result.json[0].groupId, 'team-leader-group-decision-1');
+  assert.equal(result.json[0].groupName, 'Team Hermes');
+  assert.equal(result.json[0].advisorDecision, 'APPROVED');
+});
+
+test('team leader advisor decision notifications endpoint returns an empty list when there are no relevant notifications', async () => {
+  const leader = await User.create({
+    email: 'empty-team-leader-decision@example.edu',
+    fullName: 'Empty Team Leader Decision',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070001782',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+
+  const result = await request('/api/v1/team-leader/notifications/advisor-decisions', {
+    headers: await authHeaderFor(leader),
+  });
+
+  assert.equal(result.response.status, 200);
+  assert.deepEqual(result.json, []);
+});
+
 test('coordinator advisor transfer persists notifications for both advisor and team leader', async () => {
   const coordinator = await User.create({
     email: 'coordinator-transfer-notify@example.edu',
@@ -978,8 +1063,26 @@ test('assigned advisor can approve a pending advisor request', async () => {
 
   const updatedRequest = await AdvisorRequest.findByPk('advisor-request-1');
   const updatedGroup = await Group.findByPk(group.id);
+  const leaderNotification = await Notification.findOne({
+    where: {
+      userId: leader.id,
+      type: 'ADVISOR_DECISION',
+    },
+    order: [['createdAt', 'DESC']],
+  });
+
   assert.equal(updatedRequest.status, 'APPROVED');
   assert.equal(updatedGroup.advisorId, String(professor.id));
+  assert.equal(Boolean(leaderNotification), true);
+
+  const leaderPayload = JSON.parse(leaderNotification.payload);
+  assert.equal(leaderPayload.requestId, 'advisor-request-1');
+  assert.equal(leaderPayload.groupId, group.id);
+  assert.equal(leaderPayload.groupName, 'Team Atlas');
+  assert.equal(leaderPayload.advisorDecision, 'APPROVED');
+  assert.equal(leaderPayload.advisorId, professor.id);
+  assert.equal(leaderPayload.advisorName, 'Approve Advisor');
+  assert.equal(leaderPayload.advisorEmail, 'approve-advisor@example.edu');
 });
 
 test('advisor request cannot be decided twice', async () => {

--- a/frontend/src/StudentInvitationsPage.jsx
+++ b/frontend/src/StudentInvitationsPage.jsx
@@ -57,6 +57,12 @@ function formatPreview(entry) {
       ? `${groupLabel} is now assigned to ${advisorName}${advisorEmail ? ` (${advisorEmail})` : ''}.`
       : `Your group is now assigned to ${advisorName}${advisorEmail ? ` (${advisorEmail})` : ''}.`;
   }
+  if (entry.type === 'ADVISOR_DECISION') {
+    const decision = String(entry.advisorDecision || entry.payload?.advisorDecision || '').toUpperCase();
+    return groupLabel
+      ? `Advisor request for ${groupLabel} was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`
+      : `Your advisor request was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`;
+  }
   return 'Notification received from local mailbox.';
 }
 
@@ -72,6 +78,21 @@ function formatAdvisorTransferPreview(entry) {
   return groupLabel
     ? `${groupLabel} has been transferred to ${advisorName}${advisorEmail ? ` (${advisorEmail})` : ''}.`
     : `Your group has been transferred to ${advisorName}${advisorEmail ? ` (${advisorEmail})` : ''}.`;
+}
+
+function formatAdvisorDecisionSubject(entry) {
+  const groupLabel = getGroupLabel(entry);
+  const decision = String(entry.advisorDecision || entry.payload?.advisorDecision || '').toUpperCase();
+  const decisionLabel = decision === 'APPROVED' ? 'Approved' : 'Rejected';
+  return groupLabel ? `${decisionLabel}: ${groupLabel}` : `Advisor request ${decisionLabel.toLowerCase()}`;
+}
+
+function formatAdvisorDecisionPreview(entry) {
+  const groupLabel = getGroupLabel(entry);
+  const decision = String(entry.advisorDecision || entry.payload?.advisorDecision || '').toUpperCase();
+  return groupLabel
+    ? `${groupLabel} advisor request was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`
+    : `Your advisor request was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`;
 }
 
 function formatDate(value) {
@@ -102,9 +123,12 @@ export default function StudentInvitationsPage() {
 
   const [mailbox, setMailbox] = useState([]);
   const [advisorTransfers, setAdvisorTransfers] = useState([]);
+  const [advisorDecisions, setAdvisorDecisions] = useState([]);
   const [selectedMailId, setSelectedMailId] = useState(null);
   const [loadingTransfers, setLoadingTransfers] = useState(true);
   const [transferLoadError, setTransferLoadError] = useState('');
+  const [loadingDecisions, setLoadingDecisions] = useState(true);
+  const [decisionLoadError, setDecisionLoadError] = useState('');
 
   useEffect(() => {
     fetchInvitations();
@@ -182,6 +206,57 @@ export default function StudentInvitationsPage() {
     };
   }, []);
 
+  useEffect(() => {
+    let active = true;
+    let timeoutId;
+    const token = window.localStorage.getItem('studentToken') || window.localStorage.getItem('authToken');
+
+    async function loadAdvisorDecisions() {
+      try {
+        const response = await fetch('/api/v1/team-leader/notifications/advisor-decisions', {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        const payload = await response.json().catch(() => []);
+        if (!active) {
+          return;
+        }
+
+        if (!response.ok) {
+          setDecisionLoadError('Advisor decision notifications could not be loaded.');
+          setAdvisorDecisions([]);
+        } else {
+          const rows = Array.isArray(payload) ? payload : payload.notifications || [];
+          setAdvisorDecisions(rows);
+          setDecisionLoadError('');
+        }
+      } catch {
+        if (!active) {
+          return;
+        }
+
+        setDecisionLoadError('Advisor decision notifications could not be loaded.');
+        setAdvisorDecisions([]);
+      } finally {
+        if (!active) {
+          return;
+        }
+
+        setLoadingDecisions(false);
+        timeoutId = window.setTimeout(loadAdvisorDecisions, 15000);
+      }
+    }
+
+    loadAdvisorDecisions();
+
+    return () => {
+      active = false;
+      window.clearTimeout(timeoutId);
+    };
+  }, []);
+
   async function handleRespond(invitationId, response) {
     const invitation = invitations.find((inv) => inv.id === invitationId);
 
@@ -231,6 +306,37 @@ export default function StudentInvitationsPage() {
 
   return (
     <main className="page page-mailbox">
+      <section className="panel">
+        <div className="mail-sidebar-header">
+          <p className="mailbox-title">Advisor Decision Notifications</p>
+          <p className="mailbox-count">{advisorDecisions.length} notifications</p>
+        </div>
+
+        {loadingDecisions && (
+          <p className="mail-state" aria-live="polite">Loading advisor decision notifications...</p>
+        )}
+
+        {!loadingDecisions && decisionLoadError && (
+          <p className="mail-state" aria-live="polite">{decisionLoadError}</p>
+        )}
+
+        {!loadingDecisions && !decisionLoadError && advisorDecisions.length === 0 && (
+          <p className="mail-state" aria-live="polite">No advisor decision notifications yet.</p>
+        )}
+
+        {!loadingDecisions && !decisionLoadError && advisorDecisions.length > 0 && (
+          <section className="mail-nav" aria-label="Advisor decision notification list">
+            {advisorDecisions.map((entry) => (
+              <article key={entry.id} className="mail-nav-item">
+                <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
+                <span className="mail-nav-subject">{formatAdvisorDecisionSubject(entry)}</span>
+                <span className="mail-nav-preview">{formatAdvisorDecisionPreview(entry)}</span>
+              </article>
+            ))}
+          </section>
+        )}
+      </section>
+
       <section className="panel">
         <div className="mail-sidebar-header">
           <p className="mailbox-title">Advisor Transfer Notifications</p>

--- a/frontend/src/StudentInvitationsPage.jsx
+++ b/frontend/src/StudentInvitationsPage.jsx
@@ -63,6 +63,12 @@ function formatPreview(entry) {
       ? `Advisor request for ${groupLabel} was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`
       : `Your advisor request was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`;
   }
+  if (entry.type === 'ADVISOR_RELEASE') {
+    const advisorName = entry.previousAdvisor?.fullName || entry.payload?.previousAdvisorName || 'the previous advisor';
+    return groupLabel
+      ? `${advisorName} is no longer assigned to ${groupLabel}.`
+      : `${advisorName} is no longer assigned to your group.`;
+  }
   return 'Notification received from local mailbox.';
 }
 
@@ -95,6 +101,19 @@ function formatAdvisorDecisionPreview(entry) {
     : `Your advisor request was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`;
 }
 
+function formatAdvisorReleaseSubject(entry) {
+  const groupLabel = getGroupLabel(entry);
+  return groupLabel ? `Advisor released: ${groupLabel}` : 'Advisor release update';
+}
+
+function formatAdvisorReleasePreview(entry) {
+  const advisorName = entry.previousAdvisor?.fullName || entry.payload?.previousAdvisorName || 'the previous advisor';
+  const groupLabel = getGroupLabel(entry);
+  return groupLabel
+    ? `${advisorName} left ${groupLabel}.`
+    : `${advisorName} left your group.`;
+}
+
 function formatDate(value) {
   if (!value) {
     return 'Now';
@@ -124,11 +143,14 @@ export default function StudentInvitationsPage() {
   const [mailbox, setMailbox] = useState([]);
   const [advisorTransfers, setAdvisorTransfers] = useState([]);
   const [advisorDecisions, setAdvisorDecisions] = useState([]);
+  const [advisorReleases, setAdvisorReleases] = useState([]);
   const [selectedMailId, setSelectedMailId] = useState(null);
   const [loadingTransfers, setLoadingTransfers] = useState(true);
   const [transferLoadError, setTransferLoadError] = useState('');
   const [loadingDecisions, setLoadingDecisions] = useState(true);
   const [decisionLoadError, setDecisionLoadError] = useState('');
+  const [loadingReleases, setLoadingReleases] = useState(true);
+  const [releaseLoadError, setReleaseLoadError] = useState('');
 
   useEffect(() => {
     fetchInvitations();
@@ -199,6 +221,57 @@ export default function StudentInvitationsPage() {
     }
 
     loadAdvisorTransfers();
+
+    return () => {
+      active = false;
+      window.clearTimeout(timeoutId);
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    let timeoutId;
+    const token = window.localStorage.getItem('studentToken') || window.localStorage.getItem('authToken');
+
+    async function loadAdvisorReleases() {
+      try {
+        const response = await fetch('/api/v1/team-leader/notifications/advisor-releases', {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        const payload = await response.json().catch(() => []);
+        if (!active) {
+          return;
+        }
+
+        if (!response.ok) {
+          setReleaseLoadError('Advisor release notifications could not be loaded.');
+          setAdvisorReleases([]);
+        } else {
+          const rows = Array.isArray(payload) ? payload : payload.notifications || [];
+          setAdvisorReleases(rows);
+          setReleaseLoadError('');
+        }
+      } catch {
+        if (!active) {
+          return;
+        }
+
+        setReleaseLoadError('Advisor release notifications could not be loaded.');
+        setAdvisorReleases([]);
+      } finally {
+        if (!active) {
+          return;
+        }
+
+        setLoadingReleases(false);
+        timeoutId = window.setTimeout(loadAdvisorReleases, 15000);
+      }
+    }
+
+    loadAdvisorReleases();
 
     return () => {
       active = false;
@@ -306,6 +379,37 @@ export default function StudentInvitationsPage() {
 
   return (
     <main className="page page-mailbox">
+      <section className="panel">
+        <div className="mail-sidebar-header">
+          <p className="mailbox-title">Advisor Release Notifications</p>
+          <p className="mailbox-count">{advisorReleases.length} notifications</p>
+        </div>
+
+        {loadingReleases && (
+          <p className="mail-state" aria-live="polite">Loading advisor release notifications...</p>
+        )}
+
+        {!loadingReleases && releaseLoadError && (
+          <p className="mail-state" aria-live="polite">{releaseLoadError}</p>
+        )}
+
+        {!loadingReleases && !releaseLoadError && advisorReleases.length === 0 && (
+          <p className="mail-state" aria-live="polite">No advisor release notifications yet.</p>
+        )}
+
+        {!loadingReleases && !releaseLoadError && advisorReleases.length > 0 && (
+          <section className="mail-nav" aria-label="Advisor release notification list">
+            {advisorReleases.map((entry) => (
+              <article key={entry.id} className="mail-nav-item">
+                <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
+                <span className="mail-nav-subject">{formatAdvisorReleaseSubject(entry)}</span>
+                <span className="mail-nav-preview">{formatAdvisorReleasePreview(entry)}</span>
+              </article>
+            ))}
+          </section>
+        )}
+      </section>
+
       <section className="panel">
         <div className="mail-sidebar-header">
           <p className="mailbox-title">Advisor Decision Notifications</p>


### PR DESCRIPTION
## What changed
This adds advisor release notifications for team leaders.

## Why
Team leaders needed to be notified when an assigned advisor leaves or is released from their group.

## Impact
Team leaders can now view advisor release notifications in the notifications UI.
Each notification clearly shows which advisor left the group.
Only notifications for the authenticated team leader are returned.
Notifications refresh automatically while the page stays open.

## Backend
- Added advisor release notification persistence during advisor assignment removal
- Added `GET /api/v1/team-leader/notifications/advisor-releases`
- Returned advisor release notification data for the authenticated team leader only

## Frontend
- Added advisor release notification list to `StudentInvitationsPage`
- Displayed the advisor who left in each notification
- Added automatic polling so notifications render without page refresh

## Validation
- `npm --prefix backend test`
- `npm --prefix frontend run build`
