### PR TITLE
Fix: mentor matching edge cases and add admin audit log page

### DIFF
--- a/backend/controllers/advisorRequestController.js
+++ b/backend/controllers/advisorRequestController.js
@@ -78,6 +78,16 @@ const createAdvisorRequest = [
         );
       }
 
+      if (group.advisorId) {
+        return res.status(409).json({
+          code: 'GROUP_ALREADY_HAS_ADVISOR',
+          message: 'This group already has an assigned advisor.',
+          errors: {
+            groupId: ['This group already has an assigned advisor'],
+          },
+        });
+      }
+
       const advisor = await Professor.findOne({
         where: { userId: advisorId },
         include: [{ model: User, attributes: ['id', 'fullName', 'email', 'role'] }],
@@ -89,6 +99,23 @@ const createAdvisorRequest = [
           message: 'Please check your input and try again',
           errors: {
             advisorId: ['The selected advisor does not exist'],
+          },
+        });
+      }
+
+      const existingPendingRequestForGroup = await AdvisorRequest.findOne({
+        where: {
+          groupId,
+          status: 'PENDING',
+        },
+      });
+
+      if (existingPendingRequestForGroup) {
+        return res.status(409).json({
+          code: 'GROUP_ALREADY_HAS_PENDING_REQUEST',
+          message: 'This group already has a pending advisor request.',
+          errors: {
+            groupId: ['This group already has a pending advisor request'],
           },
         });
       }

--- a/backend/controllers/auditLogController.js
+++ b/backend/controllers/auditLogController.js
@@ -1,0 +1,48 @@
+const { AuditLog, User } = require('../models');
+
+async function listAuditLogs(req, res) {
+  const rawLimit = Number.parseInt(String(req.query.limit || '100'), 10);
+  const limit = Number.isInteger(rawLimit) ? Math.min(Math.max(rawLimit, 1), 250) : 100;
+
+  try {
+    const rows = await AuditLog.findAll({
+      include: [
+        {
+          model: User,
+          attributes: ['id', 'fullName', 'email', 'role', 'studentId'],
+        },
+      ],
+      order: [['createdAt', 'DESC']],
+      limit,
+    });
+
+    return res.status(200).json({
+      count: rows.length,
+      data: rows.map((row) => ({
+        id: row.id,
+        action: row.action,
+        targetType: row.targetType,
+        targetId: row.targetId,
+        metadata: row.metadata || {},
+        createdAt: row.createdAt,
+        actor: row.User ? {
+          id: row.User.id,
+          fullName: row.User.fullName,
+          email: row.User.email,
+          role: row.User.role,
+          studentId: row.User.studentId || null,
+        } : null,
+      })),
+    });
+  } catch (error) {
+    console.error('Audit log listing failed unexpectedly:', error);
+    return res.status(500).json({
+      code: 'AUDIT_LOG_FETCH_FAILED',
+      message: 'Audit logs could not be loaded.',
+    });
+  }
+}
+
+module.exports = {
+  listAuditLogs,
+};

