### PR TITLE
fix: restore group cleanup and advisor group flows

### DIFF
--- a/backend/controllers/advisorRequestController.js
+++ b/backend/controllers/advisorRequestController.js
@@ -3,6 +3,7 @@ const { Op } = require('sequelize');
 const { body, validationResult } = require('express-validator');
 const { AdvisorRequest, Group, Professor, User } = require('../models');
 const { processDecision } = require('../services/advisorRequestService');
+const NotificationService = require('../services/notificationService');
 
 const buildErrorResponse = (message, code) => ({
   message,
@@ -96,11 +97,30 @@ const createAdvisorRequest = [
         where: {
           groupId,
           advisorId,
-          status: { [Op.in]: ['PENDING', 'APPROVED'] },
+          status: 'PENDING',
         },
       });
 
       if (existingRequest) {
+        return res.status(409).json({
+          code: 'REQUEST_ALREADY_EXISTS',
+          message: 'An advisor request already exists for this group and advisor',
+          errors: {
+            groupId: ['An advisor request already exists for this group and advisor'],
+          },
+        });
+      }
+
+      const existingApprovedRequest = await AdvisorRequest.findOne({
+        where: {
+          groupId,
+          advisorId,
+          status: 'APPROVED',
+        },
+        order: [['updatedAt', 'DESC']],
+      });
+
+      if (existingApprovedRequest && String(group.advisorId || '') === String(advisorId)) {
         return res.status(409).json({
           code: 'REQUEST_ALREADY_EXISTS',
           message: 'An advisor request already exists for this group and advisor',
@@ -116,6 +136,15 @@ const createAdvisorRequest = [
         advisorId,
         teamLeaderId: req.user.id,
         status: 'PENDING',
+      });
+
+      await NotificationService.notifyAdvisorRequestReceived({
+        advisorId,
+        requestId: advisorRequest.id,
+        groupId,
+        groupName: group.name,
+        teamLeaderId: req.user.id,
+        teamLeaderName: req.user.fullName || null,
       });
 
       return res.status(201).json({

--- a/backend/controllers/groupController.js
+++ b/backend/controllers/groupController.js
@@ -247,6 +247,40 @@ exports.getGroupMembership = async (req, res) => {
 
     const { groupId } = req.params;
     const groupData = await GroupService.getGroupMembership(groupId);
+    const leaderId = groupData.leaderId ? String(groupData.leaderId) : null;
+    const memberIds = Array.isArray(groupData.memberIds) ? groupData.memberIds.map((id) => String(id)) : [];
+    const participantIds = [...new Set([leaderId, ...memberIds].filter(Boolean))];
+
+    const users = participantIds.length > 0
+      ? await User.findAll({
+        where: { id: { [Op.in]: participantIds } },
+        attributes: ['id', 'fullName', 'studentId', 'email'],
+      })
+      : [];
+
+    const usersById = new Map(users.map((user) => [String(user.id), user]));
+
+    const advisorUser = groupData.advisorId
+      ? await User.findByPk(groupData.advisorId, { attributes: ['id', 'fullName', 'email'] })
+      : null;
+
+    const advisorProfessor = groupData.advisorId
+      ? await Professor.findOne({
+        where: { userId: groupData.advisorId },
+        attributes: ['userId', 'department', 'fullName'],
+      })
+      : null;
+
+    const members = participantIds.map((id) => {
+      const user = usersById.get(String(id));
+      return {
+        id: String(id),
+        fullName: user?.fullName || 'Unknown Student',
+        studentId: user?.studentId || null,
+        email: user?.email || null,
+        isLeader: String(id) === leaderId,
+      };
+    });
 
     res.status(200).json({
       code: 'SUCCESS',
@@ -256,10 +290,20 @@ exports.getGroupMembership = async (req, res) => {
         groupName: groupData.name,
         status: groupData.status,
         advisorId: groupData.advisorId || null,
+        advisor: advisorUser
+          ? {
+            id: advisorUser.id,
+            fullName: advisorProfessor?.fullName || advisorUser.fullName,
+            email: advisorUser.email,
+            department: advisorProfessor?.department || null,
+          }
+          : null,
+        leaderId,
         maxMembers: groupData.maxMembers,
-        members: groupData.memberIds,
-        currentMemberCount: groupData.memberIds.length,
-        availableSlots: groupData.maxMembers - groupData.memberIds.length,
+        memberIds: members.map((member) => member.id),
+        members,
+        currentMemberCount: members.length,
+        availableSlots: Math.max(groupData.maxMembers - members.length, 0),
       },
     });
   } catch (error) {

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -1,5 +1,10 @@
 const Group = require('../models/Group');
-const { Invitation, AuditLog } = require('../models');
+const {
+  Invitation,
+  AuditLog,
+  AdvisorRequest,
+  GroupAdvisorAssignment,
+} = require('../models');
 const sequelize = require('../db');
 const NotificationService = require('./notificationService');
 const mentorMatchingService = require('./mentorMatchingService');
@@ -90,6 +95,8 @@ class GroupService {
 
     try {
       await Invitation.destroy({ where: { groupId: group.id } });
+      await AdvisorRequest.destroy({ where: { groupId: group.id } });
+      await GroupAdvisorAssignment.destroy({ where: { groupId: group.id } });
       await group.destroy();
 
       await AuditLog.create({

--- a/backend/services/notificationService.js
+++ b/backend/services/notificationService.js
@@ -1,6 +1,51 @@
 const { Notification } = require('../models');
 
 class NotificationService {
+  static async notifyAdvisorRequestReceived({
+    advisorId,
+    requestId,
+    groupId,
+    groupName,
+    teamLeaderId = null,
+    teamLeaderName = null,
+    message = null,
+  }) {
+    const fallbackMessage = groupName
+      ? `A team leader submitted an advisor request for ${groupName}.`
+      : 'A team leader submitted an advisor request.';
+    let row;
+
+    try {
+      row = await Notification.create({
+        userId: advisorId,
+        type: 'ADVISOR_REQUEST',
+        payload: JSON.stringify({
+          requestId,
+          groupId,
+          groupName,
+          teamLeaderId,
+          teamLeaderName,
+          message: message || fallbackMessage,
+          requestStatus: 'PENDING',
+        }),
+        status: 'PENDING',
+      });
+    } catch (error) {
+      console.error('[NotificationService] Failed to persist advisor request notification', error);
+      return;
+    }
+
+    await NotificationService.#pushAndMark(row, `user:${advisorId}`, {
+      requestId,
+      groupId,
+      groupName,
+      teamLeaderId,
+      teamLeaderName,
+      message: message || fallbackMessage,
+      requestStatus: 'PENDING',
+    });
+  }
+
   static async notifyTeamLeaderAdvisorDecision({
     leaderId,
     requestId,

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -584,25 +584,30 @@ test('orphan group cleanup works after advisor removal', async () => {
     role: 'PROFESSOR',
     status: 'ACTIVE',
   });
-
-  await Professor.create({
-    userId: usedProfessorUser.id,
-    department: 'Software Engineering',
+  
+  const group = await Group.create({
+    name: 'Cleanup Group',
+    maxMembers: 4,
+    leaderId: null,
+    memberIds: [],
+    advisorId: advisor.id,
   });
-
-  const usedResult = await request('/api/v1/password-setup-token-store/verify', {
-    method: 'POST',
+  
+  const headers = await authHeaderFor(admin);
+  await request(`/api/v1/group-database/groups/${group.id}/advisor-assignment`, {
+    method: 'DELETE',
     headers,
-    body: JSON.stringify({
-      setupToken: usedSetupToken,
-    }),
   });
-
-  assert.equal(usedResult.response.status, 200);
-  assert.deepEqual(usedResult.json, {
-    valid: false,
-    message: 'Setup token is invalid, expired, or already used',
+  
+  const res = await request(`/api/v1/group-database/groups/${group.id}`, {
+    method: 'DELETE',
+    headers,
   });
+  assert.equal(res.response.status, 200);
+  assert.equal(res.json.code, 'SUCCESS');
+  
+  const deleted = await Group.findByPk(group.id);
+  assert.equal(deleted, null);
 });
 
 test('internal professor record endpoint requires admin auth, persists record, and rejects duplicates', async () => {
@@ -1932,30 +1937,14 @@ test('[E2E NOTIFICATIONS] leader receives notification after invitee accepts', a
   const emittedEventLines = allNotifications.filter((log) =>
     log.includes('[NotificationService] Event emitted')
   );
-  
-  const group = await Group.create({
-    name: 'Cleanup Group',
-    maxMembers: 4,
-    leaderId: null,
-    memberIds: [],
-    advisorId: advisor.id,
-  });
-  
-  const headers = await authHeaderFor(admin);
-  await request(`/api/v1/group-database/groups/${group.id}/advisor-assignment`, {
-    method: 'DELETE',
-    headers,
-  });
-  
-  const res = await request(`/api/v1/group-database/groups/${group.id}`, {
-    method: 'DELETE',
-    headers,
-  });
-  assert.equal(res.response.status, 200);
-  assert.equal(res.json.code, 'SUCCESS');
-  
-  const deleted = await Group.findByPk(group.id);
-  assert.equal(deleted, null);
+
+  assert.equal(emittedEventLines.length, 2);
+  assert.ok(
+    emittedEventLines.every((line) => line.includes('GROUP_MEMBERSHIP_ACCEPTED')),
+    'Expected membership acceptance notifications to be emitted for the leader',
+  );
+
+  console.log = originalLog;
 });
 
 test('advisor notification endpoints filter by authenticated advisor and support mark-as-read', async () => {
@@ -2100,4 +2089,54 @@ test('team leader can view their advisor request details but others cannot', asy
     headers: await authHeaderFor(outsider),
   });
   assert.equal(forbiddenResponse.response.status, 403);
+});
+
+test('team leader can submit a new request to the same advisor after advisor release', async () => {
+  const leader = await createStudent({
+    studentId: '11070001002',
+    email: 'leader-rerequest@example.edu',
+    fullName: 'Leader Rerequest',
+    password: 'StrongPass1!',
+  });
+  const advisor = await createProfessorUser({
+    email: 'advisor-rerequest@example.edu',
+    fullName: 'Advisor Rerequest',
+  });
+  const group = await Group.create({
+    name: 'Rerequest Group',
+    leaderId: leader.id,
+    memberIds: [leader.id],
+    advisorId: advisor.id,
+    status: 'HAS_ADVISOR',
+    maxMembers: 4,
+  });
+
+  await AdvisorRequest.create({
+    id: '33333333-3333-3333-3333-333333333333',
+    groupId: group.id,
+    advisorId: advisor.id,
+    teamLeaderId: leader.id,
+    status: 'APPROVED',
+  });
+
+  await request(`/api/v1/groups/${group.id}/advisor-release`, {
+    method: 'PATCH',
+    headers: await authHeaderFor(advisor),
+  });
+
+  const retryResponse = await request('/api/v1/advisor-requests', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      groupId: group.id,
+      professorId: advisor.id,
+    }),
+  });
+
+  assert.equal(retryResponse.response.status, 201);
+  assert.equal(retryResponse.json.status, 'PENDING');
+  assert.equal(retryResponse.json.advisorId, advisor.id);
 });

--- a/frontend/src/AdminHomePage.jsx
+++ b/frontend/src/AdminHomePage.jsx
@@ -34,6 +34,14 @@ const adminTools = [
     cta: 'Open Add Coordinator',
     status: 'Ready',
   },
+  {
+    eyebrow: 'Groups',
+    title: 'Group Cleanup',
+    description: 'Delete orphan groups from the group database when they no longer have an assigned advisor.',
+    href: '/admin/groups/cleanup',
+    cta: 'Open Cleanup Tool',
+    status: 'Ready',
+  },
 ];
 
 export default function AdminHomePage() {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import AdminProfessorCreatePage from './AdminProfessorCreatePage';
 import AuthPage from './AuthPage';
 import CoordinatorGroupMembershipPage from './CoordinatorGroupMembershipPage';
 import CoordinatorAdvisorTransferPage from './CoordinatorAdvisorTransferPage';
+import GroupCleanupPage from './GroupCleanupPage';
 import CoordinatorHomePage from './CoordinatorHomePage';
 import CoordinatorLoginPage from './CoordinatorLoginPage';
 import CoordinatorStudentIdUploadPage from './CoordinatorStudentIdUploadPage';
@@ -39,6 +40,7 @@ export default function App() {
               <Route path="/auth" element={<AuthPage />} />
               <Route path="/students/register" element={<AuthPage />} />
               <Route path="/students/login" element={<AuthPage />} />
+              <Route path="/students/groups/manage" element={<StudentGroupShellPage />} />
               <Route path="/students/groups/new" element={<StudentGroupShellPage />} />
               <Route path="/students/notifications" element={<StudentInvitationsPage />} />
               <Route path="/team-leader/advisor-requests/new" element={<SubmitAdvisorRequestPage />} />
@@ -50,11 +52,13 @@ export default function App() {
               <Route path="/admin" element={<AdminHomePage />} />
               <Route path="/admin/professors/new" element={<AdminProfessorCreatePage />} />
               <Route path="/admin/coordinators/new" element={<AdminCoordinatorCreatePage />} />
+              <Route path="/admin/groups/cleanup" element={<GroupCleanupPage role="ADMIN" />} />
               <Route path="/coordinator/login" element={<AuthPage />} />
               <Route path="/coordinator" element={<CoordinatorHomePage />} />
               <Route path="/coordinator/student-id-registry/import" element={<CoordinatorStudentIdUploadPage />} />
               <Route path="/coordinator/groups/manage" element={<CoordinatorGroupMembershipPage />} />
               <Route path="/coordinator/groups/transfer" element={<CoordinatorAdvisorTransferPage />} />
+              <Route path="/coordinator/groups/cleanup" element={<GroupCleanupPage role="COORDINATOR" />} />
               <Route path="/groups/:groupId" element={<GroupPage />} />
               <Route path="/advisor/requests" element={<AdvisorRequestsPage />} />
               <Route path="*" element={<HomePage />} />

--- a/frontend/src/CoordinatorHomePage.jsx
+++ b/frontend/src/CoordinatorHomePage.jsx
@@ -41,6 +41,14 @@ const coordinatorTools = [
     cta: 'Open Transfer Tool',
     status: 'Ready',
   },
+  {
+    eyebrow: 'Groups',
+    title: 'Group Cleanup',
+    description: 'Delete orphan groups from the group database when they no longer have an assigned advisor.',
+    href: '/coordinator/groups/cleanup',
+    cta: 'Open Cleanup Tool',
+    status: 'Ready',
+  },
 ];
 
 export default function CoordinatorHomePage() {

--- a/frontend/src/GroupCleanupPage.jsx
+++ b/frontend/src/GroupCleanupPage.jsx
@@ -1,0 +1,263 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useNotification } from './contexts/NotificationContext';
+
+const ROLE_CONFIG = {
+  ADMIN: {
+    tokenKey: 'adminToken',
+    loginPath: '/admin/login',
+    homePath: '/admin',
+    eyebrow: 'Admin Workspace',
+    title: 'Delete Group Records',
+    subtitle: 'Delete orphan groups from the group database when they no longer have an assigned advisor.',
+    backLabel: 'Back to Admin Workspace',
+  },
+  COORDINATOR: {
+    tokenKey: 'coordinatorToken',
+    loginPath: '/coordinator/login',
+    homePath: '/coordinator',
+    eyebrow: 'Coordinator Workspace',
+    title: 'Delete Group Records',
+    subtitle: 'Clean up orphan groups from the group database after advisor removal or abandoned group formation.',
+    backLabel: 'Back to Coordinator Workspace',
+  },
+};
+
+const initialFeedback = {
+  type: 'idle',
+  title: 'Ready',
+  message: 'Select a group to review whether it can be removed from the group database.',
+};
+
+function normalizeGroups(payload) {
+  return Array.isArray(payload?.data) ? payload.data : [];
+}
+
+export default function GroupCleanupPage({ role = 'COORDINATOR' }) {
+  const config = ROLE_CONFIG[role] || ROLE_CONFIG.COORDINATOR;
+  const [groups, setGroups] = useState([]);
+  const [selectedGroupId, setSelectedGroupId] = useState('');
+  const [loadingGroups, setLoadingGroups] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState(initialFeedback);
+
+  const navigate = useNavigate();
+  const { notify } = useNotification();
+  const token = window.localStorage.getItem(config.tokenKey) || '';
+
+  useEffect(() => {
+    if (token) {
+      return;
+    }
+
+    notify({
+      type: 'warning',
+      title: `${role === 'ADMIN' ? 'Admin' : 'Coordinator'} login required`,
+      message: 'Please sign in before opening group cleanup.',
+    });
+    navigate(config.loginPath, { replace: true });
+  }, [config.loginPath, navigate, notify, role, token]);
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    async function fetchGroups() {
+      setLoadingGroups(true);
+      try {
+        const response = await fetch('/api/v1/groups', {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(payload.message || 'Could not load group data.');
+        }
+
+        const rows = normalizeGroups(payload);
+        setGroups(rows);
+        setSelectedGroupId((current) => {
+          if (current && rows.some((item) => String(item.groupId) === String(current))) {
+            return current;
+          }
+          return rows[0]?.groupId || '';
+        });
+        setFeedback(initialFeedback);
+      } catch (error) {
+        setGroups([]);
+        setSelectedGroupId('');
+        setFeedback({
+          type: 'error',
+          title: 'Load failed',
+          message: error.message || 'Could not load group data.',
+        });
+      } finally {
+        setLoadingGroups(false);
+      }
+    }
+
+    fetchGroups();
+  }, [token]);
+
+  const selectedGroup = useMemo(
+    () => groups.find((group) => String(group.groupId) === String(selectedGroupId)) || null,
+    [groups, selectedGroupId],
+  );
+
+  const hasAdvisor = Boolean(selectedGroup?.advisor?.id);
+  const totalMembers = (selectedGroup?.members || []).length + (selectedGroup?.leader ? 1 : 0);
+
+  async function handleDelete() {
+    if (!selectedGroup) {
+      return;
+    }
+
+    if (hasAdvisor) {
+      const message = 'This group still has an active advisor assignment and cannot be deleted.';
+      setFeedback({
+        type: 'warning',
+        title: 'Advisor still assigned',
+        message,
+      });
+      notify({
+        type: 'warning',
+        title: 'Delete blocked',
+        message,
+      });
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Delete ${selectedGroup.groupName} from the group database? This action cannot be undone.`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    setSubmitting(true);
+    setFeedback({
+      type: 'loading',
+      title: 'Deleting group',
+      message: `Removing ${selectedGroup.groupName} from the group database...`,
+    });
+
+    try {
+      const response = await fetch(`/api/v1/group-database/groups/${selectedGroup.groupId}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(payload.message || 'Group deletion failed.');
+      }
+
+      const nextGroups = groups.filter((group) => String(group.groupId) !== String(selectedGroup.groupId));
+      setGroups(nextGroups);
+      setSelectedGroupId(nextGroups[0]?.groupId || '');
+
+      setFeedback({
+        type: 'success',
+        title: 'Group deleted',
+        message: `${selectedGroup.groupName} was removed from the group database successfully.`,
+      });
+      notify({
+        type: 'success',
+        title: 'Group deleted',
+        message: `${selectedGroup.groupName} was removed successfully.`,
+      });
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        title: 'Delete failed',
+        message: error.message || 'Group deletion failed.',
+      });
+      notify({
+        type: 'error',
+        title: 'Delete failed',
+        message: error.message || 'Group deletion failed.',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="page">
+      <section className="hero">
+        <p className="eyebrow">{config.eyebrow}</p>
+        <h1>{config.title}</h1>
+        <p className="subtitle">{config.subtitle}</p>
+      </section>
+
+      <p className="back-link-wrap">
+        <Link className="back-link" to={config.homePath}>
+          {config.backLabel}
+        </Link>
+      </p>
+
+      <section className="panel">
+        <section className="form">
+          <label className="field">
+            <span>Group</span>
+            <select
+              value={selectedGroupId}
+              onChange={(event) => setSelectedGroupId(event.target.value)}
+              disabled={loadingGroups || groups.length === 0}
+            >
+              {groups.length === 0 && <option value="">No groups found</option>}
+              {groups.map((group) => (
+                <option key={group.groupId} value={group.groupId}>
+                  {group.groupName}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="cleanup-actions">
+            <button
+              type="button"
+              className="cleanup-delete-button"
+              onClick={handleDelete}
+              disabled={submitting || loadingGroups || !selectedGroup || hasAdvisor}
+            >
+              {submitting ? 'Deleting...' : 'Delete Group'}
+            </button>
+            {hasAdvisor && (
+              <p className="group-muted cleanup-hint">
+                Delete is disabled while the selected group still has an assigned advisor.
+              </p>
+            )}
+          </div>
+        </section>
+
+        <div className="side-column">
+          <section className="token-panel">
+            <p className="feedback-label">Selected Group</p>
+            <h2>{selectedGroup?.groupName || 'No Group Selected'}</h2>
+            <p className="token-copy">Status: {selectedGroup?.status || '-'}</p>
+            <p className="token-copy">
+              Leader: {selectedGroup?.leader?.fullName || selectedGroup?.leader?.studentId || 'Unknown'}
+            </p>
+            <p className="token-copy">Members: {selectedGroup ? totalMembers : 0}</p>
+            <p className="token-copy">
+              Advisor: {selectedGroup?.advisor?.fullName || selectedGroup?.advisor?.email || 'None assigned'}
+            </p>
+          </section>
+
+          <section className={`feedback feedback-${feedback.type}`} aria-live="polite">
+            <p className="feedback-label">Cleanup Status</p>
+            <h2>{feedback.title}</h2>
+            <p>{feedback.message}</p>
+          </section>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/GroupPage.jsx
+++ b/frontend/src/GroupPage.jsx
@@ -15,10 +15,17 @@ export default function GroupPage() {
   const [userAdvisorId, setUserAdvisorId] = useState(null);
   const [error, setError] = useState(null);
   const [showReleaseConfirm, setShowReleaseConfirm] = useState(false);
+  const [isStudentViewer, setIsStudentViewer] = useState(false);
+
+  const loadGroupData = async () => {
+    const response = await apiClient.get(`/v1/groups/${groupId}/membership`);
+    return response.data.data;
+  };
 
   useEffect(() => {
     const studentId = window.localStorage.getItem('studentId');
     setUserStudentId(studentId);
+    setIsStudentViewer(Boolean(window.localStorage.getItem('studentUser') || studentId));
 
     try {
       const professorUser = JSON.parse(window.localStorage.getItem('professorUser') || '{}');
@@ -47,6 +54,7 @@ export default function GroupPage() {
       setGroup((prev) => ({
         ...prev,
         advisorId: null,
+        advisor: null,
         status: response.data?.data?.status || 'LOOKING_FOR_ADVISOR',
       }));
       notify({
@@ -68,8 +76,8 @@ export default function GroupPage() {
     const fetchGroupData = async () => {
       try {
         setLoading(true);
-        const response = await apiClient.get(`/v1/groups/${groupId}/membership`);
-        setGroup(response.data.data);
+        const data = await loadGroupData();
+        setGroup(data);
         setError(null);
       } catch (err) {
         console.error('Error fetching group data:', err);
@@ -104,18 +112,14 @@ export default function GroupPage() {
     try {
       setJoining(true);
 
-      const response = await apiClient.post(`/v1/groups/${groupId}/membership/finalize`, {
+      await apiClient.post(`/v1/groups/${groupId}/membership/finalize`, {
         studentId: userStudentId,
       });
 
-      // Update local state
-      setGroup((prevGroup) => ({
-        ...prevGroup,
-        members: response.data.data.members || [...(prevGroup?.members || []), userStudentId],
-        currentMemberCount: response.data.data.totalMembers,
-      }));
+      const refreshedGroup = await loadGroupData();
 
-      // Show success notification
+      setGroup(refreshedGroup);
+
       notify({
         type: 'success',
         title: 'Joined group successfully',
@@ -171,55 +175,49 @@ export default function GroupPage() {
     );
   }
 
-  const isAlreadyMember = userStudentId && group.members?.includes(userStudentId);
+  const isAlreadyMember = Boolean(
+    userStudentId
+    && (group.memberIds || group.members?.map((member) => String(member.id)) || []).includes(String(userStudentId)),
+  );
   const isFull = group.currentMemberCount >= group.maxMembers;
   const isFinalized = group.status === 'COMPLETED' || group.status === 'DISBANDED';
 
   const isAdvisor = userAdvisorId && group.advisorId && String(group.advisorId) === String(userAdvisorId);
 
   return (
-    <div style={{ padding: '2rem', maxWidth: '600px', margin: '0 auto' }}>
+    <div className="group-page-shell">
       {/* Group Header */}
-      <div style={{ marginBottom: '2rem' }}>
+      <div className="group-page-header">
         <h1>{group.groupName || 'Unnamed Group'}</h1>
-        <p style={{ color: '#666' }}>Status: <strong>{group.status}</strong></p>
+        <p className="group-page-status">Status: <strong>{group.status}</strong></p>
       </div>
 
       {/* Group Info */}
-      <div style={{ 
-        border: '1px solid #ddd', 
-        padding: '1rem', 
-        borderRadius: '8px', 
-        marginBottom: '2rem',
-        backgroundColor: '#f9f9f9',
-      }}>
-        <div style={{ marginBottom: '1rem' }}>
+      <div className="group-details-card">
+        <div className="group-details-summary">
           <h3>Group Details</h3>
           <p><strong>Status:</strong> {group.status}</p>
           <p><strong>Members:</strong> {group.currentMemberCount} / {group.maxMembers}</p>
           <p><strong>Available Slots:</strong> {group.availableSlots}</p>
-          <p><strong>Advisor:</strong> {group.advisorId ? group.advisorId : <span style={{ color: '#999' }}>None assigned</span>}</p>
+          <p>
+            <strong>Advisor:</strong>{' '}
+            {group.advisor
+              ? `${group.advisor.fullName || group.advisor.email}${group.advisor.department ? ` (${group.advisor.department})` : ''}`
+              : <span className="group-muted">None assigned</span>}
+          </p>
         </div>
 
         {/* Member List */}
         <div>
-          <h3>Members ({group.members?.length || 0})</h3>
+          <h3>Members ({group.currentMemberCount || 0})</h3>
           {group.members && group.members.length > 0 ? (
-            <ul style={{ listStyle: 'none', padding: 0 }}>
-              {group.members.map((memberId, index) => (
-                <li
-                  key={`${memberId}-${index}`}
-                  style={{
-                    padding: '0.5rem',
-                    backgroundColor: '#fff',
-                    borderRadius: '4px',
-                    marginBottom: '0.5rem',
-                    border: '1px solid #eee',
-                  }}
-                >
-                  {memberId}
-                  {memberId === userStudentId && (
-                    <span style={{ marginLeft: '0.5rem', color: '#28a745', fontWeight: 'bold' }}>
+            <ul className="group-members-list">
+              {group.members.map((member, index) => (
+                <li key={`${member.id}-${index}`} className="group-member-chip">
+                  {member.fullName || member.email || member.studentId || member.id}
+                  {member.isLeader ? ' (Leader)' : ''}
+                  {String(member.id) === String(userStudentId) && (
+                    <span className="group-member-you">
                       (You)
                     </span>
                   )}
@@ -227,14 +225,14 @@ export default function GroupPage() {
               ))}
             </ul>
           ) : (
-            <p style={{ color: '#999' }}>No members yet</p>
+            <p className="group-muted">No members yet</p>
           )}
         </div>
       </div>
 
       {/* Action Buttons */}
       <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
-        {isAlreadyMember ? (
+        {isStudentViewer && isAlreadyMember ? (
           <div style={{ 
             padding: '1rem', 
             backgroundColor: '#d4edda', 
@@ -244,7 +242,7 @@ export default function GroupPage() {
           }}>
             ✓ You are a member of this group
           </div>
-        ) : isFinalized ? (
+        ) : isStudentViewer && isFinalized ? (
           <div style={{ 
             padding: '1rem', 
             backgroundColor: '#f8d7da', 
@@ -254,7 +252,7 @@ export default function GroupPage() {
           }}>
             This group is no longer accepting members
           </div>
-        ) : isFull ? (
+        ) : isStudentViewer && isFull ? (
           <div style={{ 
             padding: '1rem', 
             backgroundColor: '#fff3cd', 
@@ -264,7 +262,7 @@ export default function GroupPage() {
           }}>
             This group is at full capacity
           </div>
-        ) : (
+        ) : isStudentViewer ? (
           <button
             onClick={handleJoinGroup}
             disabled={joining}
@@ -281,7 +279,7 @@ export default function GroupPage() {
           >
             {joining ? 'Joining...' : 'Join Group'}
           </button>
-        )}
+        ) : null}
 
         {isAdvisor && (
           <>

--- a/frontend/src/HomePage.jsx
+++ b/frontend/src/HomePage.jsx
@@ -419,7 +419,7 @@ export default function HomePage() {
               )}
             </section>
             <div className="workspace-actions">
-              <Link className="workspace-button workspace-button-primary" to="/students/groups/new">
+              <Link className="workspace-button workspace-button-primary" to="/students/groups/manage">
                 Manage Group
               </Link>
               <Link className="workspace-button workspace-button-secondary" to="/students/notifications">

--- a/frontend/src/ProfessorAdvisorRequestsPage.jsx
+++ b/frontend/src/ProfessorAdvisorRequestsPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 function getProfessorToken() {
   return window.localStorage.getItem('professorToken') || window.localStorage.getItem('authToken');
@@ -365,9 +366,9 @@ export default function ProfessorAdvisorRequestsPage() {
 
           {!loadingTransfers && !transferLoadError && transferNotifications.length > 0 && (
             <section className="mail-nav" aria-label="Group transfer notification list">
-                {transferNotifications.map((entry) => (
+              {transferNotifications.map((entry) => (
+                <article key={entry.id} className="mail-nav-item">
                   <button
-                    key={entry.id}
                     type="button"
                     className="mail-nav-item"
                     onClick={() => {
@@ -380,8 +381,14 @@ export default function ProfessorAdvisorRequestsPage() {
                     <span className="mail-nav-subject">{buildTransferSubject(entry)}</span>
                     <span className="mail-nav-preview">{buildTransferPreview(entry)}</span>
                   </button>
-                ))}
-              </section>
+                  {entry.groupId && (
+                    <Link to={`/groups/${entry.groupId}`}>
+                      Open Group
+                    </Link>
+                  )}
+                </article>
+              ))}
+            </section>
           )}
         </div>
 
@@ -460,6 +467,14 @@ export default function ProfessorAdvisorRequestsPage() {
                       <dd>{formatStatus(selectedRequest.status)}</dd>
                     </div>
                   </dl>
+
+                  {selectedRequest?.groupId && (
+                    <div className="mail-actions">
+                      <Link className="workspace-button workspace-button-primary" to={`/groups/${selectedRequest.groupId}`}>
+                        Open Group
+                      </Link>
+                    </div>
+                  )}
 
                   {canDecide && (
                     <div className="mail-actions">

--- a/frontend/src/RoleHomePage.jsx
+++ b/frontend/src/RoleHomePage.jsx
@@ -9,7 +9,7 @@ const ROLE_CONFIG = {
     loginRoute: '/students/login',
     tokenKey: 'studentToken',
     userKey: 'studentUser',
-    actionHref: '/students/groups/new',
+    actionHref: '/students/groups/manage',
     actionLabel: 'Manage Group',
   },
   professor: {

--- a/frontend/src/StudentGroupShellPage.jsx
+++ b/frontend/src/StudentGroupShellPage.jsx
@@ -338,6 +338,13 @@ export default function StudentGroupShellPage() {
           </label>
         </section>
 
+        <div className="invite-form-actions">
+          <button type="button" onClick={() => setShowAddGroupModal(true)}>
+            Create Group
+          </button>
+          <Link to="/team-leader/advisor-requests/new">Request Advisor</Link>
+        </div>
+
         {selectedGroup && (
           <section className="manage-group-layout">
             <section className="form">
@@ -457,8 +464,6 @@ export default function StudentGroupShellPage() {
                   </label>
 
                   <div className="invite-form-actions">
-                    <button type="button" onClick={() => setShowAddGroupModal(true)}>Add Group</button>
-                    <Link to="/team-leader/advisor-requests/new">Request Advisor</Link>
                     <button type="button" onClick={handleDeleteSelectedGroup}>Delete Group</button>
                   </div>
                 </>

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -8,7 +8,7 @@ const roleMenuSections = {
       title: 'Workspace',
       items: [
         { to: '/home', label: 'Student Home', icon: 'HM' },
-        { to: '/students/groups/new', label: 'Manage Group', icon: 'GR' },
+        { to: '/students/groups/manage', label: 'Manage Group', icon: 'GR' },
       ],
     },
   ],
@@ -34,6 +34,7 @@ const roleMenuSections = {
         { to: '/coordinator/student-id-registry/import', label: 'Student ID Import', icon: 'OP' },
         { to: '/coordinator/groups/manage', label: 'Group Membership Edit', icon: 'GM' },
         { to: '/coordinator/groups/transfer', label: 'Advisor Transfer', icon: 'AT' },
+        { to: '/coordinator/groups/cleanup', label: 'Group Cleanup', icon: 'GC' },
       ],
     },
   ],
@@ -49,6 +50,7 @@ const roleMenuSections = {
       items: [
         { to: '/admin/professors/new', label: 'Create Professor Account', icon: 'MG' },
         { to: '/admin/coordinators/new', label: 'Create Coordinator Account', icon: 'CG' },
+        { to: '/admin/groups/cleanup', label: 'Group Cleanup', icon: 'GC' },
       ],
     },
   ],

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -6,7 +6,10 @@
   --line: rgba(168, 183, 206, 0.2);
   --accent: #12a8b2;
   --accent-strong: #38c3cc;
-  --error-bg: #fef3f2;
+  --error-bg: linear-gradient(180deg, rgba(72, 24, 27, 0.94), rgba(53, 19, 23, 0.94));
+  --error-line: rgba(248, 113, 113, 0.34);
+  --error-ink: #fecaca;
+  --error-ink-strong: #ffe4e6;
   --success-bg: #ecfdf3;
   --warning-bg: #fff7ed;
   --shadow: 0 24px 64px rgba(6, 10, 16, 0.35);
@@ -395,6 +398,8 @@ textarea {
 
 .notification-error {
   background: var(--error-bg);
+  border-color: var(--error-line);
+  color: var(--error-ink-strong);
 }
 
 .notification-warning {
@@ -1472,7 +1477,8 @@ button:disabled {
 
 .feedback-error {
   background: var(--error-bg);
-  border-color: rgba(180, 35, 24, 0.18);
+  border-color: var(--error-line);
+  color: var(--error-ink-strong);
 }
 
 .feedback-warning {
@@ -1501,8 +1507,26 @@ button:disabled {
 
 .mail-state-error {
   background: var(--error-bg);
-  border-color: rgba(180, 35, 24, 0.18);
-  color: #7f1d1d;
+  border-color: var(--error-line);
+  color: var(--error-ink-strong);
+}
+
+.field-error {
+  margin-top: 8px;
+  border: 1px solid var(--error-line);
+  border-radius: 14px;
+  background: var(--error-bg);
+  color: var(--error-ink);
+  padding: 10px 12px;
+  box-shadow: 0 12px 28px rgba(33, 10, 14, 0.24);
+}
+
+.field-error p {
+  margin: 0;
+}
+
+.field-error p + p {
+  margin-top: 6px;
 }
 
 .page-mailbox {
@@ -1765,6 +1789,81 @@ button:disabled {
 .mail-detail-grid dd {
   margin: 6px 0 0;
   font-weight: 600;
+}
+
+.group-page-shell {
+  padding: 2rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.group-page-header {
+  margin-bottom: 2rem;
+}
+
+.group-page-status {
+  color: var(--muted);
+}
+
+.group-details-card {
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, rgba(28, 38, 52, 0.96), rgba(20, 28, 40, 0.96));
+  box-shadow: var(--shadow);
+  padding: 1.1rem;
+  margin-bottom: 2rem;
+}
+
+.group-details-summary {
+  margin-bottom: 1rem;
+}
+
+.group-details-summary h3 {
+  margin-top: 0;
+}
+
+.group-muted {
+  color: var(--muted);
+}
+
+.group-members-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.group-member-chip {
+  padding: 0.65rem 0.75rem;
+  background: rgba(65, 79, 102, 0.22);
+  border-radius: 10px;
+  border: 1px solid rgba(168, 183, 206, 0.16);
+}
+
+.group-member-you {
+  margin-left: 0.5rem;
+  color: #6ee7b7;
+  font-weight: 700;
+}
+
+.cleanup-actions {
+  display: grid;
+  gap: 12px;
+}
+
+.cleanup-delete-button {
+  background: linear-gradient(140deg, #8f1d2c 0%, #b42336 55%, #d14343 100%);
+  box-shadow: 0 12px 24px rgba(149, 35, 53, 0.24);
+}
+
+.cleanup-delete-button:hover {
+  box-shadow: 0 18px 32px rgba(149, 35, 53, 0.3);
+}
+
+.cleanup-hint {
+  margin: 0;
 }
 
 @keyframes mailDrawerIn {


### PR DESCRIPTION
## Summary

This PR restores and stabilizes several merged group/advisor flows, with a focus on:

- correct group details rendering
- advisor request notification delivery
- allowing re-request after advisor release
- adding orphan group cleanup UI for admin and coordinator
- making orphan group deletion more robust in the backend

## What Changed

### Backend

- fixed group membership response shape so group details can show the real participant data
- updated `GET /api/v1/groups/:groupId/membership` to return:
  - leader-aware member counts
  - full member objects instead of raw IDs only
  - advisor details instead of showing only advisor user ID
- fixed advisor request creation to emit advisor-facing notifications when a team leader submits a request
- fixed duplicate advisor request logic so:
  - active `PENDING` requests are still blocked
  - previously `APPROVED` requests do not block a new request after advisor release
- added test coverage for re-requesting the same advisor after release
- strengthened orphan group deletion so deleting a valid orphan group also removes related:
  - invitations
  - advisor requests
  - mirrored group-advisor assignment rows

### Frontend

- fixed `GroupPage` so it now displays:
  - correct member totals including the team leader
  - correct available slot count
  - advisor name/department instead of raw ID
  - member names with leader labeling
- refreshed the local group state after join operations so the UI stays correct without page refresh
- made `Open Group` more visible from the professor advisor request screen
- improved the placement of the student `Create Group` action in the group management page
- updated error feedback blocks to use the current dark theme instead of mismatched light error styling
- adjusted the `Group Details` card styling to match the rest of the app theme

### New Group Cleanup UI

Added a dedicated group cleanup page for both coordinator and admin:

- `/coordinator/groups/cleanup`
- `/admin/groups/cleanup`

This page:
- lists available groups
- shows whether a group still has an assigned advisor
- disables deletion for groups with active advisor assignments
- deletes orphan groups through the canonical backend endpoint:
  - `DELETE /api/v1/group-database/groups/:groupId`
- updates the UI immediately after successful deletion

Also added entry points to this cleanup flow from:
- coordinator home
- admin home
- role-specific app navigation

## Endpoints Touched

- `GET /api/v1/groups/:groupId/membership`
- `POST /api/v1/advisor-requests`
- `DELETE /api/v1/group-database/groups/:groupId`

## Verification

Ran:

```bash
cd frontend
npm run build
