### PR TITLE
fix: restore merged advisor request and notification flows

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -20,7 +20,6 @@ const passwordSetupTokenStoreRoutes = require('./routes/passwordSetupTokenStore'
 const userDatabaseRoutes = require('./routes/userDatabase');
 const groupRoutes = require('./routes/groups');
 const groupDatabaseRoutes = require('./routes/groupDatabase');
-const advisorRequestDetailRoutes = require('./routes/advisor');
 
 const app = express();
 const frontendDistPath = path.join(__dirname, '..', 'frontend', 'dist');
@@ -50,7 +49,6 @@ app.use('/api/v1/password-setup-token-store', passwordSetupTokenStoreRoutes);
 app.use('/api/v1/user-database', userDatabaseRoutes);
 app.use('/api/v1/group-database', groupDatabaseRoutes);
 app.use('/api/v1/groups', groupRoutes);
-app.use('/api/v1', advisorRequestDetailRoutes);
 
 // Global error handler
 app.use((err, req, res, _next) => {

--- a/backend/controllers/advisorRequestController.js
+++ b/backend/controllers/advisorRequestController.js
@@ -26,14 +26,18 @@ function formatValidationErrors(errors) {
 const createAdvisorRequest = [
   body('groupId').isString().trim().notEmpty().withMessage('Group ID is required'),
   body('advisorId')
-    .exists({ checkFalsy: true })
-    .withMessage('Advisor is required')
-    .bail()
+    .optional({ values: 'falsy' })
+    .isInt({ min: 1 })
+    .withMessage('Advisor selection must be a positive integer')
+    .toInt(),
+  body('professorId')
+    .optional({ values: 'falsy' })
     .isInt({ min: 1 })
     .withMessage('Advisor selection must be a positive integer')
     .toInt(),
   async (req, res) => {
     const errors = validationResult(req);
+    const requestedAdvisorId = req.body.advisorId ?? req.body.professorId;
     if (!errors.isEmpty()) {
       return res.status(400).json({
         code: 'VALIDATION_ERROR',
@@ -42,7 +46,18 @@ const createAdvisorRequest = [
       });
     }
 
-    const { groupId, advisorId } = req.body;
+    if (!requestedAdvisorId) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: 'Please check your input and try again',
+        errors: {
+          advisorId: ['Advisor is required'],
+        },
+      });
+    }
+
+    const { groupId } = req.body;
+    const advisorId = requestedAdvisorId;
 
     try {
       const group = await Group.findByPk(groupId);

--- a/backend/controllers/professorController.js
+++ b/backend/controllers/professorController.js
@@ -2,6 +2,7 @@ const bcrypt = require('bcryptjs');
 const { body, validationResult } = require('express-validator');
 const jwt = require('jsonwebtoken');
 const professorService = require('../services/professorService');
+const { Professor, User } = require('../models');
 
 const buildErrorResponse = (message, errorCode) => ({
   message,
@@ -134,4 +135,35 @@ const setupProfessorPassword = [
   },
 ];
 
-module.exports = { loginProfessor, setupProfessorPassword };
+async function listProfessors(req, res) {
+  try {
+    const professors = await Professor.findAll({
+      include: [
+        {
+          model: User,
+          attributes: ['id', 'fullName', 'email', 'role'],
+          where: { role: 'PROFESSOR' },
+        },
+      ],
+    });
+
+    return res.status(200).json(
+      professors
+        .map((professor) => ({
+        id: professor.userId,
+        professorProfileId: professor.id,
+        fullName: professor.User?.fullName || '',
+        email: professor.User?.email || '',
+        department: professor.department || '',
+        }))
+        .sort((left, right) => left.fullName.localeCompare(right.fullName)),
+    );
+  } catch (error) {
+    console.error('Error listing professors:', error);
+    return res.status(500).json(
+      buildErrorResponse('Failed to fetch professors', 'INTERNAL_SERVER_ERROR'),
+    );
+  }
+}
+
+module.exports = { loginProfessor, setupProfessorPassword, listProfessors };

--- a/backend/models/Notification.js
+++ b/backend/models/Notification.js
@@ -48,10 +48,11 @@ const Notification = sequelize.define(
      * Delivery lifecycle:
      *   PENDING  – persisted, not yet pushed
      *   SENT     – successfully pushed to client
+     *   READ     – viewed by the recipient
      *   FAILED   – push failed; eligible for retry job
      */
     status: {
-      type: DataTypes.ENUM('PENDING', 'SENT', 'FAILED'),
+      type: DataTypes.ENUM('PENDING', 'SENT', 'READ', 'FAILED'),
       allowNull: false,
       defaultValue: 'PENDING',
     },

--- a/backend/routes/advisorRequests.js
+++ b/backend/routes/advisorRequests.js
@@ -4,6 +4,7 @@ const { authenticate, authorize } = require('../middleware/auth');
 const NotificationService = require('../services/notificationService');
 const sequelize = require('../db');
 const { syncAdvisorAssignmentsForGroup } = require('../services/mentorMatchingService');
+const { getAdvisorRequestDetails } = require('../controllers/advisorController');
 const {
   createAdvisorRequest,
   getPendingAdvisorRequest,
@@ -28,6 +29,13 @@ router.get(
   authenticate,
   authorize(['PROFESSOR']),
   listAdvisorRequests,
+);
+
+router.get(
+  '/advisor-requests/:requestId',
+  authenticate,
+  authorize(['STUDENT']),
+  getAdvisorRequestDetails,
 );
 
 router.get(

--- a/backend/routes/advisors.js
+++ b/backend/routes/advisors.js
@@ -13,6 +13,24 @@ function parsePayload(rawPayload) {
   }
 }
 
+function buildReadState(status) {
+  return status === 'READ';
+}
+
+function buildTypeFilter(type) {
+  if (type === 'advisee-request') {
+    return {
+      [Op.in]: ['ADVISEE_REQUEST', 'ADVISOR_REQUEST'],
+    };
+  }
+
+  if (type === 'group-transfer') {
+    return 'GROUP_TRANSFER';
+  }
+
+  return null;
+}
+
 router.get(
   '/notifications/advisee-requests',
   authenticate,
@@ -61,7 +79,7 @@ router.get(
           groupName: payload.groupName ?? null,
           requestStatus: request?.status || payload.requestStatus || payload.status || 'PENDING',
           message: payload.message || 'A team leader submitted an advisor request.',
-          read: false,
+          isRead: buildReadState(row.status),
           createdAt: row.createdAt,
           status: row.status,
           note: request?.note ?? null,
@@ -69,7 +87,10 @@ router.get(
         };
       });
 
-      return res.status(200).json(notifications);
+      return res.status(200).json({
+        data: notifications,
+        count: notifications.length,
+      });
     } catch (error) {
       console.error('Error in advisors/notifications/advisee-requests:', error);
       return res.status(500).json({ message: 'Internal server error' });
@@ -119,15 +140,70 @@ router.get(
           groupId: payload.groupId ?? null,
           groupName: payload.groupName ?? group?.name ?? null,
           message: payload.message || 'A new group has been assigned to you through transfer.',
-          read: false,
+          isRead: buildReadState(row.status),
           createdAt: row.createdAt,
           status: row.status,
         };
       });
 
-      return res.status(200).json(notifications);
+      return res.status(200).json({
+        data: notifications,
+        count: notifications.length,
+      });
     } catch (error) {
       console.error('Error in advisors/notifications/group-transfers:', error);
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  },
+);
+
+router.put(
+  '/notifications/:type/:notificationId/read',
+  authenticate,
+  authorize(['PROFESSOR']),
+  async (req, res) => {
+    try {
+      const { type, notificationId } = req.params;
+      const typeFilter = buildTypeFilter(type);
+
+      if (!typeFilter) {
+        return res.status(400).json({
+          message: 'Invalid notification type',
+          code: 'INVALID_NOTIFICATION_TYPE',
+        });
+      }
+
+      const notification = await Notification.findOne({
+        where: {
+          id: notificationId,
+          userId: req.user.id,
+          type: typeFilter,
+        },
+      });
+
+      if (!notification) {
+        return res.status(404).json({
+          message: 'Notification not found',
+          code: 'NOTIFICATION_NOT_FOUND',
+        });
+      }
+
+      if (notification.status !== 'READ') {
+        await notification.update({
+          status: 'READ',
+        });
+      }
+
+      return res.status(200).json({
+        message: 'Notification marked as read',
+        notification: {
+          id: notification.id,
+          isRead: true,
+          updatedAt: notification.updatedAt,
+        },
+      });
+    } catch (error) {
+      console.error('Error in advisors/notifications/:type/:notificationId/read:', error);
       return res.status(500).json({ message: 'Internal server error' });
     }
   },

--- a/backend/routes/professors.js
+++ b/backend/routes/professors.js
@@ -1,9 +1,16 @@
 const express = require('express');
-const { loginProfessor, setupProfessorPassword } = require('../controllers/professorController');
+const { authenticate, authorize } = require('../middleware/auth');
+const {
+  loginProfessor,
+  setupProfessorPassword,
+  listProfessors,
+} = require('../controllers/professorController');
 
 const router = express.Router();
 
 router.post('/login', loginProfessor);
 router.post('/password-setup', setupProfessorPassword);
+router.get('/', authenticate, authorize(['STUDENT', 'PROFESSOR', 'ADMIN', 'COORDINATOR']), listProfessors);
+router.get('/list', authenticate, authorize(['STUDENT', 'PROFESSOR', 'ADMIN', 'COORDINATOR']), listProfessors);
 
 module.exports = router;

--- a/backend/services/advisorService.js
+++ b/backend/services/advisorService.js
@@ -1,4 +1,4 @@
-const { AdvisorRequest, Group, User } = require('../models');
+const { AdvisorRequest, Group, Professor, User } = require('../models');
 
 /**
  * Get advisor request details by requestId
@@ -17,11 +17,7 @@ async function getAdvisorRequestDetails(requestId, userId) {
     throw error;
   }
 
-  const group = await Group.findByPk(request.groupId, {
-    attributes: ['id', 'name', 'leaderId'],
-  });
-
-  const advisor = await User.findByPk(request.advisorId, {
+  const advisorUser = await User.findByPk(request.advisorId, {
     attributes: ['id', 'email', 'fullName'],
   });
 
@@ -30,6 +26,15 @@ async function getAdvisorRequestDetails(requestId, userId) {
       attributes: ['id', 'email', 'fullName'],
     })
     : null;
+
+  const group = await Group.findByPk(request.groupId, {
+    attributes: ['id', 'name', 'leaderId'],
+  });
+
+  const professor = await Professor.findOne({
+    where: { userId: request.advisorId },
+    attributes: ['id', 'department', 'userId'],
+  });
 
   // Authorization check: Only the team leader can view the request
   const ownerId = request.teamLeaderId ?? group?.leaderId;
@@ -50,9 +55,31 @@ async function getAdvisorRequestDetails(requestId, userId) {
     decisionNote: request.note,
     createdAt: request.createdAt,
     updatedAt: request.updatedAt,
-    // Optional: Include related data if needed
-    group,
-    advisor,
+    group: group
+      ? {
+        id: group.id,
+        name: group.name,
+        teamLeader,
+      }
+      : null,
+    advisor: advisorUser
+      ? {
+        id: advisorUser.id,
+        email: advisorUser.email,
+        fullName: advisorUser.fullName,
+      }
+      : null,
+    professor: {
+      id: professor?.id ?? null,
+      department: professor?.department ?? null,
+      user: advisorUser
+        ? {
+          id: advisorUser.id,
+          email: advisorUser.email,
+          fullName: advisorUser.fullName,
+        }
+        : null,
+    },
     teamLeader,
   };
 }

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -11,6 +11,7 @@ require('../models');
 const {
   User,
   Group,
+  Professor,
   GroupAdvisorAssignment,
   AdvisorRequest,
   AuditLog,
@@ -373,4 +374,148 @@ test('orphan group cleanup works after advisor removal', async () => {
   
   const deleted = await Group.findByPk(group.id);
   assert.equal(deleted, null);
+});
+
+test('advisor notification endpoints filter by authenticated advisor and support mark-as-read', async () => {
+  const advisorA = await User.create({
+    email: 'advisor-a@example.com',
+    fullName: 'Advisor A',
+    role: 'PROFESSOR',
+    status: 'ACTIVE',
+  });
+  const advisorB = await User.create({
+    email: 'advisor-b@example.com',
+    fullName: 'Advisor B',
+    role: 'PROFESSOR',
+    status: 'ACTIVE',
+  });
+
+  await Notification.bulkCreate([
+    {
+      userId: advisorA.id,
+      type: 'ADVISOR_REQUEST',
+      payload: JSON.stringify({
+        requestId: 'req-a',
+        groupId: 'group-a',
+        groupName: 'Group A',
+        status: 'PENDING',
+      }),
+      status: 'SENT',
+    },
+    {
+      userId: advisorB.id,
+      type: 'ADVISOR_REQUEST',
+      payload: JSON.stringify({
+        requestId: 'req-b',
+        groupId: 'group-b',
+        groupName: 'Group B',
+        status: 'PENDING',
+      }),
+      status: 'SENT',
+    },
+    {
+      userId: advisorA.id,
+      type: 'GROUP_TRANSFER',
+      payload: JSON.stringify({
+        groupId: 'group-transfer-a',
+        groupName: 'Transfer A',
+        message: 'Transferred to you',
+      }),
+      status: 'SENT',
+    },
+  ]);
+
+  const headersA = await authHeaderFor(advisorA);
+
+  const adviseeResponse = await request('/api/v1/advisors/notifications/advisee-requests', {
+    headers: headersA,
+  });
+  assert.equal(adviseeResponse.response.status, 200);
+  assert.equal(adviseeResponse.json.count, 1);
+  assert.equal(adviseeResponse.json.data[0].groupName, 'Group A');
+  assert.equal(adviseeResponse.json.data[0].isRead, false);
+
+  const transferResponse = await request('/api/v1/advisors/notifications/group-transfers', {
+    headers: headersA,
+  });
+  assert.equal(transferResponse.response.status, 200);
+  assert.equal(transferResponse.json.count, 1);
+  assert.equal(transferResponse.json.data[0].groupName, 'Transfer A');
+
+  const notificationId = adviseeResponse.json.data[0].id;
+  const markReadResponse = await request(`/api/v1/advisors/notifications/advisee-request/${notificationId}/read`, {
+    method: 'PUT',
+    headers: headersA,
+  });
+  assert.equal(markReadResponse.response.status, 200);
+  assert.equal(markReadResponse.json.notification.isRead, true);
+
+  const updatedNotification = await Notification.findByPk(notificationId);
+  assert.equal(updatedNotification.status, 'READ');
+
+  const forbiddenRead = await request(`/api/v1/advisors/notifications/advisee-request/${notificationId}/read`, {
+    method: 'PUT',
+    headers: await authHeaderFor(advisorB),
+  });
+  assert.equal(forbiddenRead.response.status, 404);
+});
+
+test('team leader can view their advisor request details but others cannot', async () => {
+  const leader = await User.create({
+    email: 'leader-details@example.com',
+    fullName: 'Leader Details',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070008888',
+    password: 'irrelevant',
+  });
+  const outsider = await User.create({
+    email: 'outsider-details@example.com',
+    fullName: 'Outsider Details',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    studentId: '11070007777',
+    password: 'irrelevant',
+  });
+  const advisorUser = await User.create({
+    email: 'advisor-details@example.com',
+    fullName: 'Advisor Details',
+    role: 'PROFESSOR',
+    status: 'ACTIVE',
+    password: 'irrelevant',
+  });
+  const professor = await Professor.create({
+    userId: advisorUser.id,
+    department: 'Computer Engineering',
+  });
+  const group = await Group.create({
+    id: '11111111-1111-1111-1111-111111111111',
+    name: 'Detail Group',
+    leaderId: leader.id,
+    memberIds: [leader.id],
+    maxMembers: 4,
+    status: 'FORMATION',
+  });
+  const advisorRequest = await AdvisorRequest.create({
+    id: '22222222-2222-2222-2222-222222222222',
+    groupId: group.id,
+    advisorId: advisorUser.id,
+    teamLeaderId: leader.id,
+    status: 'PENDING',
+  });
+
+  const okResponse = await request(`/api/v1/advisor-requests/${advisorRequest.id}`, {
+    headers: await authHeaderFor(leader),
+  });
+  assert.equal(okResponse.response.status, 200);
+  assert.equal(okResponse.json.id, advisorRequest.id);
+  assert.equal(okResponse.json.group.id, group.id);
+  assert.equal(okResponse.json.group.teamLeader.id, leader.id);
+  assert.equal(okResponse.json.professor.id, professor.id);
+  assert.equal(okResponse.json.professor.user.id, advisorUser.id);
+
+  const forbiddenResponse = await request(`/api/v1/advisor-requests/${advisorRequest.id}`, {
+    headers: await authHeaderFor(outsider),
+  });
+  assert.equal(forbiddenResponse.response.status, 403);
 });

--- a/frontend/src/AdvisorRequestDetailsView.jsx
+++ b/frontend/src/AdvisorRequestDetailsView.jsx
@@ -80,6 +80,9 @@ function AdvisorRequestDetailsView({ requestId, authToken, onClose }) {
     });
   };
 
+  const professorUser = request?.professor?.user || request?.advisor || null;
+  const teamLeader = request?.group?.teamLeader || request?.teamLeader || null;
+
   if (loading) {
     return (
       <div className="advisor-request-view loading">
@@ -168,22 +171,40 @@ function AdvisorRequestDetailsView({ requestId, authToken, onClose }) {
                 <label>Group Name</label>
                 <span className="value">{request.group.name}</span>
               </div>
+              {teamLeader && (
+                <>
+                  <div className="info-item">
+                    <label>Team Leader</label>
+                    <span className="value">{teamLeader.fullName}</span>
+                  </div>
+                  <div className="info-item">
+                    <label>Team Leader Email</label>
+                    <span className="value">{teamLeader.email}</span>
+                  </div>
+                </>
+              )}
             </div>
           </div>
         )}
 
-        {request.advisor && (
+        {(request.advisor || request.professor) && (
           <div className="request-section">
             <h3>Requested Advisor</h3>
             <div className="info-grid">
               <div className="info-item">
                 <label>Name</label>
-                <span className="value">{request.advisor.fullName}</span>
+                <span className="value">{professorUser?.fullName}</span>
               </div>
               <div className="info-item">
                 <label>Email</label>
-                <span className="value">{request.advisor.email}</span>
+                <span className="value">{professorUser?.email}</span>
               </div>
+              {request.professor?.department && (
+                <div className="info-item">
+                  <label>Department</label>
+                  <span className="value">{request.professor.department}</span>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,7 @@ import Register from './Register';
 import StudentLoginPage from './StudentLoginPage';
 import StudentGroupShellPage from './StudentGroupShellPage';
 import StudentInvitationsPage from './StudentInvitationsPage';
+import SubmitAdvisorRequestPage from './SubmitAdvisorRequestPage';
 import TeamLeaderAdvisorRequestDetailsPage from './TeamLeaderAdvisorRequestDetailsPage';
 import AppShell from './components/AppShell';
 import { AuthProvider } from './contexts/AuthContext';
@@ -40,6 +41,7 @@ export default function App() {
               <Route path="/students/login" element={<AuthPage />} />
               <Route path="/students/groups/new" element={<StudentGroupShellPage />} />
               <Route path="/students/notifications" element={<StudentInvitationsPage />} />
+              <Route path="/team-leader/advisor-requests/new" element={<SubmitAdvisorRequestPage />} />
               <Route path="/team-leader/advisor-requests/:requestId" element={<TeamLeaderAdvisorRequestDetailsPage />} />
               <Route path="/professors/login" element={<AuthPage />} />
               <Route path="/professors/notifications" element={<ProfessorAdvisorRequestsPage />} />

--- a/frontend/src/ProfessorAdvisorRequestsPage.jsx
+++ b/frontend/src/ProfessorAdvisorRequestsPage.jsx
@@ -32,6 +32,7 @@ function normalizeAdviseeNotification(entry) {
     groupName: entry?.groupName || group?.name || null,
     createdAt: entry?.createdAt || advisorRequest?.createdAt || null,
     status: entry?.status || (entry?.isRead ? 'READ' : 'UNREAD'),
+    isRead: Boolean(entry?.isRead || entry?.status === 'READ'),
     message: entry?.message || null,
     note: entry?.note ?? null,
     decidedAt: entry?.decidedAt ?? null,
@@ -47,6 +48,7 @@ function normalizeTransferNotification(entry) {
     groupName: entry?.groupName || group?.name || null,
     createdAt: entry?.createdAt || null,
     status: entry?.status || (entry?.isRead ? 'READ' : 'UNREAD'),
+    isRead: Boolean(entry?.isRead || entry?.status === 'READ'),
     message: entry?.message || entry?.reason || null,
     reason: entry?.reason || null,
   };
@@ -230,6 +232,51 @@ export default function ProfessorAdvisorRequestsPage() {
   const selectedRequestBusy = selectedRequest && submittingDecision === selectedRequest.requestId;
   const canDecide = selectedRequest?.requestId && selectedRequest?.requestStatus === 'PENDING';
 
+  async function markNotificationAsRead(type, id) {
+    const token = getProfessorToken();
+    if (!token || !id) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/v1/advisors/notifications/${type}/${id}/read`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        return;
+      }
+
+      if (type === 'advisee-request') {
+        setRequests((current) => current.map((entry) => (
+          entry.id === id
+            ? {
+              ...entry,
+              status: 'READ',
+              isRead: true,
+            }
+            : entry
+        )));
+        return;
+      }
+
+      setTransferNotifications((current) => current.map((entry) => (
+        entry.id === id
+          ? {
+            ...entry,
+            status: 'READ',
+            isRead: true,
+          }
+          : entry
+      )));
+    } catch {
+      // Keep mailbox interaction resilient; a failed read update should not block the UI.
+    }
+  }
+
   async function handleDecision(decision) {
     if (!selectedRequest?.requestId) {
       setFeedback({
@@ -318,14 +365,23 @@ export default function ProfessorAdvisorRequestsPage() {
 
           {!loadingTransfers && !transferLoadError && transferNotifications.length > 0 && (
             <section className="mail-nav" aria-label="Group transfer notification list">
-              {transferNotifications.map((entry) => (
-                <article key={entry.id} className="mail-nav-item">
-                  <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
-                  <span className="mail-nav-subject">{buildTransferSubject(entry)}</span>
-                  <span className="mail-nav-preview">{buildTransferPreview(entry)}</span>
-                </article>
-              ))}
-            </section>
+                {transferNotifications.map((entry) => (
+                  <button
+                    key={entry.id}
+                    type="button"
+                    className="mail-nav-item"
+                    onClick={() => {
+                      if (!entry.isRead) {
+                        markNotificationAsRead('group-transfer', entry.id);
+                      }
+                    }}
+                  >
+                    <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
+                    <span className="mail-nav-subject">{buildTransferSubject(entry)}</span>
+                    <span className="mail-nav-preview">{buildTransferPreview(entry)}</span>
+                  </button>
+                ))}
+              </section>
           )}
         </div>
 
@@ -357,7 +413,12 @@ export default function ProfessorAdvisorRequestsPage() {
                       key={entry.id}
                       type="button"
                       className={`mail-nav-item${isActive ? ' mail-nav-item-active' : ''}`}
-                      onClick={() => setSelectedRequestId(entry.id)}
+                      onClick={() => {
+                        setSelectedRequestId(entry.id);
+                        if (!entry.isRead) {
+                          markNotificationAsRead('advisee-request', entry.id);
+                        }
+                      }}
                     >
                       <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
                       <span className="mail-nav-subject">{buildSubject(entry)}</span>

--- a/frontend/src/StudentGroupShellPage.jsx
+++ b/frontend/src/StudentGroupShellPage.jsx
@@ -458,6 +458,7 @@ export default function StudentGroupShellPage() {
 
                   <div className="invite-form-actions">
                     <button type="button" onClick={() => setShowAddGroupModal(true)}>Add Group</button>
+                    <Link to="/team-leader/advisor-requests/new">Request Advisor</Link>
                     <button type="button" onClick={handleDeleteSelectedGroup}>Delete Group</button>
                   </div>
                 </>

--- a/frontend/src/StudentInvitationsPage.jsx
+++ b/frontend/src/StudentInvitationsPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useNotification } from './contexts/NotificationContext';
 import { useStudentInvitations } from './hooks/useStudentInvitations';
 
@@ -99,6 +100,10 @@ function formatAdvisorDecisionPreview(entry) {
   return groupLabel
     ? `${groupLabel} advisor request was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`
     : `Your advisor request was ${decision === 'APPROVED' ? 'approved' : 'rejected'}.`;
+}
+
+function getAdvisorDecisionRequestId(entry) {
+  return entry.requestId || entry.payload?.requestId || null;
 }
 
 function formatAdvisorReleaseSubject(entry) {
@@ -572,6 +577,14 @@ export default function StudentInvitationsPage() {
               <p className="field-error" role="alert" aria-live="polite">
                 {selectedError}
               </p>
+            )}
+
+            {selectedMail.type === 'ADVISOR_DECISION' && getAdvisorDecisionRequestId(selectedMail) && (
+              <div className="mail-actions">
+                <Link to={`/team-leader/advisor-requests/${getAdvisorDecisionRequestId(selectedMail)}`}>
+                  View request details
+                </Link>
+              </div>
             )}
           </section>
         </div>

--- a/frontend/src/SubmitAdvisorRequestPage.jsx
+++ b/frontend/src/SubmitAdvisorRequestPage.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import apiClient from '../services/apiClient';
+import { useEffect, useState } from 'react';
+import apiClient from './services/apiClient';
 
 const initialForm = {
   groupId: '',
@@ -12,16 +12,22 @@ const initialFeedback = {
   result: '',
 };
 
+const initialFieldErrors = {
+  groupId: [],
+  professorId: [],
+};
+
 export default function SubmitAdvisorRequestPage() {
   const [form, setForm] = useState(initialForm);
   const [feedback, setFeedback] = useState(initialFeedback);
+  const [fieldErrors, setFieldErrors] = useState(initialFieldErrors);
   const [groups, setGroups] = useState([]);
   const [professors, setProfessors] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
-    const loadData = async () => {
+    async function loadData() {
       try {
         const [groupsRes, professorsRes] = await Promise.all([
           apiClient.get('/v1/groups/my-groups'),
@@ -29,35 +35,44 @@ export default function SubmitAdvisorRequestPage() {
         ]);
         setGroups(groupsRes.data || []);
         setProfessors(professorsRes.data || []);
+        setFeedback(initialFeedback);
       } catch (error) {
-        console.error('Failed to load data:', error);
+        console.error('Failed to load advisor request form data:', error);
         setFeedback({
           status: 'error',
           title: 'Error',
-          result: error.mappedError?.result || 'Failed to load groups and professors',
+          result: error.response?.data?.message || 'Failed to load groups and professors.',
         });
       } finally {
         setIsLoading(false);
       }
-    };
+    }
 
     loadData();
   }, []);
 
-  const handleChange = (e) => {
-    const { name, value } = e.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
-  };
+  function handleChange(event) {
+    const { name, value } = event.target;
+    setForm((current) => ({ ...current, [name]: value }));
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
+    if (fieldErrors[name]?.length > 0) {
+      setFieldErrors((current) => ({
+        ...current,
+        [name]: [],
+      }));
+    }
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
     setFeedback({ status: 'loading', title: '', result: '' });
+    setFieldErrors(initialFieldErrors);
     setIsSubmitting(true);
 
     try {
       await apiClient.post('/v1/advisor-requests', {
-        groupId: parseInt(form.groupId, 10),
-        professorId: parseInt(form.professorId, 10),
+        groupId: form.groupId,
+        professorId: Number(form.professorId),
       });
 
       setFeedback({
@@ -65,20 +80,122 @@ export default function SubmitAdvisorRequestPage() {
         title: 'Request Submitted',
         result: 'Your advisor request has been submitted successfully.',
       });
-
       setForm(initialForm);
 
       const groupsRes = await apiClient.get('/v1/groups/my-groups');
       setGroups(groupsRes.data || []);
     } catch (error) {
-      console.error('Submit error:', error);
-      const errorData = error.response?.data;
+      console.error('Submit advisor request error:', error);
+      const errorData = error.response?.data || {};
+      setFieldErrors({
+        groupId: errorData.errors?.groupId || [],
+        professorId: errorData.errors?.professorId || errorData.errors?.advisorId || [],
+      });
       setFeedback({
         status: 'error',
-        title: errorData?.code || 'Error',
-        result: errorData?.message || error.mappedError?.result || 'Failed to submit request',
+        title: errorData.code || 'Error',
+        result: errorData.message || 'Failed to submit request.',
       });
     } finally {
       setIsSubmitting(false);
     }
-  };\n\n  if (isLoading) {\n    return (\n      <div className=\"page\">\n        <div className=\"feedback feedback-loading\">\n          <h2>Loading...</h2>\n        </div>\n      </div>\n    );\n  }\n\n  return (\n    <div className=\"page\">\n      <div className=\"hero\">\n        <h1>Submit Advisor Request</h1>\n        <p className=\"subtitle\">Request a professor to be your group's advisor</p>\n      </div>\n\n      <div className=\"panel\">\n        <form className=\"form\" onSubmit={handleSubmit}>\n          <div className=\"field\">\n            <span>Your Group *</span>\n            <select\n              name=\"groupId\"\n              value={form.groupId}\n              onChange={handleChange}\n              disabled={isSubmitting}\n              required\n            >\n              <option value=\"\">-- Select a group --</option>\n              {groups.map((group) => (\n                <option key={group.id} value={group.id}>\n                  {group.name}\n                  {group.advisorId ? ' (Already has advisor)' : ''}\n                </option>\n              ))}\n            </select>\n          </div>\n\n          <div className=\"field\">\n            <span>Select Professor *</span>\n            <select\n              name=\"professorId\"\n              value={form.professorId}\n              onChange={handleChange}\n              disabled={isSubmitting}\n              required\n            >\n              <option value=\"\">-- Select a professor --</option>\n              {professors.map((prof) => (\n                <option key={prof.id} value={prof.id}>\n                  {prof.fullName}\n                </option>\n              ))}\n            </select>\n          </div>\n\n          <button\n            type=\"submit\"\n            disabled={\n              isSubmitting\n              || !form.groupId\n              || !form.professorId\n              || groups.length === 0\n              || professors.length === 0\n            }\n          >\n            {isSubmitting ? 'Submitting...' : 'Submit Request'}\n          </button>\n        </form>\n\n        {feedback.status && (\n          <div className={`feedback feedback-${feedback.status}`}>\n            <div className=\"feedback-label\">{feedback.status}</div>\n            {feedback.title && <h2>{feedback.title}</h2>}\n            <p>{feedback.result}</p>\n          </div>\n        )}\n      </div>\n    </div>\n  );\n}
+  }
+
+  if (isLoading) {
+    return (
+      <div className="page">
+        <div className="feedback feedback-loading">
+          <h2>Loading...</h2>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page">
+      <div className="hero">
+        <h1>Submit Advisor Request</h1>
+        <p className="subtitle">Request a professor to be your group&apos;s advisor.</p>
+      </div>
+
+      <div className="panel">
+        <form className="form" onSubmit={handleSubmit}>
+          <label className="field">
+            <span>Your Group *</span>
+            <select
+              name="groupId"
+              value={form.groupId}
+              onChange={handleChange}
+              disabled={isSubmitting}
+              aria-invalid={fieldErrors.groupId.length > 0}
+              required
+            >
+              <option value="">-- Select a group --</option>
+              {groups.map((group) => (
+                <option key={group.id} value={group.id}>
+                  {group.name}
+                  {group.advisorId ? ' (Already has advisor)' : ''}
+                </option>
+              ))}
+            </select>
+            {fieldErrors.groupId.length > 0 && (
+              <div className="field-error" role="alert">
+                {fieldErrors.groupId.map((error) => (
+                  <p key={error}>{error}</p>
+                ))}
+              </div>
+            )}
+          </label>
+
+          <label className="field">
+            <span>Select Professor *</span>
+            <select
+              name="professorId"
+              value={form.professorId}
+              onChange={handleChange}
+              disabled={isSubmitting}
+              aria-invalid={fieldErrors.professorId.length > 0}
+              required
+            >
+              <option value="">-- Select a professor --</option>
+              {professors.map((professor) => (
+                <option key={professor.id} value={professor.id}>
+                  {professor.fullName}
+                  {professor.department ? ` (${professor.department})` : ''}
+                </option>
+              ))}
+            </select>
+            {fieldErrors.professorId.length > 0 && (
+              <div className="field-error" role="alert">
+                {fieldErrors.professorId.map((error) => (
+                  <p key={error}>{error}</p>
+                ))}
+              </div>
+            )}
+          </label>
+
+          <button
+            type="submit"
+            disabled={
+              isSubmitting
+              || !form.groupId
+              || !form.professorId
+              || groups.length === 0
+              || professors.length === 0
+            }
+          >
+            {isSubmitting ? 'Submitting...' : 'Submit Request'}
+          </button>
+        </form>
+
+        {feedback.status && (
+          <div className={`feedback feedback-${feedback.status}`} aria-live="polite">
+            <div className="feedback-label">{feedback.status}</div>
+            {feedback.title && <h2>{feedback.title}</h2>}
+            <p>{feedback.result}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This PR fixes the regressions introduced after merging the advisor request detail, advisor request validation/submission, and advisor notification filtering work.

It stabilizes the merged flows across backend and frontend so that:
- team leaders can submit advisor requests again
- team leaders can open advisor request details from the UI
- professors only see their own advisor-related notifications
- advisor notifications can be marked as read
- merged route and response-shape conflicts no longer break the app

## What Changed

### Backend
- removed the duplicate advisor-request detail route wiring and kept the canonical `GET /api/v1/advisor-requests/:requestId` flow
- connected advisor request detail retrieval to the existing advisor request route set
- aligned advisor request detail responses so the current UI can safely consume:
  - request metadata
  - group info
  - team leader info
  - professor/advisor info
- added support for both `advisorId` and `professorId` request payloads when creating advisor requests
- added advisor notification read support:
  - `PUT /api/v1/advisors/notifications/:type/:notificationId/read`
- normalized advisor notification list responses to return:
  - `data`
  - `count`
  - `isRead`
- extended the `Notification` model to support `READ` status
- added professor listing endpoints required by the request submission UI:
  - `GET /api/v1/professors`
  - `GET /api/v1/professors/list`
- removed the extra parallel advisor detail route mount from `backend/app.js`

### Frontend
- restored a working team leader advisor request submission page
- registered the advisor request submission route:
  - `/team-leader/advisor-requests/new`
- registered and kept the advisor request detail page route:
  - `/team-leader/advisor-requests/:requestId`
- updated the advisor request detail view to support the merged backend response shape
- added a “Request Advisor” entry point from the student group management page
- added a “View request details” link from student advisor decision notifications
- updated the professor inbox page to:
  - consume the normalized filtered notification response
  - mark advisor notifications as read without page refresh

## Endpoints Covered

- `POST /api/v1/advisor-requests`
- `GET /api/v1/advisor-requests/:requestId`
- `GET /api/v1/advisors/notifications/advisee-requests`
- `GET /api/v1/advisors/notifications/group-transfers`
- `PUT /api/v1/advisors/notifications/:type/:notificationId/read`
- `GET /api/v1/professors`
- `GET /api/v1/professors/list`

## Verification

Ran:

```bash
cd frontend
npm run build