--- a/backend/controllers/groupController.js
+++ b/backend/controllers/groupController.js
@@ -435,8 +435,15 @@ exports.renameGroup = async (req, res) => {
 
     if (maxMembers !== undefined) {
       const nextMax = Number(maxMembers);
-      const memberCount = Array.isArray(group.memberIds) ? group.memberIds.length : 0;
-      if (nextMax < memberCount) {
+      const participantIds = new Set();
+      if (group.leaderId) {
+        participantIds.add(String(group.leaderId));
+      }
+      (Array.isArray(group.memberIds) ? group.memberIds : []).forEach((memberId) => {
+        participantIds.add(String(memberId));
+      });
+
+      if (nextMax < participantIds.size) {
         return res.status(400).json({ code: 'INVALID_MAX_MEMBERS', message: 'Max members cannot be lower than current member count.' });
       }
       group.maxMembers = nextMax;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -2,9 +2,11 @@ const express = require('express');
 const router = express.Router();
 const { authenticate, authorize } = require('../middleware/auth');
 const { adminLogin, registerProfessor, registerCoordinator } = require('../controllers/adminController.js');
+const { listAuditLogs } = require('../controllers/auditLogController');
 
 router.post('/login', adminLogin);
 router.post('/professors', authenticate, authorize(['ADMIN']), registerProfessor);
 router.post('/coordinators', authenticate, authorize(['ADMIN']), registerCoordinator);
+router.get('/audit-logs', authenticate, authorize(['ADMIN']), listAuditLogs);
 
 module.exports = router;

--- a/backend/services/coordinatorGroupService.js
+++ b/backend/services/coordinatorGroupService.js
@@ -23,9 +23,11 @@ function assertCoordinatorActor(actor) {
 }
 
 function computeMemberUpdate(memberIds, action, userId) {
-  const current = Array.isArray(memberIds) ? [...memberIds] : [];
+  const current = Array.from(
+    new Set((Array.isArray(memberIds) ? memberIds : []).map((memberId) => String(memberId))),
+  );
   const normalizedUserId = String(userId);
-  const hasStudent = current.map((memberId) => String(memberId)).includes(normalizedUserId);
+  const hasStudent = current.includes(normalizedUserId);
 
   if (action === 'ADD') {
     if (hasStudent) {
@@ -43,6 +45,20 @@ function computeMemberUpdate(memberIds, action, userId) {
 
 function getAuditAction(action) {
   return action === 'ADD' ? 'COORDINATOR_MEMBER_ADDED' : 'COORDINATOR_MEMBER_REMOVED';
+}
+
+function buildParticipantSet(group) {
+  const participantIds = new Set();
+
+  if (group?.leaderId) {
+    participantIds.add(String(group.leaderId));
+  }
+
+  (Array.isArray(group?.memberIds) ? group.memberIds : []).forEach((memberId) => {
+    participantIds.add(String(memberId));
+  });
+
+  return participantIds;
 }
 
 async function updateGroupMembershipByCoordinator({ groupId, action, studentId, actor }) {
@@ -76,6 +92,10 @@ async function updateGroupMembershipByCoordinator({ groupId, action, studentId, 
     }
 
     if (normalizedAction === 'ADD') {
+      if (String(group.leaderId || '') === String(student.id)) {
+        throw createServiceError(400, 'MEMBERSHIP_NO_CHANGE', 'Student already belongs to this group as its leader.');
+      }
+
       const allGroups = await Group.findAll({
         attributes: ['id', 'leaderId', 'memberIds'],
         transaction,
@@ -96,6 +116,12 @@ async function updateGroupMembershipByCoordinator({ groupId, action, studentId, 
       if (alreadyInOtherGroup) {
         throw createServiceError(409, 'STUDENT_ALREADY_IN_OTHER_GROUP', 'Student already belongs to another group.');
       }
+
+      const participantIds = buildParticipantSet(group);
+      participantIds.add(String(student.id));
+      if (participantIds.size > Number(group.maxMembers || 0)) {
+        throw createServiceError(409, 'GROUP_FULL', 'This group has reached maximum member capacity.');
+      }
     }
 
     const previousMemberIds = Array.isArray(group.memberIds) ? [...group.memberIds] : [];
@@ -105,10 +131,10 @@ async function updateGroupMembershipByCoordinator({ groupId, action, studentId, 
     await group.save({ transaction });
 
     const auditPayload = {
-      actorId: String(actor.id),
+      actorId: actor.id,
       action: getAuditAction(normalizedAction),
+      targetType: 'GROUP',
       targetId: group.id,
-      timestamp: new Date(),
       metadata: {
         groupId: group.id,
         targetUserId: student.id,

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -409,11 +409,11 @@ class GroupService {
   static async _writeAuditLog({ invitationId, groupId, actorId, action }) {
     try {
       await AuditLog.create({
-        entityType: 'INVITATION',
-        entityId: invitationId,
+        targetType: 'INVITATION',
+        targetId: invitationId,
         actorId,
         action,
-        metadata: JSON.stringify({ groupId }),
+        metadata: { groupId },
       });
     } catch (err) {
       console.error('[GroupService] _writeAuditLog failed', { invitationId, action }, err);

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -9,6 +9,20 @@ const sequelize = require('../db');
 const NotificationService = require('./notificationService');
 const mentorMatchingService = require('./mentorMatchingService');
 
+function getParticipantSet(group) {
+  const participantIds = new Set();
+
+  if (group?.leaderId) {
+    participantIds.add(String(group.leaderId));
+  }
+
+  (Array.isArray(group?.memberIds) ? group.memberIds : []).forEach((memberId) => {
+    participantIds.add(String(memberId));
+  });
+
+  return participantIds;
+}
+
 class GroupService {
 
   /**
@@ -135,7 +149,7 @@ class GroupService {
 
       const leaderMatches = String(group.leaderId || '') === normalizedUserId;
       const memberMatches = Array.isArray(group.memberIds)
-        && group.memberIds.map((id) => String(id)).includes(normalizedUserId);
+        && group.memberIds.map(String).includes(normalizedUserId);
 
       return leaderMatches || memberMatches;
     }) || null;
@@ -155,7 +169,7 @@ class GroupService {
         }
 
         return Array.isArray(group.memberIds)
-          && group.memberIds.map((id) => String(id)).includes(userId);
+          && group.memberIds.map(String).includes(userId);
       });
 
       if (isMemberInAnotherGroup) {
@@ -217,7 +231,8 @@ class GroupService {
         throw error;
       }
 
-      const currentMembers = group.memberIds || [];
+      const currentMembers = Array.isArray(group.memberIds) ? group.memberIds.map(String) : [];
+      const currentParticipants = getParticipantSet(group);
 
       const existingGroup = await GroupService.findAnyGroupForUser(studentId, {
         excludeGroupId: group.id,
@@ -229,19 +244,20 @@ class GroupService {
         throw error;
       }
 
-      if (currentMembers.includes(studentId)) {
+      if (currentMembers.includes(String(studentId))) {
         const error = new Error('Student is already a member of this group');
         error.code = 'DUPLICATE_MEMBER';
         throw error;
       }
 
-      if (currentMembers.length >= group.maxMembers) {
+      if (currentParticipants.size >= group.maxMembers) {
         const error = new Error('Group has reached maximum member capacity');
         error.code = 'MAX_MEMBERS_REACHED';
         throw error;
       }
 
-      const updatedMembers = [...currentMembers, studentId];
+      const updatedMembers = [...currentMembers, String(studentId)];
+      const updatedTotalMembers = currentParticipants.size + 1;
       await group.update({ memberIds: updatedMembers }, { transaction });
       await transaction.commit();
 
@@ -250,7 +266,7 @@ class GroupService {
           groupId: group.id,
           leaderId: group.leaderId,
           studentId,
-          totalMembers: updatedMembers.length,
+          totalMembers: updatedTotalMembers,
           maxMembers: group.maxMembers,
         });
       }
@@ -258,7 +274,7 @@ class GroupService {
       return {
         groupId: group.id,
         studentId,
-        totalMembers: updatedMembers.length,
+        totalMembers: updatedTotalMembers,
         maxMembers: group.maxMembers,
         success: true,
       };

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -14,6 +14,7 @@ const {
   Professor,
   GroupAdvisorAssignment,
   AdvisorRequest,
+  Invitation,
   AuditLog,
   Notification,
   ValidStudentId,
@@ -122,6 +123,43 @@ test('admin can log in with email and password', async () => {
 
   assert.equal(invalidResult.response.status, 401);
   assert.equal(invalidResult.json.code, 'INVALID_CREDENTIALS');
+});
+
+test('audit log feed is admin-only', async () => {
+  const admin = await User.create({
+    email: 'audit-admin@example.com',
+    fullName: 'Audit Admin',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+  const student = await createStudent({
+    studentId: '11070001011',
+    email: 'audit-student@example.edu',
+    fullName: 'Audit Student',
+    password: 'StrongPass1!',
+  });
+
+  await AuditLog.create({
+    action: 'GROUP_CREATED',
+    actorId: admin.id,
+    targetType: 'GROUP',
+    targetId: 'group-audit-1',
+    metadata: { groupName: 'Audit Group' },
+  });
+
+  const forbidden = await request('/api/v1/admin/audit-logs', {
+    headers: await authHeaderFor(student),
+  });
+  assert.equal(forbidden.response.status, 403);
+
+  const success = await request('/api/v1/admin/audit-logs', {
+    headers: await authHeaderFor(admin),
+  });
+  assert.equal(success.response.status, 200);
+  assert.equal(success.json.count, 1);
+  assert.equal(success.json.data[0].action, 'GROUP_CREATED');
+  assert.equal(success.json.data[0].actor.email, 'audit-admin@example.com');
 });
 
 test('coordinator can log in with email and password', async () => {
@@ -1480,6 +1518,68 @@ test('group database advisor transfer enforces role checks and updates the persi
   assert.equal(staleAdvisor.json.code, 'GROUP_HAS_INVALID_ADVISOR');
 });
 
+test('coordinator can add a student to a group and the membership audit log is written', async () => {
+  const coordinator = await User.create({
+    email: 'membership-coordinator@example.edu',
+    fullName: 'Membership Coordinator',
+    role: 'COORDINATOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+  const leader = await createStudent({
+    studentId: '11070001110',
+    email: 'membership-leader@example.edu',
+    fullName: 'Membership Leader',
+    password: 'StrongPass1!',
+  });
+  const member = await createStudent({
+    studentId: '11070001002',
+    email: 'membership-target@example.edu',
+    fullName: 'Membership Target',
+    password: 'StrongPass1!',
+  });
+
+  const group = await Group.create({
+    id: 'group-membership-coordinator-1',
+    name: 'baba',
+    leaderId: String(leader.id),
+    memberIds: [String(leader.id)],
+    maxMembers: 4,
+    status: 'FORMATION',
+  });
+
+  const response = await request(`/api/v1/coordinator/groups/${group.id}/members`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(coordinator)),
+    },
+    body: JSON.stringify({
+      action: 'ADD',
+      studentId: '11070001002',
+    }),
+  });
+
+  assert.equal(response.response.status, 200);
+  assert.equal(response.json.id, group.id);
+  assert.ok(response.json.memberIds.includes(String(member.id)));
+
+  const updatedGroup = await Group.findByPk(group.id);
+  assert.ok(updatedGroup.memberIds.includes(String(member.id)));
+
+  const auditLog = await AuditLog.findOne({
+    where: {
+      action: 'COORDINATOR_MEMBER_ADDED',
+      actorId: coordinator.id,
+      targetType: 'GROUP',
+      targetId: group.id,
+    },
+  });
+  assert.ok(auditLog);
+  assert.equal(auditLog.metadata.studentId, '11070001002');
+  assert.equal(auditLog.metadata.membershipAction, 'ADD');
+});
+
 test('user database advisor assignment sync validates membership and rewrites mirrored rows', async () => {
   const coordinator = await User.create({
     email: 'sync-coordinator@example.edu',
@@ -2029,6 +2129,225 @@ test('advisor notification endpoints filter by authenticated advisor and support
     headers: await authHeaderFor(advisorB),
   });
   assert.equal(forbiddenRead.response.status, 404);
+});
+
+test('legacy invitation response route writes a compatible audit log entry', async () => {
+  const leader = await createStudent({
+    studentId: '11070001141',
+    email: 'legacy-invite-leader@example.edu',
+    fullName: 'Legacy Invite Leader',
+    password: 'StrongPass1!',
+  });
+  const invitee = await createStudent({
+    studentId: '11070001142',
+    email: 'legacy-invite-student@example.edu',
+    fullName: 'Legacy Invite Student',
+    password: 'StrongPass1!',
+  });
+
+  const group = await Group.create({
+    name: 'Legacy Invitation Group',
+    leaderId: leader.id,
+    memberIds: [String(leader.id)],
+    advisorId: null,
+    status: 'FORMATION',
+    maxMembers: 4,
+  });
+
+  const invitation = await Invitation.create({
+    id: '44444444-4444-4444-4444-444444444444',
+    groupId: group.id,
+    inviteeId: invitee.id,
+    status: 'PENDING',
+  });
+
+  const response = await request(`/api/v1/invitations/${invitation.id}/response`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(invitee)),
+    },
+    body: JSON.stringify({ response: 'REJECT' }),
+  });
+
+  assert.equal(response.response.status, 200);
+  assert.equal(response.json.invitation.status, 'REJECTED');
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  const auditLog = await AuditLog.findOne({
+    where: {
+      action: 'INVITATION_REJECTED',
+      targetType: 'INVITATION',
+      targetId: invitation.id,
+      actorId: invitee.id,
+    },
+  });
+
+  assert.ok(auditLog);
+  assert.equal(auditLog.metadata.groupId, group.id);
+});
+
+test('team leader cannot submit an advisor request for a group that already has an advisor', async () => {
+  const leader = await createStudent({
+    studentId: '11070001121',
+    email: 'leader-has-advisor@example.edu',
+    fullName: 'Leader Has Advisor',
+    password: 'StrongPass1!',
+  });
+  const currentAdvisor = await createProfessorUser({
+    email: 'current-advisor-has-group@example.edu',
+    fullName: 'Current Advisor Has Group',
+  });
+  const requestedAdvisor = await createProfessorUser({
+    email: 'requested-advisor-has-group@example.edu',
+    fullName: 'Requested Advisor Has Group',
+  });
+  const group = await Group.create({
+    name: 'Already Assigned Group',
+    leaderId: leader.id,
+    memberIds: [leader.id],
+    advisorId: currentAdvisor.id,
+    status: 'HAS_ADVISOR',
+    maxMembers: 4,
+  });
+
+  const response = await request('/api/v1/advisor-requests', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      groupId: group.id,
+      professorId: requestedAdvisor.id,
+    }),
+  });
+
+  assert.equal(response.response.status, 409);
+  assert.equal(response.json.code, 'GROUP_ALREADY_HAS_ADVISOR');
+});
+
+test('team leader cannot submit advisor requests to multiple advisors while one request is pending', async () => {
+  const leader = await createStudent({
+    studentId: '11070001131',
+    email: 'leader-pending-request@example.edu',
+    fullName: 'Leader Pending Request',
+    password: 'StrongPass1!',
+  });
+  const firstAdvisor = await createProfessorUser({
+    email: 'pending-first-advisor@example.edu',
+    fullName: 'Pending First Advisor',
+  });
+  const secondAdvisor = await createProfessorUser({
+    email: 'pending-second-advisor@example.edu',
+    fullName: 'Pending Second Advisor',
+  });
+
+  const group = await Group.create({
+    name: 'Pending Request Group',
+    leaderId: leader.id,
+    memberIds: [leader.id],
+    advisorId: null,
+    status: 'FORMATION',
+    maxMembers: 4,
+  });
+
+  const firstResponse = await request('/api/v1/advisor-requests', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      groupId: group.id,
+      professorId: firstAdvisor.id,
+    }),
+  });
+
+  assert.equal(firstResponse.response.status, 201);
+
+  const secondResponse = await request('/api/v1/advisor-requests', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      groupId: group.id,
+      professorId: secondAdvisor.id,
+    }),
+  });
+
+  assert.equal(secondResponse.response.status, 409);
+  assert.equal(secondResponse.json.code, 'GROUP_ALREADY_HAS_PENDING_REQUEST');
+});
+
+test('coordinator membership edit blocks adding the leader and enforces group max capacity', async () => {
+  const coordinator = await User.create({
+    email: 'coordinator-capacity@example.edu',
+    fullName: 'Coordinator Capacity',
+    role: 'COORDINATOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+  const leader = await createStudent({
+    studentId: '11070001122',
+    email: 'coordinator-capacity-leader@example.edu',
+    fullName: 'Coordinator Capacity Leader',
+    password: 'StrongPass1!',
+  });
+  const member = await createStudent({
+    studentId: '11070001123',
+    email: 'coordinator-capacity-member@example.edu',
+    fullName: 'Coordinator Capacity Member',
+    password: 'StrongPass1!',
+  });
+  const extraStudent = await createStudent({
+    studentId: '11070001124',
+    email: 'coordinator-capacity-extra@example.edu',
+    fullName: 'Coordinator Capacity Extra',
+    password: 'StrongPass1!',
+  });
+
+  const group = await Group.create({
+    id: 'group-membership-capacity-1',
+    name: 'Capacity Group',
+    leaderId: String(leader.id),
+    memberIds: [String(member.id)],
+    maxMembers: 2,
+    status: 'FORMATION',
+  });
+
+  const leaderAddResponse = await request(`/api/v1/coordinator/groups/${group.id}/members`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(coordinator)),
+    },
+    body: JSON.stringify({
+      action: 'ADD',
+      studentId: leader.studentId,
+    }),
+  });
+
+  assert.equal(leaderAddResponse.response.status, 400);
+  assert.equal(leaderAddResponse.json.code, 'MEMBERSHIP_NO_CHANGE');
+
+  const overCapacityResponse = await request(`/api/v1/coordinator/groups/${group.id}/members`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(coordinator)),
+    },
+    body: JSON.stringify({
+      action: 'ADD',
+      studentId: extraStudent.studentId,
+    }),
+  });
+
+  assert.equal(overCapacityResponse.response.status, 409);
+  assert.equal(overCapacityResponse.json.code, 'GROUP_FULL');
 });
 
 test('team leader can view their advisor request details but others cannot', async () => {

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -2044,6 +2044,41 @@ test('[E2E NOTIFICATIONS] leader receives notification after invitee accepts', a
     'Expected membership acceptance notifications to be emitted for the leader',
   );
 
+
+test('finalize membership counts the leader toward maxMembers', async () => {
+  const leader = await createStudent({
+    studentId: '11070030000',
+    email: 'finalize-capacity-leader@example.edu',
+    fullName: 'Finalize Capacity Leader',
+    password: 'StrongPass1!',
+  });
+  const invitee = await createStudent({
+    studentId: '11070030001',
+    email: 'finalize-capacity-invitee@example.edu',
+    fullName: 'Finalize Capacity Invitee',
+    password: 'StrongPass1!',
+  });
+
+  const groupResult = await request('/api/v1/groups', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(await authHeaderFor(leader)) },
+    body: JSON.stringify({
+      groupName: 'Finalize Capacity Group',
+      maxMembers: 1,
+    }),
+  });
+
+  assert.equal(groupResult.response.status, 201);
+
+  const finalizeResponse = await request(`/api/v1/groups/${groupResult.json.data.groupId}/membership/finalize`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ studentId: invitee.studentId }),
+  });
+
+  assert.equal(finalizeResponse.response.status, 400);
+  assert.equal(finalizeResponse.json.code, 'MAX_MEMBERS_REACHED');
+});
   console.log = originalLog;
 });
 
@@ -2348,6 +2383,53 @@ test('coordinator membership edit blocks adding the leader and enforces group ma
 
   assert.equal(overCapacityResponse.response.status, 409);
   assert.equal(overCapacityResponse.json.code, 'GROUP_FULL');
+});
+
+test('group leader cannot lower maxMembers below current participant count', async () => {
+  const leader = await createStudent({
+    studentId: '11070001125',
+    email: 'rename-max-leader@example.edu',
+    fullName: 'Rename Max Leader',
+    password: 'StrongPass1!',
+  });
+  const memberOne = await createStudent({
+    studentId: '11070001126',
+    email: 'rename-max-member-one@example.edu',
+    fullName: 'Rename Max Member One',
+    password: 'StrongPass1!',
+  });
+  const memberTwo = await createStudent({
+    studentId: '11070001127',
+    email: 'rename-max-member-two@example.edu',
+    fullName: 'Rename Max Member Two',
+    password: 'StrongPass1!',
+  });
+
+  const group = await Group.create({
+    id: 'group-rename-max-1',
+    name: 'Rename Max Group',
+    leaderId: String(leader.id),
+    memberIds: [String(memberOne.id), String(memberTwo.id)],
+    maxMembers: 5,
+    status: 'FORMATION',
+  });
+
+  const response = await request(`/api/v1/groups/${group.id}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      maxMembers: 2,
+    }),
+  });
+
+  assert.equal(response.response.status, 400);
+  assert.equal(response.json.code, 'INVALID_MAX_MEMBERS');
+
+  const unchangedGroup = await Group.findByPk(group.id);
+  assert.equal(unchangedGroup.maxMembers, 5);
 });
 
 test('team leader can view their advisor request details but others cannot', async () => {

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -2009,41 +2009,45 @@ test('[E2E NOTIFICATIONS] leader receives notification after invitee accepts', a
   // Capture logs for notification verification
   const originalLog = console.log;
   const allNotifications = [];
-  console.log = (...args) => {
-    const logEntry = args.join(' ');
-    allNotifications.push(logEntry);
-    originalLog(...args);
-  };
+  try {
+    console.log = (...args) => {
+      const logEntry = args.join(' ');
+      allNotifications.push(logEntry);
+      originalLog(...args);
+    };
 
-  // Invitee 1 accepts (first member)
-  await request(`/api/v1/groups/${groupId}/membership/finalize`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...leaderHeaders },
-    body: JSON.stringify({ studentId: '11070020000' }),
-  });
+    // Invitee 1 accepts (first member)
+    await request(`/api/v1/groups/${groupId}/membership/finalize`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...leaderHeaders },
+      body: JSON.stringify({ studentId: '11070020000' }),
+    });
 
-  await new Promise((resolve) => setTimeout(resolve, 150));
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
-  // Invitee 2 accepts (second member)
-  await request(`/api/v1/groups/${groupId}/membership/finalize`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...leaderHeaders },
-    body: JSON.stringify({ studentId: '11070020001' }),
-  });
+    // Invitee 2 accepts (second member)
+    await request(`/api/v1/groups/${groupId}/membership/finalize`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...leaderHeaders },
+      body: JSON.stringify({ studentId: '11070020001' }),
+    });
 
-  await new Promise((resolve) => setTimeout(resolve, 150));
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
-  // Verify leader received 2 notifications by checking all logs
-  const emittedEventLines = allNotifications.filter((log) =>
-    log.includes('[NotificationService] Event emitted')
-  );
+    // Verify leader received 2 notifications by checking all logs
+    const emittedEventLines = allNotifications.filter((log) =>
+      log.includes('[NotificationService] Event emitted')
+    );
 
-  assert.equal(emittedEventLines.length, 2);
-  assert.ok(
-    emittedEventLines.every((line) => line.includes('GROUP_MEMBERSHIP_ACCEPTED')),
-    'Expected membership acceptance notifications to be emitted for the leader',
-  );
-
+    assert.equal(emittedEventLines.length, 2);
+    assert.ok(
+      emittedEventLines.every((line) => line.includes('GROUP_MEMBERSHIP_ACCEPTED')),
+      'Expected membership acceptance notifications to be emitted for the leader',
+    );
+  } finally {
+    console.log = originalLog;
+  }
+});
 
 test('finalize membership counts the leader toward maxMembers', async () => {
   const leader = await createStudent({
@@ -2078,8 +2082,6 @@ test('finalize membership counts the leader toward maxMembers', async () => {
 
   assert.equal(finalizeResponse.response.status, 400);
   assert.equal(finalizeResponse.json.code, 'MAX_MEMBERS_REACHED');
-});
-  console.log = originalLog;
 });
 
 test('advisor notification endpoints filter by authenticated advisor and support mark-as-read', async () => {

--- a/frontend/src/AdminAuditLogPage.jsx
+++ b/frontend/src/AdminAuditLogPage.jsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useNotification } from './contexts/NotificationContext';
+
+function formatDate(value) {
+  if (!value) {
+    return '-';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '-';
+  }
+
+  return date.toLocaleString();
+}
+
+export default function AdminAuditLogPage() {
+  const [logs, setLogs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const navigate = useNavigate();
+  const { notify } = useNotification();
+  const token = window.localStorage.getItem('adminToken') || '';
+
+  useEffect(() => {
+    if (token) {
+      return;
+    }
+
+    notify({
+      type: 'warning',
+      title: 'Admin login required',
+      message: 'Please sign in before opening audit logs.',
+    });
+    navigate('/admin/login', { replace: true });
+  }, [navigate, notify, token]);
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    async function loadLogs() {
+      setLoading(true);
+      setError('');
+
+      try {
+        const response = await fetch('/api/v1/admin/audit-logs?limit=150', {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(payload.message || 'Audit logs could not be loaded.');
+        }
+
+        setLogs(Array.isArray(payload.data) ? payload.data : []);
+      } catch (loadError) {
+        setLogs([]);
+        setError(loadError.message || 'Audit logs could not be loaded.');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadLogs();
+  }, [token]);
+
+  return (
+    <main className="page">
+      <section className="hero">
+        <p className="eyebrow">Admin Workspace</p>
+        <h1>Audit Logs</h1>
+        <p className="subtitle">
+          Review recorded system actions from a single admin-only activity stream.
+        </p>
+      </section>
+
+      <p className="back-link-wrap">
+        <Link className="back-link" to="/admin">
+          Back to Admin Workspace
+        </Link>
+      </p>
+
+      <section className="single-panel">
+        {loading && (
+          <section className="feedback feedback-loading" aria-live="polite">
+            <p className="feedback-label">Audit Feed</p>
+            <h2>Loading</h2>
+            <p>Fetching the latest audit log entries.</p>
+          </section>
+        )}
+
+        {!loading && error && (
+          <section className="feedback feedback-error" aria-live="polite">
+            <p className="feedback-label">Audit Feed</p>
+            <h2>Load failed</h2>
+            <p>{error}</p>
+          </section>
+        )}
+
+        {!loading && !error && logs.length === 0 && (
+          <section className="feedback feedback-idle" aria-live="polite">
+            <p className="feedback-label">Audit Feed</p>
+            <h2>No logs yet</h2>
+            <p>No audit records are available right now.</p>
+          </section>
+        )}
+
+        {!loading && !error && logs.length > 0 && (
+          <section className="audit-log-list" aria-label="Audit logs">
+            {logs.map((entry) => (
+              <article key={entry.id} className="audit-log-card">
+                <div className="audit-log-topline">
+                  <span className="audit-log-action">{entry.action}</span>
+                  <span className="audit-log-time">{formatDate(entry.createdAt)}</span>
+                </div>
+
+                <div className="audit-log-grid">
+                  <div>
+                    <p className="audit-log-label">Actor</p>
+                    <p className="audit-log-value">
+                      {entry.actor?.fullName || entry.actor?.email || 'Unknown actor'}
+                    </p>
+                    <p className="audit-log-subvalue">
+                      {entry.actor?.role || 'UNKNOWN'}
+                      {entry.actor?.studentId ? ` • ${entry.actor.studentId}` : ''}
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="audit-log-label">Target</p>
+                    <p className="audit-log-value">{entry.targetType}</p>
+                    <p className="audit-log-subvalue">{entry.targetId}</p>
+                  </div>
+                </div>
+
+                <pre className="audit-log-metadata">
+                  {JSON.stringify(entry.metadata || {}, null, 2)}
+                </pre>
+              </article>
+            ))}
+          </section>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/AdminHomePage.jsx
+++ b/frontend/src/AdminHomePage.jsx
@@ -42,6 +42,14 @@ const adminTools = [
     cta: 'Open Cleanup Tool',
     status: 'Ready',
   },
+  {
+    eyebrow: 'Compliance',
+    title: 'Audit Logs',
+    description: 'Inspect recorded actions and trace actor, target, and metadata from the admin workspace.',
+    href: '/admin/audit-logs',
+    cta: 'Open Audit Logs',
+    status: 'Ready',
+  },
 ];
 
 export default function AdminHomePage() {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import AdminHomePage from './AdminHomePage';
 import AdminCoordinatorCreatePage from './AdminCoordinatorCreatePage';
+import AdminAuditLogPage from './AdminAuditLogPage';
 import AdminLoginPage from './AdminLoginPage';
 import AdminProfessorCreatePage from './AdminProfessorCreatePage';
 import AuthPage from './AuthPage';
@@ -50,6 +51,7 @@ export default function App() {
               <Route path="/professors/password-setup" element={<ProfessorPasswordSetupPage />} />
               <Route path="/admin/login" element={<AuthPage />} />
               <Route path="/admin" element={<AdminHomePage />} />
+              <Route path="/admin/audit-logs" element={<AdminAuditLogPage />} />
               <Route path="/admin/professors/new" element={<AdminProfessorCreatePage />} />
               <Route path="/admin/coordinators/new" element={<AdminCoordinatorCreatePage />} />
               <Route path="/admin/groups/cleanup" element={<GroupCleanupPage role="ADMIN" />} />

--- a/frontend/src/CoordinatorAdvisorTransferPage.jsx
+++ b/frontend/src/CoordinatorAdvisorTransferPage.jsx
@@ -104,6 +104,25 @@ export default function CoordinatorAdvisorTransferPage() {
     [groups, selectedGroupId],
   );
 
+  const totalMembers = useMemo(() => {
+    if (!selectedGroup) {
+      return 0;
+    }
+
+    const participantIds = new Set();
+    const leaderId = String(selectedGroup.leader?.id || selectedGroup.leaderId || '');
+
+    if (leaderId) {
+      participantIds.add(leaderId);
+    }
+
+    (selectedGroup.members || []).forEach((member) => {
+      participantIds.add(String(member.id));
+    });
+
+    return participantIds.size;
+  }, [selectedGroup]);
+
   useEffect(() => {
     if (!selectedGroup) {
       setSelectedAdvisorId('');
@@ -289,7 +308,7 @@ export default function CoordinatorAdvisorTransferPage() {
               Current Advisor: {selectedGroup?.advisor?.fullName || selectedGroup?.advisor?.email || 'Unassigned'}
             </p>
             <p className="token-copy">
-              Members: {(selectedGroup?.members || []).length}
+              Members: {totalMembers}
             </p>
           </section>
 

--- a/frontend/src/CoordinatorGroupMembershipPage.jsx
+++ b/frontend/src/CoordinatorGroupMembershipPage.jsx
@@ -90,6 +90,25 @@ export default function CoordinatorGroupMembershipPage() {
     [groups, selectedGroupId],
   );
 
+  const totalMembers = useMemo(() => {
+    if (!selectedGroup) {
+      return 0;
+    }
+
+    const participantIds = new Set();
+    const leaderId = String(selectedGroup.leader?.id || selectedGroup.leaderId || '');
+
+    if (leaderId) {
+      participantIds.add(leaderId);
+    }
+
+    (selectedGroup.members || []).forEach((member) => {
+      participantIds.add(String(member.id));
+    });
+
+    return participantIds.size;
+  }, [selectedGroup]);
+
   async function handleSubmit(event) {
     event.preventDefault();
 
@@ -233,7 +252,7 @@ export default function CoordinatorGroupMembershipPage() {
               Leader: {selectedGroup?.leader?.fullName || selectedGroup?.leader?.studentId || 'Unknown'}
             </p>
             <p className="token-copy">
-              Members: {(selectedGroup?.members || []).length}
+              Members: {totalMembers}
             </p>
           </section>
 

--- a/frontend/src/GroupCleanupPage.jsx
+++ b/frontend/src/GroupCleanupPage.jsx
@@ -108,7 +108,7 @@ export default function GroupCleanupPage({ role = 'COORDINATOR' }) {
   );
 
   const hasAdvisor = Boolean(selectedGroup?.advisor?.id);
-  const totalMembers = (selectedGroup?.members || []).length + (selectedGroup?.leader ? 1 : 0);
+  const totalMembers = (selectedGroup?.members || []).length;
 
   async function handleDelete() {
     if (!selectedGroup) {

--- a/frontend/src/GroupCleanupPage.jsx
+++ b/frontend/src/GroupCleanupPage.jsx
@@ -108,7 +108,24 @@ export default function GroupCleanupPage({ role = 'COORDINATOR' }) {
   );
 
   const hasAdvisor = Boolean(selectedGroup?.advisor?.id);
-  const totalMembers = (selectedGroup?.members || []).length;
+  const totalMembers = useMemo(() => {
+    if (!selectedGroup) {
+      return 0;
+    }
+
+    const participantIds = new Set();
+    const leaderId = String(selectedGroup.leader?.id || selectedGroup.leaderId || '');
+
+    if (leaderId) {
+      participantIds.add(leaderId);
+    }
+
+    (selectedGroup.members || []).forEach((member) => {
+      participantIds.add(String(member.id));
+    });
+
+    return participantIds.size;
+  }, [selectedGroup]);
 
   async function handleDelete() {
     if (!selectedGroup) {

--- a/frontend/src/StudentGroupShellPage.jsx
+++ b/frontend/src/StudentGroupShellPage.jsx
@@ -58,6 +58,15 @@ export default function StudentGroupShellPage() {
     return rows;
   })();
 
+  const kickableMembers = (() => {
+    if (!selectedGroup) {
+      return [];
+    }
+
+    const leaderId = String(selectedGroup.leader?.id || selectedGroup.leaderId || '');
+    return (selectedGroup.members || []).filter((member) => String(member.id) !== leaderId);
+  })();
+
   async function loadGroupDirectory() {
     setGroupsLoading(true);
 
@@ -101,7 +110,8 @@ export default function StudentGroupShellPage() {
     setEditGroupMaxMembers(selectedGroup?.maxMembers || 4);
     setInviteIds([]);
     setSelectedInviteIds([]);
-    const firstKickable = (selectedGroup?.members || [])[0];
+    const leaderId = String(selectedGroup?.leader?.id || selectedGroup?.leaderId || '');
+    const firstKickable = (selectedGroup?.members || []).find((member) => String(member.id) !== leaderId);
     setSelectedKickMemberId(firstKickable ? String(firstKickable.id) : '');
   }, [selectedGroup]);
 
@@ -447,8 +457,8 @@ export default function StudentGroupShellPage() {
                         value={selectedKickMemberId}
                         onChange={(event) => setSelectedKickMemberId(event.target.value)}
                       >
-                        {!selectedGroup.members?.length && <option value="">No members to kick</option>}
-                        {(selectedGroup.members || []).map((member) => (
+                        {kickableMembers.length === 0 && <option value="">No members to kick</option>}
+                        {kickableMembers.map((member) => (
                           <option key={member.id} value={member.id}>{member.fullName || member.studentId || member.id}</option>
                         ))}
                       </select>

--- a/frontend/src/StudentInvitationsPage.jsx
+++ b/frontend/src/StudentInvitationsPage.jsx
@@ -3,6 +3,53 @@ import { Link } from 'react-router-dom';
 import { useNotification } from './contexts/NotificationContext';
 import { useStudentInvitations } from './hooks/useStudentInvitations';
 
+function NotificationSection({
+  title,
+  eyebrow,
+  entries,
+  loading,
+  error,
+  emptyMessage,
+  formatSubjectLine,
+  formatPreviewLine,
+}) {
+  return (
+    <section className="mail-category-panel">
+      <div className="mail-category-header">
+        <p className="mail-category-eyebrow">{eyebrow}</p>
+        <div className="mail-category-heading">
+          <h2>{title}</h2>
+          <span className="mail-category-count">{entries.length}</span>
+        </div>
+      </div>
+
+      {loading && (
+        <p className="mail-state" aria-live="polite">Loading notifications...</p>
+      )}
+
+      {!loading && error && (
+        <p className="mail-state" aria-live="polite">{error}</p>
+      )}
+
+      {!loading && !error && entries.length === 0 && (
+        <p className="mail-state" aria-live="polite">{emptyMessage}</p>
+      )}
+
+      {!loading && !error && entries.length > 0 && (
+        <section className="mail-nav mail-nav-static" aria-label={`${title} list`}>
+          {entries.map((entry) => (
+            <article key={entry.id} className="mail-nav-item mail-nav-item-static">
+              <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
+              <span className="mail-nav-subject">{formatSubjectLine(entry)}</span>
+              <span className="mail-nav-preview">{formatPreviewLine(entry)}</span>
+            </article>
+          ))}
+        </section>
+      )}
+    </section>
+  );
+}
+
 function getGroupLabel(entry) {
   const raw = entry.groupName || entry.payload?.groupName || '';
   if (!raw) {
@@ -384,100 +431,56 @@ export default function StudentInvitationsPage() {
 
   return (
     <main className="page page-mailbox">
-      <section className="panel">
-        <div className="mail-sidebar-header">
-          <p className="mailbox-title">Advisor Release Notifications</p>
-          <p className="mailbox-count">{advisorReleases.length} notifications</p>
-        </div>
-
-        {loadingReleases && (
-          <p className="mail-state" aria-live="polite">Loading advisor release notifications...</p>
-        )}
-
-        {!loadingReleases && releaseLoadError && (
-          <p className="mail-state" aria-live="polite">{releaseLoadError}</p>
-        )}
-
-        {!loadingReleases && !releaseLoadError && advisorReleases.length === 0 && (
-          <p className="mail-state" aria-live="polite">No advisor release notifications yet.</p>
-        )}
-
-        {!loadingReleases && !releaseLoadError && advisorReleases.length > 0 && (
-          <section className="mail-nav" aria-label="Advisor release notification list">
-            {advisorReleases.map((entry) => (
-              <article key={entry.id} className="mail-nav-item">
-                <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
-                <span className="mail-nav-subject">{formatAdvisorReleaseSubject(entry)}</span>
-                <span className="mail-nav-preview">{formatAdvisorReleasePreview(entry)}</span>
-              </article>
-            ))}
-          </section>
-        )}
+      <section className="hero">
+        <p className="eyebrow">Student Workspace</p>
+        <h1>Notifications</h1>
+        <p className="subtitle">
+          Review advisor decisions, transfer updates, release notices, and pending invitations in one mailbox.
+        </p>
       </section>
 
-      <section className="panel">
-        <div className="mail-sidebar-header">
-          <p className="mailbox-title">Advisor Decision Notifications</p>
-          <p className="mailbox-count">{advisorDecisions.length} notifications</p>
-        </div>
+      <p className="back-link-wrap">
+        <Link className="back-link" to="/students/groups/manage">
+          Back to Group Management
+        </Link>
+      </p>
 
-        {loadingDecisions && (
-          <p className="mail-state" aria-live="polite">Loading advisor decision notifications...</p>
-        )}
+      <section className="mail-summary-grid">
+        <NotificationSection
+          title="Advisor Release"
+          eyebrow="Lifecycle"
+          entries={advisorReleases}
+          loading={loadingReleases}
+          error={releaseLoadError}
+          emptyMessage="No advisor release notifications yet."
+          formatSubjectLine={formatAdvisorReleaseSubject}
+          formatPreviewLine={formatAdvisorReleasePreview}
+        />
 
-        {!loadingDecisions && decisionLoadError && (
-          <p className="mail-state" aria-live="polite">{decisionLoadError}</p>
-        )}
+        <NotificationSection
+          title="Advisor Decisions"
+          eyebrow="Requests"
+          entries={advisorDecisions}
+          loading={loadingDecisions}
+          error={decisionLoadError}
+          emptyMessage="No advisor decision notifications yet."
+          formatSubjectLine={formatAdvisorDecisionSubject}
+          formatPreviewLine={formatAdvisorDecisionPreview}
+        />
 
-        {!loadingDecisions && !decisionLoadError && advisorDecisions.length === 0 && (
-          <p className="mail-state" aria-live="polite">No advisor decision notifications yet.</p>
-        )}
-
-        {!loadingDecisions && !decisionLoadError && advisorDecisions.length > 0 && (
-          <section className="mail-nav" aria-label="Advisor decision notification list">
-            {advisorDecisions.map((entry) => (
-              <article key={entry.id} className="mail-nav-item">
-                <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
-                <span className="mail-nav-subject">{formatAdvisorDecisionSubject(entry)}</span>
-                <span className="mail-nav-preview">{formatAdvisorDecisionPreview(entry)}</span>
-              </article>
-            ))}
-          </section>
-        )}
+        <NotificationSection
+          title="Advisor Transfers"
+          eyebrow="Assignments"
+          entries={advisorTransfers}
+          loading={loadingTransfers}
+          error={transferLoadError}
+          emptyMessage="No advisor transfer notifications yet."
+          formatSubjectLine={formatAdvisorTransferSubject}
+          formatPreviewLine={formatAdvisorTransferPreview}
+        />
       </section>
 
-      <section className="panel">
-        <div className="mail-sidebar-header">
-          <p className="mailbox-title">Advisor Transfer Notifications</p>
-          <p className="mailbox-count">{advisorTransfers.length} notifications</p>
-        </div>
-
-        {loadingTransfers && (
-          <p className="mail-state" aria-live="polite">Loading advisor transfer notifications...</p>
-        )}
-
-        {!loadingTransfers && transferLoadError && (
-          <p className="mail-state" aria-live="polite">{transferLoadError}</p>
-        )}
-
-        {!loadingTransfers && !transferLoadError && advisorTransfers.length === 0 && (
-          <p className="mail-state" aria-live="polite">No advisor transfer notifications yet.</p>
-        )}
-
-        {!loadingTransfers && !transferLoadError && advisorTransfers.length > 0 && (
-          <section className="mail-nav" aria-label="Advisor transfer notification list">
-            {advisorTransfers.map((entry) => (
-              <article key={entry.id} className="mail-nav-item">
-                <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
-                <span className="mail-nav-subject">{formatAdvisorTransferSubject(entry)}</span>
-                <span className="mail-nav-preview">{formatAdvisorTransferPreview(entry)}</span>
-              </article>
-            ))}
-          </section>
-        )}
-      </section>
-
-      <section className="single-panel">
+      <section className="single-panel mail-inbox-shell">
         {loading && (
           <p className="mail-state" aria-live="polite">Loading mail...</p>
         )}
@@ -495,7 +498,17 @@ export default function StudentInvitationsPage() {
             <aside className="mail-sidebar" aria-label="Mailbox items">
               <div className="mail-sidebar-header">
                 <p className="mailbox-title">Inbox</p>
-                <p className="mailbox-count">{allMail.length} messages</p>
+                <p className="mailbox-count">Open a message to respond or inspect details.</p>
+                <div className="mailbox-stat-row">
+                  <span className="mailbox-stat">
+                    <strong>{pendingInviteMails.length}</strong>
+                    Pending invites
+                  </span>
+                  <span className="mailbox-stat">
+                    <strong>{allMail.length}</strong>
+                    Total messages
+                  </span>
+                </div>
               </div>
 
               <section className="mail-nav">
@@ -505,7 +518,7 @@ export default function StudentInvitationsPage() {
                     <button
                       key={key}
                       type="button"
-                      className="mail-nav-item"
+                      className={`mail-nav-item ${selectedMailId === key ? 'mail-nav-item-active' : ''}`}
                       onClick={() => setSelectedMailId(key)}
                     >
                       <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>

--- a/frontend/src/SubmitAdvisorRequestPage.jsx
+++ b/frontend/src/SubmitAdvisorRequestPage.jsx
@@ -26,6 +26,10 @@ export default function SubmitAdvisorRequestPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const selectedGroup = groups.find((group) => String(group.id) === String(form.groupId)) || null;
+  const selectedGroupHasAdvisor = Boolean(selectedGroup?.advisorId);
+  const eligibleGroups = groups.filter((group) => !group.advisorId);
+
   useEffect(() => {
     async function loadData() {
       try {
@@ -132,12 +136,17 @@ export default function SubmitAdvisorRequestPage() {
             >
               <option value="">-- Select a group --</option>
               {groups.map((group) => (
-                <option key={group.id} value={group.id}>
+                <option key={group.id} value={group.id} disabled={Boolean(group.advisorId)}>
                   {group.name}
                   {group.advisorId ? ' (Already has advisor)' : ''}
                 </option>
               ))}
             </select>
+            {groups.length > 0 && eligibleGroups.length === 0 && (
+              <div className="field-help" role="note">
+                All of your groups already have advisors, so no new advisor request can be created.
+              </div>
+            )}
             {fieldErrors.groupId.length > 0 && (
               <div className="field-error" role="alert">
                 {fieldErrors.groupId.map((error) => (
@@ -153,7 +162,7 @@ export default function SubmitAdvisorRequestPage() {
               name="professorId"
               value={form.professorId}
               onChange={handleChange}
-              disabled={isSubmitting}
+              disabled={isSubmitting || !form.groupId || selectedGroupHasAdvisor}
               aria-invalid={fieldErrors.professorId.length > 0}
               required
             >
@@ -165,6 +174,11 @@ export default function SubmitAdvisorRequestPage() {
                 </option>
               ))}
             </select>
+            {selectedGroupHasAdvisor && (
+              <div className="field-help" role="note">
+                This group already has an assigned advisor. Choose a different group to submit a new request.
+              </div>
+            )}
             {fieldErrors.professorId.length > 0 && (
               <div className="field-error" role="alert">
                 {fieldErrors.professorId.map((error) => (
@@ -181,7 +195,9 @@ export default function SubmitAdvisorRequestPage() {
               || !form.groupId
               || !form.professorId
               || groups.length === 0
+              || eligibleGroups.length === 0
               || professors.length === 0
+              || selectedGroupHasAdvisor
             }
           >
             {isSubmitting ? 'Submitting...' : 'Submit Request'}

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Link, NavLink, Outlet } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, NavLink, Outlet, useLocation } from 'react-router-dom';
 import NotificationViewport from './NotificationViewport';
 
 const roleMenuSections = {
@@ -51,6 +51,7 @@ const roleMenuSections = {
         { to: '/admin/professors/new', label: 'Create Professor Account', icon: 'MG' },
         { to: '/admin/coordinators/new', label: 'Create Coordinator Account', icon: 'CG' },
         { to: '/admin/groups/cleanup', label: 'Group Cleanup', icon: 'GC' },
+        { to: '/admin/audit-logs', label: 'Audit Logs', icon: 'AL' },
       ],
     },
   ],
@@ -96,7 +97,13 @@ function readAuthenticatedUser() {
 export default function AppShell() {
   const [openMenu, setOpenMenu] = useState(false);
   const [openProfile, setOpenProfile] = useState(false);
-  const authenticatedUser = readAuthenticatedUser();
+  const location = useLocation();
+  const [authenticatedUser, setAuthenticatedUser] = useState(() => readAuthenticatedUser());
+
+  useEffect(() => {
+    setAuthenticatedUser(readAuthenticatedUser());
+  }, [location.key]);
+
   const isAuthenticated = Boolean(authenticatedUser);
   const viewer = authenticatedUser || { label: 'Guest', role: 'Guest', initials: 'G' };
   const menuSections = isAuthenticated ? (roleMenuSections[authenticatedUser.role] || []) : [];

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -10,8 +10,15 @@
   --error-line: rgba(248, 113, 113, 0.34);
   --error-ink: #fecaca;
   --error-ink-strong: #ffe4e6;
-  --success-bg: #ecfdf3;
-  --warning-bg: #fff7ed;
+  --success-bg: linear-gradient(180deg, rgba(10, 58, 41, 0.96), rgba(8, 45, 32, 0.94));
+  --success-line: rgba(74, 222, 128, 0.28);
+  --success-ink: #dcfce7;
+  --warning-bg: linear-gradient(180deg, rgba(95, 52, 12, 0.96), rgba(73, 37, 8, 0.94));
+  --warning-line: rgba(245, 158, 11, 0.28);
+  --warning-ink: #ffedd5;
+  --info-bg: linear-gradient(180deg, rgba(9, 57, 70, 0.96), rgba(8, 43, 54, 0.94));
+  --info-line: rgba(56, 195, 204, 0.28);
+  --info-ink: #d9fbff;
   --shadow: 0 24px 64px rgba(6, 10, 16, 0.35);
   --radius-xl: 28px;
   --radius-pill: 999px;
@@ -389,11 +396,14 @@ textarea {
   border: 1px solid var(--line);
   box-shadow: var(--shadow);
   padding: 16px 18px;
-  background: rgba(255, 252, 245, 0.96);
+  background: rgba(24, 33, 47, 0.96);
+  color: var(--ink);
 }
 
 .notification-success {
   background: var(--success-bg);
+  border-color: var(--success-line);
+  color: var(--success-ink);
 }
 
 .notification-error {
@@ -404,6 +414,8 @@ textarea {
 
 .notification-warning {
   background: var(--warning-bg);
+  border-color: var(--warning-line);
+  color: var(--warning-ink);
 }
 
 .notification-title {
@@ -413,7 +425,8 @@ textarea {
 
 .notification-message {
   margin: 0;
-  color: var(--muted);
+  color: inherit;
+  opacity: 0.82;
   line-height: 1.5;
 }
 
@@ -421,8 +434,8 @@ textarea {
   width: auto;
   min-width: auto;
   padding: 10px 14px;
-  background: rgba(31, 42, 31, 0.08);
-  color: var(--ink);
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
   box-shadow: none;
 }
 
@@ -1093,6 +1106,13 @@ textarea {
   min-height: 132px;
 }
 
+.field-help {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
 .field input:focus,
 .field textarea:focus,
 .field select:focus {
@@ -1467,12 +1487,15 @@ button:disabled {
 }
 
 .feedback-loading {
-  background: linear-gradient(180deg, rgba(15, 118, 110, 0.08), rgba(255, 252, 245, 0.95));
+  background: var(--info-bg);
+  border-color: var(--info-line);
+  color: var(--info-ink);
 }
 
 .feedback-success {
   background: var(--success-bg);
-  border-color: rgba(22, 101, 52, 0.18);
+  border-color: var(--success-line);
+  color: var(--success-ink);
 }
 
 .feedback-error {
@@ -1483,7 +1506,8 @@ button:disabled {
 
 .feedback-warning {
   background: var(--warning-bg);
-  border-color: rgba(180, 83, 9, 0.18);
+  border-color: var(--warning-line);
+  color: var(--warning-ink);
 }
 
 .mail-layout {
@@ -1534,6 +1558,66 @@ button:disabled {
   max-width: 1200px;
 }
 
+.mail-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-bottom: 24px;
+}
+
+.mail-category-panel,
+.mail-inbox-shell {
+  border: 1px solid var(--line);
+  border-radius: 28px;
+  background:
+    radial-gradient(circle at top right, rgba(56, 195, 204, 0.1), transparent 30%),
+    linear-gradient(180deg, rgba(26, 35, 49, 0.96), rgba(18, 25, 37, 0.96));
+  box-shadow: var(--shadow);
+}
+
+.mail-category-panel {
+  padding: 18px;
+}
+
+.mail-category-header {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.mail-category-eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.mail-category-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mail-category-heading h2 {
+  margin: 0;
+  font-size: 1.12rem;
+}
+
+.mail-category-count {
+  min-width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 195, 204, 0.34);
+  background: rgba(56, 195, 204, 0.12);
+  color: #c9fbff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+
 .page-mailbox .hero {
   max-width: 620px;
   margin-bottom: 16px;
@@ -1550,54 +1634,92 @@ button:disabled {
 }
 
 .mail-sidebar {
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  background: rgba(24, 33, 47, 0.85);
+  border-radius: 28px;
+  background: transparent;
   overflow: hidden;
 }
 
 .mail-sidebar-header {
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--line);
-  background: rgba(17, 24, 36, 0.76);
+  padding: 22px 22px 16px;
+  border-bottom: 1px solid rgba(168, 183, 206, 0.16);
+  background: rgba(9, 15, 24, 0.22);
 }
 
 .mailbox-title {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 1.15rem;
   font-weight: 700;
 }
 
 .mailbox-count {
-  margin: 4px 0 0;
-  font-size: 0.82rem;
+  margin: 8px 0 0;
+  font-size: 0.92rem;
   color: var(--muted);
 }
 
-.mail-nav {
-  padding: 8px;
+.mailbox-stat-row {
+  margin-top: 16px;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.mailbox-stat {
+  min-width: 140px;
+  border: 1px solid rgba(168, 183, 206, 0.18);
+  border-radius: 16px;
+  padding: 10px 12px;
+  background: rgba(30, 40, 56, 0.54);
+  color: var(--muted);
   display: grid;
-  gap: 8px;
+  gap: 3px;
+  font-size: 0.84rem;
+}
+
+.mailbox-stat strong {
+  color: var(--ink);
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.mail-nav {
+  padding: 14px;
+  display: grid;
+  gap: 10px;
   max-height: 72vh;
   overflow: auto;
+}
+
+.mail-nav-static {
+  max-height: 360px;
 }
 
 .mail-nav-item {
   width: 100%;
   text-align: left;
-  min-height: 74px;
-  border-radius: 10px;
-  padding: 10px 12px;
+  min-height: 88px;
+  border: 1px solid rgba(168, 183, 206, 0.14);
+  border-radius: 18px;
+  padding: 14px;
   box-shadow: none;
-  background: rgba(65, 79, 102, 0.22);
+  background: linear-gradient(180deg, rgba(35, 46, 64, 0.74), rgba(25, 34, 49, 0.84));
   display: grid;
-  gap: 4px;
+  gap: 6px;
   align-content: center;
 }
 
+.mail-nav-item-static:hover {
+  transform: none;
+  filter: none;
+  box-shadow: none;
+}
+
 .mail-nav-item-active {
-  border: 1px solid rgba(56, 195, 204, 0.46);
-  background: rgba(56, 195, 204, 0.16);
+  border-color: rgba(56, 195, 204, 0.52);
+  background:
+    radial-gradient(circle at top right, rgba(56, 195, 204, 0.14), transparent 34%),
+    linear-gradient(180deg, rgba(30, 55, 68, 0.8), rgba(22, 38, 51, 0.9));
+  box-shadow: inset 0 0 0 1px rgba(56, 195, 204, 0.14);
 }
 
 .mail-nav-time {
@@ -1675,10 +1797,10 @@ button:disabled {
 }
 
 .mail-preview {
-  margin: 6px 0 0;
-  color: var(--muted);
-  line-height: 1.4;
-  font-size: 0.94rem;
+  margin: 16px 0 0;
+  color: #d2dcea;
+  line-height: 1.7;
+  font-size: 1rem;
 }
 
 .mail-meta {
@@ -1866,6 +1988,84 @@ button:disabled {
   margin: 0;
 }
 
+.audit-log-list {
+  display: grid;
+  gap: 16px;
+}
+
+.audit-log-card {
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at top right, rgba(56, 195, 204, 0.08), transparent 28%),
+    linear-gradient(180deg, rgba(27, 36, 50, 0.96), rgba(19, 26, 38, 0.96));
+  box-shadow: var(--shadow);
+  padding: 20px;
+}
+
+.audit-log-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.audit-log-action {
+  border-radius: 999px;
+  border: 1px solid rgba(56, 195, 204, 0.34);
+  background: rgba(56, 195, 204, 0.12);
+  color: #d4fbff;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.audit-log-time {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.audit-log-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.audit-log-label {
+  margin: 0 0 4px;
+  font-size: 0.74rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.audit-log-value {
+  margin: 0;
+  font-weight: 700;
+}
+
+.audit-log-subvalue {
+  margin: 4px 0 0;
+  color: var(--muted);
+  word-break: break-word;
+}
+
+.audit-log-metadata {
+  margin: 16px 0 0;
+  padding: 14px;
+  border: 1px solid rgba(168, 183, 206, 0.16);
+  border-radius: 16px;
+  background: rgba(10, 16, 24, 0.6);
+  color: #c9d7ea;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: auto;
+}
+
+
 @keyframes mailDrawerIn {
   from {
     opacity: 0;
@@ -1878,6 +2078,7 @@ button:disabled {
 }
 
 @media (max-width: 860px) {
+  .mail-summary-grid,
   .gateway-grid,
   .panel,
   .auth-layout-stack,
@@ -1896,6 +2097,10 @@ button:disabled {
   }
 
   .mail-detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .audit-log-grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary

This PR tightens several mentor matching and group-management edge cases, fixes legacy audit log compatibility, and adds an admin-only audit log page.

## What Changed

- blocked advisor requests for groups that already have an assigned advisor
- blocked multiple pending advisor requests for the same group
- updated the advisor request UI to disable invalid group/professor selections earlier
- fixed coordinator membership edits so the leader cannot be re-added as a member
- enforced max group capacity during coordinator membership edits
- kept coordinator membership updates writing compatible audit log entries
- fixed the legacy `GroupService._writeAuditLog` helper to use `targetType` / `targetId`
- added an admin-only audit log endpoint and frontend page
- added admin navigation access to the audit log page
- aligned group cleanup member count with the manual membership page
- improved student notifications page layout and visual consistency
- hid non-kickable users from the student kick dropdown
- refreshed app shell auth state so the top-right profile reflects the active user after login

## Backend Details

### Advisor request safeguards
- `GROUP_ALREADY_HAS_ADVISOR` is returned when the selected group already has an advisor
- `GROUP_ALREADY_HAS_PENDING_REQUEST` is returned when the group already has a pending advisor request

### Coordinator membership safeguards
- prevents re-adding the group leader as a regular member
- prevents exceeding `maxMembers`
- preserves audit metadata for coordinator membership changes

### Audit logging
- added `GET /api/v1/admin/audit-logs`
- fixed legacy invitation audit writes in `GroupService._writeAuditLog`
- admin audit log feed is restricted to `ADMIN`

## Audit Logs Currently Captured

Current persisted audit actions:

- `ADVISOR_REQUEST_APPROVED`
- `ADVISOR_REQUEST_REJECTED`
- `COORDINATOR_MEMBER_ADDED`
- `COORDINATOR_MEMBER_REMOVED`
- `INVITE_ACCEPTED`
- `INVITE_REJECTED`
- `INVITATION_ACCEPTED`
- `INVITATION_REJECTED`
- `DELETE_ORPHAN_GROUP`

Each audit record stores:

- `action`
- `actorId`
- `targetType`
- `targetId`
- `metadata`
- `createdAt`


## Frontend Details

- added `/admin/audit-logs`
- added admin menu entry for `Audit Logs`
- updated advisor request form messaging and disabled states
- updated group cleanup count logic
- improved student notifications page structure and styling
- removed self/non-kickable entries from the kick dropdown

## Verification

- backend tests passed: `41/41`
- frontend production build passed

## Additional Updates

- aligned `maxMembers` semantics so leader + members are counted consistently
- fixed coordinator membership, transfer, and cleanup screens to show total participants consistently
- prevented lowering `maxMembers` below current participant count
- added regression tests for participant-count-based capacity rules


## Notes

- Other audit logs can be added later
