### PR TITLE
Fix mentor matching audits and tighten advisor/group workflows

### DIFF
--- a/backend/controllers/groupController.js
+++ b/backend/controllers/groupController.js
@@ -594,6 +594,29 @@ exports.dispatchInvites = async (req, res) => {
     if (!group) return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
     if (String(group.leaderId || '') !== String(req.user.id)) return res.status(403).json({ code: 'FORBIDDEN', message: 'Only the group leader can send invitations' });
 
+    const participantIds = new Set();
+    if (group.leaderId) {
+      participantIds.add(String(group.leaderId));
+    }
+    (Array.isArray(group.memberIds) ? group.memberIds : []).forEach((memberId) => {
+      participantIds.add(String(memberId));
+    });
+
+    const availableSlots = Math.max(Number(group.maxMembers || 0) - participantIds.size, 0);
+    if (availableSlots <= 0) {
+      return res.status(409).json({
+        code: 'GROUP_FULL',
+        message: 'This group is already at full capacity.',
+      });
+    }
+
+    if (requestedStudentIds.length > availableSlots) {
+      return res.status(409).json({
+        code: 'INVITE_CAPACITY_EXCEEDED',
+        message: `Only ${availableSlots} slot${availableSlots === 1 ? '' : 's'} available for new invitations.`,
+      });
+    }
+
     const users = await User.findAll({ where: { role: 'STUDENT', studentId: { [Op.in]: requestedStudentIds } } });
 
     const usersByStudentId = new Map(users.map((user) => [user.studentId, user]));

--- a/backend/controllers/groupController.js
+++ b/backend/controllers/groupController.js
@@ -602,21 +602,6 @@ exports.dispatchInvites = async (req, res) => {
       participantIds.add(String(memberId));
     });
 
-    const availableSlots = Math.max(Number(group.maxMembers || 0) - participantIds.size, 0);
-    if (availableSlots <= 0) {
-      return res.status(409).json({
-        code: 'GROUP_FULL',
-        message: 'This group is already at full capacity.',
-      });
-    }
-
-    if (requestedStudentIds.length > availableSlots) {
-      return res.status(409).json({
-        code: 'INVITE_CAPACITY_EXCEEDED',
-        message: `Only ${availableSlots} slot${availableSlots === 1 ? '' : 's'} available for new invitations.`,
-      });
-    }
-
     const users = await User.findAll({ where: { role: 'STUDENT', studentId: { [Op.in]: requestedStudentIds } } });
 
     const usersByStudentId = new Map(users.map((user) => [user.studentId, user]));
@@ -665,6 +650,43 @@ exports.dispatchInvites = async (req, res) => {
     }
 
     const inviteeIds = users.map((user) => user.id);
+    const existingInvitations = await Invitation.findAll({
+      where: { groupId, inviteeId: inviteeIds },
+      attributes: ['inviteeId', 'status'],
+    });
+    const existingPendingInviteeIds = new Set(
+      existingInvitations
+        .filter((invitation) => invitation.status === 'PENDING')
+        .map((invitation) => invitation.inviteeId),
+    );
+    const pendingInvitationCount = await Invitation.count({
+      where: {
+        groupId,
+        status: 'PENDING',
+      },
+    });
+    const availableSlots = Math.max(
+      Number(group.maxMembers || 0) - participantIds.size - pendingInvitationCount,
+      0,
+    );
+    const additionalPendingInvitesNeeded = inviteeIds.filter(
+      (inviteeId) => !existingPendingInviteeIds.has(inviteeId),
+    ).length;
+
+    if (additionalPendingInvitesNeeded > 0 && availableSlots <= 0) {
+      return res.status(409).json({
+        code: 'GROUP_FULL',
+        message: 'This group is already at full capacity.',
+      });
+    }
+
+    if (additionalPendingInvitesNeeded > availableSlots) {
+      return res.status(409).json({
+        code: 'INVITE_CAPACITY_EXCEEDED',
+        message: `Only ${availableSlots} slot${availableSlots === 1 ? '' : 's'} available for new invitations.`,
+      });
+    }
+
     const { created, skipped } = await GroupService.dispatchInvites(groupId, inviteeIds);
 
     const skippedStudentIds = skipped.map((inviteeId) => users.find((user) => user.id === inviteeId)?.studentId).filter(Boolean);

--- a/backend/controllers/mentorMatchingController.js
+++ b/backend/controllers/mentorMatchingController.js
@@ -1,3 +1,11 @@
+// Controller for mentor matching operations, including advisor transfers and synchronization
+// - POST /api/v1/mentor-matching/groups/:groupId/transfer: Transfer advisor in Group DB
+// - POST /api/v1/mentor-matching/groups/:groupId/sync: Sync advisor assignment to User DB
+// - POST /api/v1/mentor-matching/groups/:groupId/transfer-by-coordinator: Transfer advisor by coordinator action
+// - DELETE /api/v1/mentor-matching/groups/:groupId/advisor: Remove advisor assignment from group
+// - DELETE /api/v1/mentor-matching/groups/:groupId/orphan: Delete orphan group without advisor
+// - GET /api/v1/mentor-matching/coordinator-advisors: List advisors available for coordinator actions
+
 const { body, param, validationResult } = require('express-validator');
 const mentorMatchingService = require('../services/mentorMatchingService');
 const GroupService = require('../services/groupService');
@@ -89,6 +97,7 @@ const transferByCoordinator = [
       const assignment = await mentorMatchingService.transferAdvisorByCoordinator({
         groupId: req.params.groupId,
         newAdvisorId: req.body.newAdvisorId,
+        actorId: req.user.id,
       });
 
       return res.status(200).json(assignment);

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -46,7 +46,10 @@ class GroupService {
       throw error;
     }
 
-    const result = await mentorMatchingService.removeAdvisorAssignmentFromGroup({ groupId });
+    const result = await mentorMatchingService.removeAdvisorAssignmentFromGroup({
+      groupId,
+      actorId: Number.parseInt(String(advisorId), 10),
+    });
     const updatedGroup = await Group.findByPk(groupId);
 
     return {
@@ -316,12 +319,19 @@ class GroupService {
 
     const existing = await Invitation.findAll({
       where: { groupId, inviteeId: uniqueInviteeIds },
-      attributes: ['inviteeId'],
+      attributes: ['id', 'groupId', 'inviteeId', 'status'],
     });
 
-    const alreadyInvited = new Set(existing.map((inv) => inv.inviteeId));
-    const toInsert = uniqueInviteeIds.filter((id) => !alreadyInvited.has(id));
-    const skipped = uniqueInviteeIds.filter((id) => alreadyInvited.has(id));
+    const pendingInviteeIds = new Set(
+      existing
+        .filter((invitation) => invitation.status === 'PENDING')
+        .map((invitation) => invitation.inviteeId),
+    );
+    const recyclableInvitations = existing.filter((invitation) => invitation.status !== 'PENDING');
+    const recyclableInviteeIds = new Set(recyclableInvitations.map((invitation) => invitation.inviteeId));
+
+    const toInsert = uniqueInviteeIds.filter((id) => !pendingInviteeIds.has(id) && !recyclableInviteeIds.has(id));
+    const skipped = uniqueInviteeIds.filter((id) => pendingInviteeIds.has(id));
 
     let created = [];
     if (toInsert.length > 0) {
@@ -330,6 +340,15 @@ class GroupService {
         { returning: true },
       );
     }
+
+    const requeued = await Promise.all(
+      recyclableInvitations.map(async (invitation) => {
+        await invitation.update({ status: 'PENDING' });
+        return invitation;
+      }),
+    );
+
+    created = [...created, ...requeued];
 
     for (const invitation of created) {
       NotificationService.queueInviteAlert(

--- a/backend/services/mentorMatchingService.js
+++ b/backend/services/mentorMatchingService.js
@@ -1,5 +1,19 @@
+// Service for handling mentor matching operations, including advisor transfers and synchronization
+// - transferAdvisorInGroupDatabase: Transfer advisor in Group DB
+// - syncAdvisorAssignmentsForGroup: Sync advisor assignment to User DB
+// - transferAdvisorByCoordinator: Transfer advisor by coordinator action
+// - removeAdvisorAssignmentFromGroup: Remove advisor assignment from group
+// - listActiveAdvisors: List advisors available for coordinator actions
+
+
 const sequelize = require('../db');
-const { Group, GroupAdvisorAssignment, Professor, User } = require('../models');
+const {
+  Group,
+  GroupAdvisorAssignment,
+  Professor,
+  User,
+  AuditLog,
+} = require('../models');
 const NotificationService = require('./notificationService');
 
 function createServiceError(status, code, message) {
@@ -150,9 +164,10 @@ async function syncAdvisorAssignmentsForGroup({ groupId, advisorId, transaction 
   };
 }
 
-async function transferAdvisorByCoordinator({ groupId, newAdvisorId }) {
+async function transferAdvisorByCoordinator({ groupId, newAdvisorId, actorId = null }) {
   const result = await sequelize.transaction(async (transaction) => {
     const group = await loadGroupForTransfer(groupId, { transaction });
+    const previousAdvisorId = group.advisorId || null;
     const assignment = await transferAdvisorInGroupDatabase({
       groupId,
       newAdvisorId,
@@ -163,6 +178,21 @@ async function transferAdvisorByCoordinator({ groupId, newAdvisorId }) {
       advisorId: newAdvisorId,
       transaction,
     });
+
+    if (actorId) {
+      await AuditLog.create({
+        action: 'ADVISOR_TRANSFER',
+        actorId,
+        targetType: 'GROUP',
+        targetId: group.id,
+        metadata: {
+          groupId: group.id,
+          groupName: group.name || null,
+          previousAdvisorId,
+          newAdvisorId: assignment.advisorId,
+        },
+      }, { transaction });
+    }
 
     return {
       groupId: assignment.groupId,
@@ -208,7 +238,7 @@ async function transferAdvisorByCoordinator({ groupId, newAdvisorId }) {
   };
 }
 
-async function removeAdvisorAssignmentFromGroup({ groupId }) {
+async function removeAdvisorAssignmentFromGroup({ groupId, actorId = null }) {
   const result = await sequelize.transaction(async (transaction) => {
     const group = await loadGroupForTransfer(groupId, { transaction });
 
@@ -225,6 +255,20 @@ async function removeAdvisorAssignmentFromGroup({ groupId }) {
     group.advisorId = null;
     group.status = 'LOOKING_FOR_ADVISOR';
     await group.save({ transaction });
+
+    if (actorId) {
+      await AuditLog.create({
+        action: 'ADVISOR_RELEASE',
+        actorId,
+        targetType: 'GROUP',
+        targetId: group.id,
+        metadata: {
+          groupId: group.id,
+          groupName: group.name || null,
+          previousAdvisorId: previousAdvisorId || null,
+        },
+      }, { transaction });
+    }
 
     return {
       groupId: group.id,

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -2826,6 +2826,12 @@ test('group leader invite dispatch enforces current capacity and available slots
     fullName: 'Invite Capacity Two',
     password: 'StrongPass1!',
   });
+  const inviteeThree = await createStudent({
+    studentId: '11070001158',
+    email: 'invite-capacity-three@example.edu',
+    fullName: 'Invite Capacity Three',
+    password: 'StrongPass1!',
+  });
 
   const fullGroup = await Group.create({
     id: 'group-invite-capacity-full',
@@ -2866,12 +2872,83 @@ test('group leader invite dispatch enforces current capacity and available slots
       ...(await authHeaderFor(leader)),
     },
     body: JSON.stringify({
-      studentIds: [inviteeOne.studentId, inviteeTwo.studentId, member.studentId],
+      studentIds: [inviteeOne.studentId, inviteeTwo.studentId, inviteeThree.studentId],
     }),
   });
 
   assert.equal(overInviteResponse.response.status, 409);
   assert.equal(overInviteResponse.json.code, 'INVITE_CAPACITY_EXCEEDED');
+});
+
+test('group leader invite dispatch treats pending invitations as reserved capacity', async () => {
+  const leader = await createStudent({
+    studentId: '11070001154',
+    email: 'invite-pending-capacity-leader@example.edu',
+    fullName: 'Invite Pending Capacity Leader',
+    password: 'StrongPass1!',
+  });
+  const member = await createStudent({
+    studentId: '11070001155',
+    email: 'invite-pending-capacity-member@example.edu',
+    fullName: 'Invite Pending Capacity Member',
+    password: 'StrongPass1!',
+  });
+  const pendingInvitee = await createStudent({
+    studentId: '11070001156',
+    email: 'invite-pending-capacity-pending@example.edu',
+    fullName: 'Invite Pending Capacity Pending',
+    password: 'StrongPass1!',
+  });
+  const newInvitee = await createStudent({
+    studentId: '11070001157',
+    email: 'invite-pending-capacity-new@example.edu',
+    fullName: 'Invite Pending Capacity New',
+    password: 'StrongPass1!',
+  });
+
+  const group = await Group.create({
+    id: 'group-invite-pending-capacity',
+    name: 'Pending Capacity Group',
+    leaderId: String(leader.id),
+    memberIds: [String(member.id)],
+    maxMembers: 3,
+    status: 'FORMATION',
+  });
+
+  await Invitation.create({
+    groupId: group.id,
+    inviteeId: pendingInvitee.id,
+    status: 'PENDING',
+  });
+
+  const blockedResponse = await request(`/api/v1/groups/${group.id}/invitations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      studentIds: [newInvitee.studentId],
+    }),
+  });
+
+  assert.equal(blockedResponse.response.status, 409);
+  assert.equal(blockedResponse.json.code, 'GROUP_FULL');
+
+  const retryPendingResponse = await request(`/api/v1/groups/${group.id}/invitations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      studentIds: [pendingInvitee.studentId],
+    }),
+  });
+
+  assert.equal(retryPendingResponse.response.status, 201);
+  assert.equal(retryPendingResponse.json.created.length, 0);
+  assert.deepEqual(retryPendingResponse.json.skippedStudentIds, [pendingInvitee.studentId]);
 });
 
 test('group leader can re-invite a student after the previous invitation was rejected', async () => {

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -2320,6 +2320,420 @@ test('team leader cannot submit advisor requests to multiple advisors while one 
   assert.equal(secondResponse.json.code, 'GROUP_ALREADY_HAS_PENDING_REQUEST');
 });
 
+test('team leader submit flow creates advisor request and advisor inbox notification', async () => {
+  const leader = await createStudent({
+    studentId: '11070001170',
+    email: 'mentor-submit-leader@example.edu',
+    fullName: 'Mentor Submit Leader',
+    password: 'StrongPass1!',
+  });
+  const advisor = await createProfessorUser({
+    email: 'mentor-submit-advisor@example.edu',
+    fullName: 'Mentor Submit Advisor',
+  });
+  const group = await Group.create({
+    id: 'group-mentor-submit-1',
+    name: 'Mentor Submit Group',
+    leaderId: String(leader.id),
+    memberIds: [],
+    advisorId: null,
+    status: 'FORMATION',
+    maxMembers: 4,
+  });
+
+  const response = await request('/api/v1/advisor-requests', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      groupId: group.id,
+      advisorId: advisor.id,
+    }),
+  });
+
+  assert.equal(response.response.status, 201);
+  assert.equal(response.json.groupId, group.id);
+  assert.equal(response.json.advisorId, advisor.id);
+  assert.equal(response.json.teamLeaderId, leader.id);
+  assert.equal(response.json.status, 'PENDING');
+
+  const storedRequest = await AdvisorRequest.findByPk(response.json.id);
+  assert.ok(storedRequest);
+  assert.equal(storedRequest.status, 'PENDING');
+
+  const storedNotification = await Notification.findOne({
+    where: {
+      userId: advisor.id,
+      type: 'ADVISOR_REQUEST',
+    },
+    order: [['createdAt', 'DESC']],
+  });
+  assert.ok(storedNotification);
+
+  const advisorInbox = await request('/api/v1/advisors/notifications/advisee-requests', {
+    headers: await authHeaderFor(advisor),
+  });
+
+  assert.equal(advisorInbox.response.status, 200);
+  assert.equal(advisorInbox.json.count, 1);
+  assert.equal(advisorInbox.json.data[0].requestId, response.json.id);
+  assert.equal(advisorInbox.json.data[0].groupId, group.id);
+  assert.equal(advisorInbox.json.data[0].groupName, 'Mentor Submit Group');
+});
+
+test('advisor approval flow updates assignment, mirrors rows, writes audit log, and notifies the team leader', async () => {
+  const leader = await createStudent({
+    studentId: '11070001171',
+    email: 'mentor-approve-leader@example.edu',
+    fullName: 'Mentor Approve Leader',
+    password: 'StrongPass1!',
+  });
+  const advisor = await createProfessorUser({
+    email: 'mentor-approve-advisor@example.edu',
+    fullName: 'Mentor Approve Advisor',
+  });
+  const group = await Group.create({
+    id: 'group-mentor-approve-1',
+    name: 'Mentor Approve Group',
+    leaderId: String(leader.id),
+    memberIds: [],
+    advisorId: null,
+    status: 'FORMATION',
+    maxMembers: 4,
+  });
+
+  const submitResponse = await request('/api/v1/advisor-requests', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      groupId: group.id,
+      advisorId: advisor.id,
+    }),
+  });
+
+  assert.equal(submitResponse.response.status, 201);
+
+  const decisionResponse = await request(`/api/v1/advisor-requests/${submitResponse.json.id}/decision`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(advisor)),
+    },
+    body: JSON.stringify({
+      decision: 'APPROVE',
+      note: 'I can supervise this team.',
+    }),
+  });
+
+  assert.equal(decisionResponse.response.status, 200);
+  assert.equal(decisionResponse.json.status, 'APPROVED');
+
+  const updatedGroup = await Group.findByPk(group.id);
+  assert.equal(updatedGroup.advisorId, String(advisor.id));
+  assert.equal(updatedGroup.status, 'HAS_ADVISOR');
+
+  const mirroredRows = await GroupAdvisorAssignment.findAll({ where: { groupId: group.id } });
+  assert.equal(mirroredRows.length, 1);
+  assert.equal(mirroredRows[0].studentUserId, leader.id);
+  assert.equal(mirroredRows[0].advisorUserId, advisor.id);
+
+  const auditLog = await AuditLog.findOne({
+    where: {
+      action: 'ADVISOR_REQUEST_APPROVED',
+      targetType: 'ADVISOR_REQUEST',
+      targetId: submitResponse.json.id,
+      actorId: advisor.id,
+    },
+  });
+  assert.ok(auditLog);
+  assert.equal(auditLog.metadata.groupId, group.id);
+  assert.equal(auditLog.metadata.decision, 'APPROVE');
+
+  const leaderNotifications = await request('/api/v1/team-leader/notifications/advisor-decisions', {
+    headers: await authHeaderFor(leader),
+  });
+
+  assert.equal(leaderNotifications.response.status, 200);
+  assert.equal(leaderNotifications.json.length, 1);
+  assert.equal(leaderNotifications.json[0].requestId, submitResponse.json.id);
+  assert.equal(leaderNotifications.json[0].groupId, group.id);
+  assert.equal(leaderNotifications.json[0].advisorDecision, 'APPROVED');
+  assert.equal(leaderNotifications.json[0].advisor.id, advisor.id);
+});
+
+test('advisor rejection flow writes audit log and notifies the team leader without assigning the group', async () => {
+  const leader = await createStudent({
+    studentId: '11070001172',
+    email: 'mentor-reject-leader@example.edu',
+    fullName: 'Mentor Reject Leader',
+    password: 'StrongPass1!',
+  });
+  const advisor = await createProfessorUser({
+    email: 'mentor-reject-advisor@example.edu',
+    fullName: 'Mentor Reject Advisor',
+  });
+  const group = await Group.create({
+    id: 'group-mentor-reject-1',
+    name: 'Mentor Reject Group',
+    leaderId: String(leader.id),
+    memberIds: [],
+    advisorId: null,
+    status: 'FORMATION',
+    maxMembers: 4,
+  });
+
+  const submitResponse = await request('/api/v1/advisor-requests', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      groupId: group.id,
+      advisorId: advisor.id,
+    }),
+  });
+
+  assert.equal(submitResponse.response.status, 201);
+
+  const decisionResponse = await request(`/api/v1/advisor-requests/${submitResponse.json.id}/decision`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(advisor)),
+    },
+    body: JSON.stringify({
+      decision: 'REJECT',
+      note: 'I am not available this term.',
+    }),
+  });
+
+  assert.equal(decisionResponse.response.status, 200);
+  assert.equal(decisionResponse.json.status, 'REJECTED');
+
+  const refreshedGroup = await Group.findByPk(group.id);
+  assert.equal(refreshedGroup.advisorId, null);
+  assert.equal(refreshedGroup.status, 'FORMATION');
+
+  const mirroredRows = await GroupAdvisorAssignment.findAll({ where: { groupId: group.id } });
+  assert.equal(mirroredRows.length, 0);
+
+  const auditLog = await AuditLog.findOne({
+    where: {
+      action: 'ADVISOR_REQUEST_REJECTED',
+      targetType: 'ADVISOR_REQUEST',
+      targetId: submitResponse.json.id,
+      actorId: advisor.id,
+    },
+  });
+  assert.ok(auditLog);
+  assert.equal(auditLog.metadata.groupId, group.id);
+  assert.equal(auditLog.metadata.decision, 'REJECT');
+
+  const leaderNotifications = await request('/api/v1/team-leader/notifications/advisor-decisions', {
+    headers: await authHeaderFor(leader),
+  });
+
+  assert.equal(leaderNotifications.response.status, 200);
+  assert.equal(leaderNotifications.json.length, 1);
+  assert.equal(leaderNotifications.json[0].groupId, group.id);
+  assert.equal(leaderNotifications.json[0].advisorDecision, 'REJECTED');
+});
+
+test('advisor release flow clears assignment and notifies the team leader', async () => {
+  const leader = await createStudent({
+    studentId: '11070001173',
+    email: 'mentor-release-leader@example.edu',
+    fullName: 'Mentor Release Leader',
+    password: 'StrongPass1!',
+  });
+  const advisor = await createProfessorUser({
+    email: 'mentor-release-advisor@example.edu',
+    fullName: 'Mentor Release Advisor',
+  });
+  const group = await Group.create({
+    id: 'group-mentor-release-1',
+    name: 'Mentor Release Group',
+    leaderId: String(leader.id),
+    memberIds: [],
+    advisorId: String(advisor.id),
+    status: 'HAS_ADVISOR',
+    maxMembers: 4,
+  });
+
+  await GroupAdvisorAssignment.create({
+    groupId: group.id,
+    studentUserId: leader.id,
+    advisorUserId: advisor.id,
+  });
+
+  const releaseResponse = await request(`/api/v1/groups/${group.id}/advisor-release`, {
+    method: 'PATCH',
+    headers: await authHeaderFor(advisor),
+  });
+
+  assert.equal(releaseResponse.response.status, 200);
+  assert.equal(releaseResponse.json.code, 'SUCCESS');
+  assert.equal(releaseResponse.json.data.groupId, group.id);
+  assert.equal(releaseResponse.json.data.advisorId, null);
+
+  const updatedGroup = await Group.findByPk(group.id);
+  assert.equal(updatedGroup.advisorId, null);
+  assert.equal(updatedGroup.status, 'LOOKING_FOR_ADVISOR');
+
+  const mirroredRows = await GroupAdvisorAssignment.findAll({ where: { groupId: group.id } });
+  assert.equal(mirroredRows.length, 0);
+
+  const auditLog = await AuditLog.findOne({
+    where: {
+      action: 'ADVISOR_RELEASE',
+      targetType: 'GROUP',
+      targetId: group.id,
+      actorId: advisor.id,
+    },
+  });
+  assert.ok(auditLog);
+  assert.equal(auditLog.metadata.groupId, group.id);
+  assert.equal(auditLog.metadata.previousAdvisorId, String(advisor.id));
+
+  const leaderNotifications = await request('/api/v1/team-leader/notifications/advisor-releases', {
+    headers: await authHeaderFor(leader),
+  });
+
+  assert.equal(leaderNotifications.response.status, 200);
+  assert.equal(leaderNotifications.json.length, 1);
+  assert.equal(leaderNotifications.json[0].groupId, group.id);
+  assert.equal(leaderNotifications.json[0].previousAdvisor.id, advisor.id);
+});
+
+test('coordinator transfer flow updates both notification endpoints for the new advisor and the team leader', async () => {
+  const coordinator = await User.create({
+    email: 'mentor-transfer-coordinator@example.edu',
+    fullName: 'Mentor Transfer Coordinator',
+    role: 'COORDINATOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+  const leader = await createStudent({
+    studentId: '11070001174',
+    email: 'mentor-transfer-leader@example.edu',
+    fullName: 'Mentor Transfer Leader',
+    password: 'StrongPass1!',
+  });
+  const currentAdvisor = await createProfessorUser({
+    email: 'mentor-transfer-current@example.edu',
+    fullName: 'Mentor Transfer Current',
+  });
+  const newAdvisor = await createProfessorUser({
+    email: 'mentor-transfer-new@example.edu',
+    fullName: 'Mentor Transfer New',
+  });
+  const group = await Group.create({
+    id: 'group-mentor-transfer-1',
+    name: 'Mentor Transfer Group',
+    leaderId: String(leader.id),
+    memberIds: [],
+    advisorId: String(currentAdvisor.id),
+    status: 'HAS_ADVISOR',
+    maxMembers: 4,
+  });
+
+  await GroupAdvisorAssignment.create({
+    groupId: group.id,
+    studentUserId: leader.id,
+    advisorUserId: currentAdvisor.id,
+  });
+
+  const transferResponse = await request(`/api/v1/coordinator/groups/${group.id}/advisor-transfer`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(coordinator)),
+    },
+    body: JSON.stringify({
+      newAdvisorId: newAdvisor.id,
+      reason: 'Load balancing',
+    }),
+  });
+
+  assert.equal(transferResponse.response.status, 200);
+  assert.equal(transferResponse.json.groupId, group.id);
+  assert.equal(transferResponse.json.advisorId, String(newAdvisor.id));
+
+  const teamLeaderTransfers = await request('/api/v1/team-leader/notifications/advisor-transfers', {
+    headers: await authHeaderFor(leader),
+  });
+
+  assert.equal(teamLeaderTransfers.response.status, 200);
+  assert.equal(teamLeaderTransfers.json.length, 1);
+  assert.equal(teamLeaderTransfers.json[0].groupId, group.id);
+  assert.equal(teamLeaderTransfers.json[0].newAdvisor.id, newAdvisor.id);
+
+  const advisorTransfers = await request('/api/v1/advisors/notifications/group-transfers', {
+    headers: await authHeaderFor(newAdvisor),
+  });
+
+  assert.equal(advisorTransfers.response.status, 200);
+  assert.equal(advisorTransfers.json.count, 1);
+  assert.equal(advisorTransfers.json.data[0].groupId, group.id);
+  assert.equal(advisorTransfers.json.data[0].groupName, 'Mentor Transfer Group');
+
+  const auditLog = await AuditLog.findOne({
+    where: {
+      action: 'ADVISOR_TRANSFER',
+      targetType: 'GROUP',
+      targetId: group.id,
+      actorId: coordinator.id,
+    },
+  });
+  assert.ok(auditLog);
+  assert.equal(auditLog.metadata.groupId, group.id);
+  assert.equal(auditLog.metadata.previousAdvisorId, String(currentAdvisor.id));
+  assert.equal(auditLog.metadata.newAdvisorId, String(newAdvisor.id));
+});
+
+test('orphan cleanup flow writes the sanitization audit log', async () => {
+  const admin = await User.create({
+    email: 'mentor-orphan-admin@example.edu',
+    fullName: 'Mentor Orphan Admin',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('StrongPass1!', 10),
+  });
+  const group = await Group.create({
+    name: 'Mentor Orphan Group',
+    leaderId: null,
+    memberIds: [],
+    advisorId: null,
+    status: 'LOOKING_FOR_ADVISOR',
+    maxMembers: 4,
+  });
+
+  const cleanupResponse = await request(`/api/v1/group-database/groups/${group.id}`, {
+    method: 'DELETE',
+    headers: await authHeaderFor(admin),
+  });
+
+  assert.equal(cleanupResponse.response.status, 200);
+
+  const auditLog = await AuditLog.findOne({
+    where: {
+      action: 'DELETE_ORPHAN_GROUP',
+      targetType: 'GROUP',
+      targetId: group.id,
+      actorId: admin.id,
+    },
+  });
+
+  assert.ok(auditLog);
+  assert.equal(auditLog.metadata.groupName, 'Mentor Orphan Group');
+});
+
 test('coordinator membership edit blocks adding the leader and enforces group max capacity', async () => {
   const coordinator = await User.create({
     email: 'coordinator-capacity@example.edu',
@@ -2385,6 +2799,224 @@ test('coordinator membership edit blocks adding the leader and enforces group ma
 
   assert.equal(overCapacityResponse.response.status, 409);
   assert.equal(overCapacityResponse.json.code, 'GROUP_FULL');
+});
+
+test('group leader invite dispatch enforces current capacity and available slots', async () => {
+  const leader = await createStudent({
+    studentId: '11070001150',
+    email: 'invite-capacity-leader@example.edu',
+    fullName: 'Invite Capacity Leader',
+    password: 'StrongPass1!',
+  });
+  const member = await createStudent({
+    studentId: '11070001151',
+    email: 'invite-capacity-member@example.edu',
+    fullName: 'Invite Capacity Member',
+    password: 'StrongPass1!',
+  });
+  const inviteeOne = await createStudent({
+    studentId: '11070001152',
+    email: 'invite-capacity-one@example.edu',
+    fullName: 'Invite Capacity One',
+    password: 'StrongPass1!',
+  });
+  const inviteeTwo = await createStudent({
+    studentId: '11070001153',
+    email: 'invite-capacity-two@example.edu',
+    fullName: 'Invite Capacity Two',
+    password: 'StrongPass1!',
+  });
+
+  const fullGroup = await Group.create({
+    id: 'group-invite-capacity-full',
+    name: 'Full Invite Group',
+    leaderId: String(leader.id),
+    memberIds: [String(member.id)],
+    maxMembers: 2,
+    status: 'FORMATION',
+  });
+
+  const fullGroupResponse = await request(`/api/v1/groups/${fullGroup.id}/invitations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      studentIds: [inviteeOne.studentId],
+    }),
+  });
+
+  assert.equal(fullGroupResponse.response.status, 409);
+  assert.equal(fullGroupResponse.json.code, 'GROUP_FULL');
+
+  const limitedGroup = await Group.create({
+    id: 'group-invite-capacity-limited',
+    name: 'Limited Invite Group',
+    leaderId: String(leader.id),
+    memberIds: [],
+    maxMembers: 3,
+    status: 'FORMATION',
+  });
+
+  const overInviteResponse = await request(`/api/v1/groups/${limitedGroup.id}/invitations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      studentIds: [inviteeOne.studentId, inviteeTwo.studentId, member.studentId],
+    }),
+  });
+
+  assert.equal(overInviteResponse.response.status, 409);
+  assert.equal(overInviteResponse.json.code, 'INVITE_CAPACITY_EXCEEDED');
+});
+
+test('group leader can re-invite a student after the previous invitation was rejected', async () => {
+  const leader = await createStudent({
+    studentId: '11070001160',
+    email: 'reinvite-leader@example.edu',
+    fullName: 'Reinvite Leader',
+    password: 'StrongPass1!',
+  });
+  const invitee = await createStudent({
+    studentId: '11070001161',
+    email: 'reinvite-invitee@example.edu',
+    fullName: 'Reinvite Invitee',
+    password: 'StrongPass1!',
+  });
+
+  const group = await Group.create({
+    id: 'group-reinvite-after-reject',
+    name: 'Reinvite Group',
+    leaderId: String(leader.id),
+    memberIds: [],
+    maxMembers: 4,
+    status: 'FORMATION',
+  });
+
+  const firstInvite = await request(`/api/v1/groups/${group.id}/invitations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      studentIds: [invitee.studentId],
+    }),
+  });
+
+  assert.equal(firstInvite.response.status, 201);
+  assert.equal(firstInvite.json.created.length, 1);
+
+  const invitationId = firstInvite.json.created[0].id;
+
+  const rejectResponse = await request(`/api/v1/invitations/${invitationId}/response`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(invitee)),
+    },
+    body: JSON.stringify({
+      response: 'REJECT',
+    }),
+  });
+
+  assert.equal(rejectResponse.response.status, 200);
+  assert.equal(rejectResponse.json.invitation.status, 'REJECTED');
+
+  const secondInvite = await request(`/api/v1/groups/${group.id}/invitations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      studentIds: [invitee.studentId],
+    }),
+  });
+
+  assert.equal(secondInvite.response.status, 201);
+  assert.equal(secondInvite.json.created.length, 1);
+  assert.equal(secondInvite.json.created[0].id, invitationId);
+  assert.equal(secondInvite.json.created[0].status, 'PENDING');
+
+  const refreshedInvitation = await Invitation.findByPk(invitationId);
+  assert.equal(refreshedInvitation.status, 'PENDING');
+});
+
+test('group leader can re-invite a student after the previous invitation was accepted and membership was cleared', async () => {
+  const leader = await createStudent({
+    studentId: '11070001162',
+    email: 'reinvite-accepted-leader@example.edu',
+    fullName: 'Reinvite Accepted Leader',
+    password: 'StrongPass1!',
+  });
+  const invitee = await createStudent({
+    studentId: '11070001163',
+    email: 'reinvite-accepted-invitee@example.edu',
+    fullName: 'Reinvite Accepted Invitee',
+    password: 'StrongPass1!',
+  });
+
+  const group = await Group.create({
+    id: 'group-reinvite-after-accept',
+    name: 'Reinvite Accepted Group',
+    leaderId: String(leader.id),
+    memberIds: [],
+    maxMembers: 4,
+    status: 'FORMATION',
+  });
+
+  const firstInvite = await request(`/api/v1/groups/${group.id}/invitations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      studentIds: [invitee.studentId],
+    }),
+  });
+
+  assert.equal(firstInvite.response.status, 201);
+  const invitationId = firstInvite.json.created[0].id;
+
+  const acceptResponse = await request(`/api/v1/invitations/${invitationId}/response`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(invitee)),
+    },
+    body: JSON.stringify({
+      response: 'ACCEPT',
+    }),
+  });
+
+  assert.equal(acceptResponse.response.status, 200);
+  assert.equal(acceptResponse.json.invitation.status, 'ACCEPTED');
+
+  const updatedGroup = await Group.findByPk(group.id);
+  updatedGroup.memberIds = [];
+  await updatedGroup.save();
+
+  const secondInvite = await request(`/api/v1/groups/${group.id}/invitations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaderFor(leader)),
+    },
+    body: JSON.stringify({
+      studentIds: [invitee.studentId],
+    }),
+  });
+
+  assert.equal(secondInvite.response.status, 201);
+  assert.equal(secondInvite.json.created.length, 1);
+  assert.equal(secondInvite.json.created[0].id, invitationId);
+  assert.equal(secondInvite.json.created[0].status, 'PENDING');
 });
 
 test('group leader cannot lower maxMembers below current participant count', async () => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import CoordinatorLoginPage from './CoordinatorLoginPage';
 import CoordinatorStudentIdUploadPage from './CoordinatorStudentIdUploadPage';
 import GroupPage from './GroupPage';
 import HomePage from './HomePage';
+import ProfessorHomePage from './ProfessorHomePage';
 import ProfessorAdvisorRequestsPage from './ProfessorAdvisorRequestsPage';
 import ProfessorLoginPage from './ProfessorLoginPage';
 import ProfessorPasswordSetupPage from './ProfessorPasswordSetupPage';
@@ -47,6 +48,8 @@ export default function App() {
               <Route path="/team-leader/advisor-requests/new" element={<SubmitAdvisorRequestPage />} />
               <Route path="/team-leader/advisor-requests/:requestId" element={<TeamLeaderAdvisorRequestDetailsPage />} />
               <Route path="/professors/login" element={<AuthPage />} />
+              <Route path="/professors" element={<ProfessorHomePage />} />
+              <Route path="/professor" element={<ProfessorHomePage />} />
               <Route path="/professors/notifications" element={<ProfessorAdvisorRequestsPage />} />
               <Route path="/professors/password-setup" element={<ProfessorPasswordSetupPage />} />
               <Route path="/admin/login" element={<AuthPage />} />

--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -54,6 +54,21 @@ function tokenStorageKeyForRole(role) {
   }
 }
 
+function routeForRole(role) {
+  switch (role) {
+    case 'student':
+      return '/home';
+    case 'professor':
+      return '/professors';
+    case 'coordinator':
+      return '/coordinator';
+    case 'admin':
+      return '/admin';
+    default:
+      return '/home';
+  }
+}
+
 export default function AuthPage() {
   const [mode, setMode] = useState('login');
   const [role, setRole] = useState('student');
@@ -135,11 +150,11 @@ export default function AuthPage() {
       setFeedback({
         type: 'success',
         title: 'Signed in',
-        message: 'Welcome back. Redirecting to home.',
+        message: 'Welcome back. Redirecting to your workspace.',
       });
       notify({ type: 'success', title: 'Signed in', message: `${LOGIN_ROLES.find((r) => r.value === role)?.label || 'User'} login successful.` });
 
-      window.setTimeout(() => navigate('/home'), 400);
+      window.setTimeout(() => navigate(routeForRole(role), { replace: true }), 400);
     } catch {
       setFeedback({
         type: 'error',

--- a/frontend/src/GroupPage.jsx
+++ b/frontend/src/GroupPage.jsx
@@ -11,6 +11,7 @@ export default function GroupPage() {
   const [group, setGroup] = useState(null);
   const [loading, setLoading] = useState(true);
   const [joining, setJoining] = useState(false);
+  const [releasing, setReleasing] = useState(false);
   const [userStudentId, setUserStudentId] = useState(null);
   const [userAdvisorId, setUserAdvisorId] = useState(null);
   const [error, setError] = useState(null);
@@ -35,43 +36,6 @@ export default function GroupPage() {
     }
   }, []);
 
-  const handleAdvisorRelease = async () => {
-    setShowReleaseConfirm(true);
-  };
-
-  const confirmAdvisorRelease = async () => {
-    setShowReleaseConfirm(false);
-    if (!userAdvisorId) {
-      notify({
-        type: 'error',
-        title: 'Not authenticated',
-        message: 'Please log in as advisor',
-      });
-      return;
-    }
-    try {
-      const response = await apiClient.patch(`/v1/groups/${groupId}/advisor-release`);
-      setGroup((prev) => ({
-        ...prev,
-        advisorId: null,
-        advisor: null,
-        status: response.data?.data?.status || 'LOOKING_FOR_ADVISOR',
-      }));
-      notify({
-        type: 'success',
-        title: 'Advisor released',
-        message: 'You have released your advisor assignment.',
-      });
-    } catch (err) {
-      notify({
-        type: 'error',
-        title: 'Release failed',
-        message: err.response?.data?.message || 'Could not release advisor assignment.',
-      });
-    }
-  };
-
-  // Fetch group membership details
   useEffect(() => {
     const fetchGroupData = async () => {
       try {
@@ -97,13 +61,49 @@ export default function GroupPage() {
     }
   }, [groupId, notify]);
 
-  // Handle joining group
-  const handleJoinGroup = async () => {
+  async function confirmAdvisorRelease() {
+    setShowReleaseConfirm(false);
+
+    if (!userAdvisorId) {
+      notify({
+        type: 'error',
+        title: 'Not authenticated',
+        message: 'Please log in as advisor.',
+      });
+      return;
+    }
+
+    try {
+      setReleasing(true);
+      const response = await apiClient.patch(`/v1/groups/${groupId}/advisor-release`);
+      setGroup((prev) => ({
+        ...prev,
+        advisorId: null,
+        advisor: null,
+        status: response.data?.data?.status || 'LOOKING_FOR_ADVISOR',
+      }));
+      notify({
+        type: 'success',
+        title: 'Advisor released',
+        message: 'You have released your advisor assignment.',
+      });
+    } catch (err) {
+      notify({
+        type: 'error',
+        title: 'Release failed',
+        message: err.response?.data?.message || 'Could not release advisor assignment.',
+      });
+    } finally {
+      setReleasing(false);
+    }
+  }
+
+  async function handleJoinGroup() {
     if (!userStudentId) {
       notify({
         type: 'error',
         title: 'Not authenticated',
-        message: 'Please log in first',
+        message: 'Please log in first.',
       });
       navigate('/');
       return;
@@ -117,34 +117,32 @@ export default function GroupPage() {
       });
 
       const refreshedGroup = await loadGroupData();
-
       setGroup(refreshedGroup);
 
       notify({
         type: 'success',
         title: 'Joined group successfully',
-        message: `Welcome to ${group?.groupName || 'the group'}!`,
+        message: `Welcome to ${group?.groupName || 'the group'}.`,
       });
     } catch (err) {
       console.error('Error joining group:', err);
 
-      // Check for specific error codes
       const errorCode = err.response?.data?.code;
       let errorTitle = 'Failed to join group';
-      let errorMessage = 'Please try again';
+      let errorMessage = 'Please try again.';
 
       if (errorCode === 'DUPLICATE_MEMBER') {
         errorTitle = 'Already a member';
-        errorMessage = 'You are already a member of this group';
+        errorMessage = 'You are already a member of this group.';
       } else if (errorCode === 'MAX_MEMBERS_REACHED') {
         errorTitle = 'Group is full';
-        errorMessage = 'This group has reached maximum capacity';
+        errorMessage = 'This group has reached maximum capacity.';
       } else if (errorCode === 'GROUP_FINALIZED') {
         errorTitle = 'Group is closed';
-        errorMessage = 'This group is no longer accepting members';
+        errorMessage = 'This group is no longer accepting members.';
       } else if (errorCode === 'GROUP_NOT_FOUND') {
         errorTitle = 'Group not found';
-        errorMessage = 'Unable to find this group';
+        errorMessage = 'Unable to find this group.';
       }
 
       notify({
@@ -155,23 +153,32 @@ export default function GroupPage() {
     } finally {
       setJoining(false);
     }
-  };
+  }
 
   if (loading) {
     return (
-      <div style={{ padding: '2rem', textAlign: 'center' }}>
-        <p>Loading group details...</p>
-      </div>
+      <main className="page page-group-view">
+        <div className="feedback feedback-loading">
+          <div className="feedback-label">loading</div>
+          <h2>Loading group</h2>
+          <p>Fetching group details...</p>
+        </div>
+      </main>
     );
   }
 
   if (error || !group) {
     return (
-      <div style={{ padding: '2rem' }}>
-        <h2>Group Not Found</h2>
-        <p>{error}</p>
-        <button onClick={() => navigate('/')}>Go Back</button>
-      </div>
+      <main className="page page-group-view">
+        <div className="feedback feedback-error">
+          <div className="feedback-label">error</div>
+          <h2>Group not found</h2>
+          <p>{error || 'The requested group could not be loaded.'}</p>
+        </div>
+        <div className="group-action-row">
+          <button type="button" onClick={() => navigate('/')}>Back</button>
+        </div>
+      </main>
     );
   }
 
@@ -181,192 +188,128 @@ export default function GroupPage() {
   );
   const isFull = group.currentMemberCount >= group.maxMembers;
   const isFinalized = group.status === 'COMPLETED' || group.status === 'DISBANDED';
-
   const isAdvisor = userAdvisorId && group.advisorId && String(group.advisorId) === String(userAdvisorId);
 
   return (
-    <div className="group-page-shell">
-      {/* Group Header */}
-      <div className="group-page-header">
+    <main className="page page-group-view">
+      <section className="hero group-page-header">
+        <p className="eyebrow">Group Workspace</p>
         <h1>{group.groupName || 'Unnamed Group'}</h1>
-        <p className="group-page-status">Status: <strong>{group.status}</strong></p>
-      </div>
+        <p className="group-page-status">
+          Status <strong>{group.status}</strong>
+        </p>
+      </section>
 
-      {/* Group Info */}
-      <div className="group-details-card">
+      <section className="group-details-card">
         <div className="group-details-summary">
           <h3>Group Details</h3>
-          <p><strong>Status:</strong> {group.status}</p>
-          <p><strong>Members:</strong> {group.currentMemberCount} / {group.maxMembers}</p>
-          <p><strong>Available Slots:</strong> {group.availableSlots}</p>
-          <p>
-            <strong>Advisor:</strong>{' '}
-            {group.advisor
-              ? `${group.advisor.fullName || group.advisor.email}${group.advisor.department ? ` (${group.advisor.department})` : ''}`
-              : <span className="group-muted">None assigned</span>}
-          </p>
+          <div className="group-summary-grid">
+            <div className="group-summary-item">
+              <span>Status</span>
+              <strong>{group.status}</strong>
+            </div>
+            <div className="group-summary-item">
+              <span>Members</span>
+              <strong>{group.currentMemberCount} / {group.maxMembers}</strong>
+            </div>
+            <div className="group-summary-item">
+              <span>Available Slots</span>
+              <strong>{group.availableSlots}</strong>
+            </div>
+            <div className="group-summary-item">
+              <span>Advisor</span>
+              <strong>
+                {group.advisor
+                  ? `${group.advisor.fullName || group.advisor.email}${group.advisor.department ? ` (${group.advisor.department})` : ''}`
+                  : 'None assigned'}
+              </strong>
+            </div>
+          </div>
         </div>
 
-        {/* Member List */}
         <div>
           <h3>Members ({group.currentMemberCount || 0})</h3>
           {group.members && group.members.length > 0 ? (
             <ul className="group-members-list">
               {group.members.map((member, index) => (
                 <li key={`${member.id}-${index}`} className="group-member-chip">
-                  {member.fullName || member.email || member.studentId || member.id}
-                  {member.isLeader ? ' (Leader)' : ''}
+                  <span>
+                    {member.fullName || member.email || member.studentId || member.id}
+                    {member.isLeader ? ' (Leader)' : ''}
+                  </span>
                   {String(member.id) === String(userStudentId) && (
-                    <span className="group-member-you">
-                      (You)
-                    </span>
+                    <span className="group-member-you">(You)</span>
                   )}
                 </li>
               ))}
             </ul>
           ) : (
-            <p className="group-muted">No members yet</p>
+            <p className="group-muted">No members yet.</p>
           )}
         </div>
-      </div>
+      </section>
 
-      {/* Action Buttons */}
-      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
-        {isStudentViewer && isAlreadyMember ? (
-          <div style={{ 
-            padding: '1rem', 
-            backgroundColor: '#d4edda', 
-            color: '#155724', 
-            borderRadius: '4px',
-            flex: 1,
-          }}>
-            ✓ You are a member of this group
+      <section className="group-action-stack">
+        {isStudentViewer && isAlreadyMember && (
+          <div className="group-callout group-callout-success">
+            You are already a member of this group.
           </div>
-        ) : isStudentViewer && isFinalized ? (
-          <div style={{ 
-            padding: '1rem', 
-            backgroundColor: '#f8d7da', 
-            color: '#721c24', 
-            borderRadius: '4px',
-            flex: 1,
-          }}>
-            This group is no longer accepting members
-          </div>
-        ) : isStudentViewer && isFull ? (
-          <div style={{ 
-            padding: '1rem', 
-            backgroundColor: '#fff3cd', 
-            color: '#856404', 
-            borderRadius: '4px',
-            flex: 1,
-          }}>
-            This group is at full capacity
-          </div>
-        ) : isStudentViewer ? (
-          <button
-            onClick={handleJoinGroup}
-            disabled={joining}
-            style={{
-              padding: '0.75rem 1.5rem',
-              backgroundColor: '#007bff',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: joining ? 'not-allowed' : 'pointer',
-              opacity: joining ? 0.6 : 1,
-              flex: 1,
-            }}
-          >
-            {joining ? 'Joining...' : 'Join Group'}
-          </button>
-        ) : null}
-
-        {isAdvisor && (
-          <>
-            <button
-              onClick={handleAdvisorRelease}
-              style={{
-                padding: '0.75rem 1.5rem',
-                backgroundColor: '#dc3545',
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer',
-              }}
-            >
-              Release Advisor Assignment
-            </button>
-            {showReleaseConfirm && (
-              <div style={{
-                position: 'fixed',
-                top: 0,
-                left: 0,
-                width: '100vw',
-                height: '100vh',
-                background: 'rgba(0,0,0,0.3)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                zIndex: 1000,
-              }}>
-                <div style={{
-                  background: 'white',
-                  padding: '2rem',
-                  borderRadius: '8px',
-                  boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
-                  maxWidth: '90vw',
-                  width: '400px',
-                  textAlign: 'center',
-                }}>
-                  <h2>Confirm Release</h2>
-                  <p>Are you sure you want to release your advisor assignment from this group? This action cannot be undone.</p>
-                  <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center', marginTop: '2rem' }}>
-                    <button
-                      onClick={confirmAdvisorRelease}
-                      style={{
-                        padding: '0.5rem 1.5rem',
-                        backgroundColor: '#dc3545',
-                        color: 'white',
-                        border: 'none',
-                        borderRadius: '4px',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      Yes, Release
-                    </button>
-                    <button
-                      onClick={() => setShowReleaseConfirm(false)}
-                      style={{
-                        padding: '0.5rem 1.5rem',
-                        backgroundColor: '#6c757d',
-                        color: 'white',
-                        border: 'none',
-                        borderRadius: '4px',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-              </div>
-            )}
-          </>
         )}
-        <button
-          onClick={() => navigate('/')}
-          style={{
-            padding: '0.75rem 1.5rem',
-            backgroundColor: '#6c757d',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            cursor: 'pointer',
-          }}
-        >
-          Back
-        </button>
-      </div>
-    </div>
+
+        {isStudentViewer && !isAlreadyMember && isFinalized && (
+          <div className="group-callout group-callout-error">
+            This group is no longer accepting members.
+          </div>
+        )}
+
+        {isStudentViewer && !isAlreadyMember && !isFinalized && isFull && (
+          <div className="group-callout group-callout-warning">
+            This group is currently at full capacity.
+          </div>
+        )}
+
+        <div className="group-action-row">
+          {isStudentViewer && !isAlreadyMember && !isFinalized && !isFull && (
+            <button type="button" onClick={handleJoinGroup} disabled={joining}>
+              {joining ? 'Joining...' : 'Join Group'}
+            </button>
+          )}
+
+          {isAdvisor && (
+            <button
+              type="button"
+              className="cleanup-delete-button"
+              onClick={() => setShowReleaseConfirm(true)}
+              disabled={releasing}
+            >
+              {releasing ? 'Releasing...' : 'Release Advisor Assignment'}
+            </button>
+          )}
+
+          <button type="button" onClick={() => navigate('/')}>Back</button>
+        </div>
+      </section>
+
+      {showReleaseConfirm && (
+        <div className="dialog-overlay" role="dialog" aria-modal="true" aria-label="Release advisor assignment">
+          <button type="button" className="dialog-backdrop" onClick={() => setShowReleaseConfirm(false)} />
+          <section className="dialog-card">
+            <span className="mail-topic">Advisor Release</span>
+            <h2>Confirm release</h2>
+            <p>
+              Release your advisor assignment from <strong>{group.groupName}</strong>? The group will return to the advisor search state.
+            </p>
+            <div className="dialog-actions">
+              <button type="button" className="cleanup-delete-button" onClick={confirmAdvisorRelease}>
+                Yes, Release
+              </button>
+              <button type="button" onClick={() => setShowReleaseConfirm(false)}>
+                Cancel
+              </button>
+            </div>
+          </section>
+        </div>
+      )}
+    </main>
   );
 }

--- a/frontend/src/GroupPage.jsx
+++ b/frontend/src/GroupPage.jsx
@@ -12,7 +12,8 @@ export default function GroupPage() {
   const [loading, setLoading] = useState(true);
   const [joining, setJoining] = useState(false);
   const [releasing, setReleasing] = useState(false);
-  const [userStudentId, setUserStudentId] = useState(null);
+  const [studentUserId, setStudentUserId] = useState(null);
+  const [studentNumber, setStudentNumber] = useState(null);
   const [userAdvisorId, setUserAdvisorId] = useState(null);
   const [error, setError] = useState(null);
   const [showReleaseConfirm, setShowReleaseConfirm] = useState(false);
@@ -24,9 +25,18 @@ export default function GroupPage() {
   };
 
   useEffect(() => {
-    const studentId = window.localStorage.getItem('studentId');
-    setUserStudentId(studentId);
-    setIsStudentViewer(Boolean(window.localStorage.getItem('studentUser') || studentId));
+    const legacyStudentId = window.localStorage.getItem('studentId');
+
+    try {
+      const studentUser = JSON.parse(window.localStorage.getItem('studentUser') || '{}');
+      setStudentUserId(studentUser?.id ? String(studentUser.id) : null);
+      setStudentNumber(studentUser?.studentId || legacyStudentId || null);
+      setIsStudentViewer(Boolean(studentUser?.id || legacyStudentId));
+    } catch {
+      setStudentUserId(null);
+      setStudentNumber(legacyStudentId || null);
+      setIsStudentViewer(Boolean(legacyStudentId));
+    }
 
     try {
       const professorUser = JSON.parse(window.localStorage.getItem('professorUser') || '{}');
@@ -62,8 +72,6 @@ export default function GroupPage() {
   }, [groupId, notify]);
 
   async function confirmAdvisorRelease() {
-    setShowReleaseConfirm(false);
-
     if (!userAdvisorId) {
       notify({
         type: 'error',
@@ -82,6 +90,7 @@ export default function GroupPage() {
         advisor: null,
         status: response.data?.data?.status || 'LOOKING_FOR_ADVISOR',
       }));
+      setShowReleaseConfirm(false);
       notify({
         type: 'success',
         title: 'Advisor released',
@@ -99,7 +108,7 @@ export default function GroupPage() {
   }
 
   async function handleJoinGroup() {
-    if (!userStudentId) {
+    if (!studentNumber) {
       notify({
         type: 'error',
         title: 'Not authenticated',
@@ -113,7 +122,7 @@ export default function GroupPage() {
       setJoining(true);
 
       await apiClient.post(`/v1/groups/${groupId}/membership/finalize`, {
-        studentId: userStudentId,
+        studentId: studentNumber,
       });
 
       const refreshedGroup = await loadGroupData();
@@ -183,8 +192,8 @@ export default function GroupPage() {
   }
 
   const isAlreadyMember = Boolean(
-    userStudentId
-    && (group.memberIds || group.members?.map((member) => String(member.id)) || []).includes(String(userStudentId)),
+    studentUserId
+    && (group.memberIds || group.members?.map((member) => String(member.id)) || []).includes(String(studentUserId)),
   );
   const isFull = group.currentMemberCount >= group.maxMembers;
   const isFinalized = group.status === 'COMPLETED' || group.status === 'DISBANDED';
@@ -237,7 +246,7 @@ export default function GroupPage() {
                     {member.fullName || member.email || member.studentId || member.id}
                     {member.isLeader ? ' (Leader)' : ''}
                   </span>
-                  {String(member.id) === String(userStudentId) && (
+                  {String(member.id) === String(studentUserId) && (
                     <span className="group-member-you">(You)</span>
                   )}
                 </li>
@@ -292,7 +301,15 @@ export default function GroupPage() {
 
       {showReleaseConfirm && (
         <div className="dialog-overlay" role="dialog" aria-modal="true" aria-label="Release advisor assignment">
-          <button type="button" className="dialog-backdrop" onClick={() => setShowReleaseConfirm(false)} />
+          <div
+            className="dialog-backdrop"
+            aria-hidden="true"
+            onClick={() => {
+              if (!releasing) {
+                setShowReleaseConfirm(false);
+              }
+            }}
+          />
           <section className="dialog-card">
             <span className="mail-topic">Advisor Release</span>
             <h2>Confirm release</h2>
@@ -300,10 +317,15 @@ export default function GroupPage() {
               Release your advisor assignment from <strong>{group.groupName}</strong>? The group will return to the advisor search state.
             </p>
             <div className="dialog-actions">
-              <button type="button" className="cleanup-delete-button" onClick={confirmAdvisorRelease}>
-                Yes, Release
+              <button
+                type="button"
+                className="cleanup-delete-button"
+                onClick={confirmAdvisorRelease}
+                disabled={releasing}
+              >
+                {releasing ? 'Releasing...' : 'Yes, Release'}
               </button>
-              <button type="button" onClick={() => setShowReleaseConfirm(false)}>
+              <button type="button" onClick={() => setShowReleaseConfirm(false)} disabled={releasing}>
                 Cancel
               </button>
             </div>

--- a/frontend/src/HomePage.jsx
+++ b/frontend/src/HomePage.jsx
@@ -9,6 +9,13 @@ const roleTitles = {
   ADMIN: 'Admin',
 };
 
+const roleHomeRoutes = {
+  STUDENT: '/home',
+  PROFESSOR: '/professors',
+  COORDINATOR: '/coordinator',
+  ADMIN: '/admin',
+};
+
 function detectSessionRole() {
   const checks = [
     ['adminUser', 'ADMIN'],
@@ -173,8 +180,16 @@ export default function HomePage() {
   useEffect(() => {
     if (!title) {
       navigate('/auth', { replace: true });
+      return;
     }
-  }, [title, navigate]);
+
+    if (role && role !== 'STUDENT') {
+      const target = roleHomeRoutes[role];
+      if (target && location.pathname !== target) {
+        navigate(target, { replace: true });
+      }
+    }
+  }, [location.pathname, navigate, role, title]);
 
   useEffect(() => {
     if (role === 'STUDENT') {

--- a/frontend/src/ProfessorAdvisorRequestsPage.jsx
+++ b/frontend/src/ProfessorAdvisorRequestsPage.jsx
@@ -232,6 +232,8 @@ export default function ProfessorAdvisorRequestsPage() {
   const selectedRequest = requests.find((entry) => entry.id === selectedRequestId) || null;
   const selectedRequestBusy = selectedRequest && submittingDecision === selectedRequest.requestId;
   const canDecide = selectedRequest?.requestId && selectedRequest?.requestStatus === 'PENDING';
+  const pendingRequestCount = requests.filter((entry) => entry.requestStatus === 'PENDING').length;
+  const unreadTransferCount = transferNotifications.filter((entry) => !entry.isRead).length;
 
   async function markNotificationAsRead(type, id) {
     const token = getProfessorToken();
@@ -345,173 +347,220 @@ export default function ProfessorAdvisorRequestsPage() {
         </p>
       </section>
 
-      <section className="single-panel">
-        <div className="panel">
+      <section className="mail-summary-grid professor-mail-summary">
+        <article className="mail-category-panel">
+          <div className="mail-category-header">
+            <p className="mail-category-eyebrow">Advisor Requests</p>
+            <div className="mail-category-heading">
+              <h2>Decision queue</h2>
+              <span className="mail-category-count">{requests.length}</span>
+            </div>
+          </div>
+          <div className="mailbox-stat-row">
+            <div className="mailbox-stat">
+              <span>Pending</span>
+              <strong>{pendingRequestCount}</strong>
+            </div>
+            <div className="mailbox-stat">
+              <span>Resolved</span>
+              <strong>{Math.max(requests.length - pendingRequestCount, 0)}</strong>
+            </div>
+          </div>
+        </article>
+
+        <article className="mail-category-panel">
+          <div className="mail-category-header">
+            <p className="mail-category-eyebrow">Transfers</p>
+            <div className="mail-category-heading">
+              <h2>Assigned groups</h2>
+              <span className="mail-category-count">{transferNotifications.length}</span>
+            </div>
+          </div>
+          <div className="mailbox-stat-row">
+            <div className="mailbox-stat">
+              <span>Unread</span>
+              <strong>{unreadTransferCount}</strong>
+            </div>
+            <div className="mailbox-stat">
+              <span>Latest</span>
+              <strong>{transferNotifications[0] ? formatDate(transferNotifications[0].createdAt) : 'None'}</strong>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      {feedback.message && (
+        <p className={`mail-state mail-state-${feedback.type || 'info'}`} aria-live="polite">
+          {feedback.message}
+        </p>
+      )}
+
+      <section className="mail-workspace">
+        <aside className="mail-inbox-shell mail-sidebar" aria-label="Advisor request list">
           <div className="mail-sidebar-header">
-            <p className="mailbox-title">Group Transfer Notifications</p>
-            <p className="mailbox-count">{transferNotifications.length} notifications</p>
+            <p className="mailbox-title">Advisor Requests</p>
+            <p className="mailbox-count">{requests.length} requests</p>
           </div>
 
-          {loadingTransfers && (
-            <p className="mail-state" aria-live="polite">Loading group transfer notifications...</p>
+          {loading && (
+            <p className="mail-state" aria-live="polite">Loading advisor requests...</p>
           )}
 
-          {!loadingTransfers && transferLoadError && (
-            <p className="mail-state" aria-live="polite">{transferLoadError}</p>
+          {!loading && loadError && (
+            <p className="mail-state mail-state-error" aria-live="polite">{loadError}</p>
           )}
 
-          {!loadingTransfers && !transferLoadError && transferNotifications.length === 0 && (
-            <p className="mail-state" aria-live="polite">No transfer notifications yet.</p>
+          {!loading && !loadError && requests.length === 0 && (
+            <p className="mail-state" aria-live="polite">No incoming advisor requests.</p>
           )}
 
-          {!loadingTransfers && !transferLoadError && transferNotifications.length > 0 && (
-            <section className="mail-nav" aria-label="Group transfer notification list">
-              {transferNotifications.map((entry) => (
-                <article key={entry.id} className="mail-nav-item">
+          {!loading && !loadError && requests.length > 0 && (
+            <section className="mail-nav" aria-label="Advisor request list">
+              {requests.map((entry) => {
+                const isActive = entry.id === selectedRequestId;
+                return (
                   <button
+                    key={entry.id}
                     type="button"
-                    className="mail-nav-item"
+                    className={`mail-nav-item${isActive ? ' mail-nav-item-active' : ''}`}
                     onClick={() => {
+                      setSelectedRequestId(entry.id);
                       if (!entry.isRead) {
-                        markNotificationAsRead('group-transfer', entry.id);
+                        markNotificationAsRead('advisee-request', entry.id);
                       }
                     }}
                   >
                     <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
-                    <span className="mail-nav-subject">{buildTransferSubject(entry)}</span>
-                    <span className="mail-nav-preview">{buildTransferPreview(entry)}</span>
+                    <span className="mail-nav-subject">{buildSubject(entry)}</span>
+                    <span className="mail-nav-preview">{buildPreview(entry)}</span>
                   </button>
+                );
+              })}
+            </section>
+          )}
+        </aside>
+
+        <section className="mail-inbox-shell mail-detail professor-mail-detail" aria-live="polite">
+          {selectedRequest ? (
+            <>
+              <div className="mail-detail-header">
+                <div>
+                  <span className="mail-topic">Advisee Request</span>
+                  <h2 className="mail-subject">{buildSubject(selectedRequest)}</h2>
+                </div>
+                <span className="mail-time">{formatDate(selectedRequest.createdAt)}</span>
+              </div>
+
+              <div className="mail-meta">
+                <span className="mail-status">{formatStatus(selectedRequest.requestStatus)}</span>
+                <span className="mail-group">{selectedRequest.groupName || selectedRequest.groupId || 'Unknown group'}</span>
+              </div>
+
+              <p className="mail-preview">{buildPreview(selectedRequest)}</p>
+
+              <dl className="mail-detail-grid">
+                <div>
+                  <dt>Request ID</dt>
+                  <dd>{selectedRequest.requestId || 'Not provided'}</dd>
+                </div>
+                <div>
+                  <dt>Notification State</dt>
+                  <dd>{formatStatus(selectedRequest.status)}</dd>
+                </div>
+                <div>
+                  <dt>Decision Time</dt>
+                  <dd>{selectedRequest.decidedAt ? formatDate(selectedRequest.decidedAt) : 'Waiting for review'}</dd>
+                </div>
+                <div>
+                  <dt>Professor Note</dt>
+                  <dd>{selectedRequest.note || 'No note recorded'}</dd>
+                </div>
+              </dl>
+
+              <div className="mail-actions">
+                {selectedRequest?.groupId && (
+                  <Link className="workspace-button workspace-button-primary" to={`/groups/${selectedRequest.groupId}`}>
+                    Open Group
+                  </Link>
+                )}
+
+                {canDecide && (
+                  <>
+                    <button
+                      type="button"
+                      disabled={Boolean(selectedRequestBusy)}
+                      onClick={() => handleDecision('APPROVE')}
+                    >
+                      {selectedRequestBusy ? 'Saving...' : 'Approve'}
+                    </button>
+                    <button
+                      type="button"
+                      disabled={Boolean(selectedRequestBusy)}
+                      onClick={() => handleDecision('REJECT')}
+                    >
+                      {selectedRequestBusy ? 'Saving...' : 'Reject'}
+                    </button>
+                  </>
+                )}
+              </div>
+
+              {!canDecide && selectedRequest?.requestStatus !== 'PENDING' && (
+                <p className="mail-state" aria-live="polite">
+                  This request has already been {formatStatus(selectedRequest.requestStatus).toLowerCase()}.
+                </p>
+              )}
+            </>
+          ) : (
+            <p className="mail-detail-empty">Select a request to review its details.</p>
+          )}
+        </section>
+      </section>
+
+      <section className="mail-inbox-shell professor-transfer-panel">
+        <div className="mail-sidebar-header">
+          <p className="mailbox-title">Group Transfer Notifications</p>
+          <p className="mailbox-count">{transferNotifications.length} notifications</p>
+        </div>
+
+        {loadingTransfers && (
+          <p className="mail-state" aria-live="polite">Loading group transfer notifications...</p>
+        )}
+
+        {!loadingTransfers && transferLoadError && (
+          <p className="mail-state mail-state-error" aria-live="polite">{transferLoadError}</p>
+        )}
+
+        {!loadingTransfers && !transferLoadError && transferNotifications.length === 0 && (
+          <p className="mail-state" aria-live="polite">No transfer notifications yet.</p>
+        )}
+
+        {!loadingTransfers && !transferLoadError && transferNotifications.length > 0 && (
+          <section className="professor-transfer-list" aria-label="Group transfer notification list">
+            {transferNotifications.map((entry) => (
+              <article key={entry.id} className="mail-card professor-transfer-card">
+                <div className="mail-detail-header">
+                  <div>
+                    <span className="mail-topic">Transfer</span>
+                    <h2 className="mail-subject">{buildTransferSubject(entry)}</h2>
+                  </div>
+                  <span className="mail-time">{formatDate(entry.createdAt)}</span>
+                </div>
+                <p className="mail-preview">{buildTransferPreview(entry)}</p>
+                <div className="mail-actions">
+                  {!entry.isRead && (
+                    <button type="button" onClick={() => markNotificationAsRead('group-transfer', entry.id)}>
+                      Mark as read
+                    </button>
+                  )}
                   {entry.groupId && (
-                    <Link to={`/groups/${entry.groupId}`}>
+                    <Link className="workspace-button workspace-button-secondary" to={`/groups/${entry.groupId}`}>
                       Open Group
                     </Link>
                   )}
-                </article>
-              ))}
-            </section>
-          )}
-        </div>
-
-        {loading && (
-          <p className="mail-state" aria-live="polite">Loading advisor requests...</p>
-        )}
-
-        {!loading && loadError && (
-          <p className="mail-state" aria-live="polite">{loadError}</p>
-        )}
-
-        {!loading && !loadError && requests.length === 0 && (
-          <p className="mail-state" aria-live="polite">No incoming advisor requests.</p>
-        )}
-
-        {!loading && !loadError && requests.length > 0 && (
-          <div className="mail-layout">
-            <aside className="mail-sidebar" aria-label="Advisor request list">
-              <div className="mail-sidebar-header">
-                <p className="mailbox-title">Advisor Requests</p>
-                <p className="mailbox-count">{requests.length} requests</p>
-              </div>
-
-              <section className="mail-nav">
-                {requests.map((entry) => {
-                  const isActive = entry.id === selectedRequestId;
-                  return (
-                    <button
-                      key={entry.id}
-                      type="button"
-                      className={`mail-nav-item${isActive ? ' mail-nav-item-active' : ''}`}
-                      onClick={() => {
-                        setSelectedRequestId(entry.id);
-                        if (!entry.isRead) {
-                          markNotificationAsRead('advisee-request', entry.id);
-                        }
-                      }}
-                    >
-                      <span className="mail-nav-time">{formatDate(entry.createdAt)}</span>
-                      <span className="mail-nav-subject">{buildSubject(entry)}</span>
-                      <span className="mail-nav-preview">{buildPreview(entry)}</span>
-                    </button>
-                  );
-                })}
-              </section>
-            </aside>
-
-            <section className="mail-detail" aria-live="polite">
-              {selectedRequest ? (
-                <>
-                  <div className="mail-detail-header">
-                    <div>
-                      <span className="mail-topic">Advisee Request</span>
-                      <h2 className="mail-subject">{buildSubject(selectedRequest)}</h2>
-                    </div>
-                    <span className="mail-time">{formatDate(selectedRequest.createdAt)}</span>
-                  </div>
-
-                  <p className="mail-preview">{buildPreview(selectedRequest)}</p>
-
-                  <dl className="mail-detail-grid">
-                    <div>
-                      <dt>Group</dt>
-                      <dd>{selectedRequest.groupName || selectedRequest.groupId || 'Not specified'}</dd>
-                    </div>
-                    <div>
-                      <dt>Request Status</dt>
-                      <dd>{formatStatus(selectedRequest.requestStatus)}</dd>
-                    </div>
-                    <div>
-                      <dt>Request ID</dt>
-                      <dd>{selectedRequest.requestId || 'Not provided'}</dd>
-                    </div>
-                    <div>
-                      <dt>Notification State</dt>
-                      <dd>{formatStatus(selectedRequest.status)}</dd>
-                    </div>
-                  </dl>
-
-                  {selectedRequest?.groupId && (
-                    <div className="mail-actions">
-                      <Link className="workspace-button workspace-button-primary" to={`/groups/${selectedRequest.groupId}`}>
-                        Open Group
-                      </Link>
-                    </div>
-                  )}
-
-                  {canDecide && (
-                    <div className="mail-actions">
-                      <button
-                        type="button"
-                        disabled={Boolean(selectedRequestBusy)}
-                        onClick={() => handleDecision('APPROVE')}
-                      >
-                        {selectedRequestBusy ? 'Saving...' : 'Approve'}
-                      </button>
-                      <button
-                        type="button"
-                        disabled={Boolean(selectedRequestBusy)}
-                        onClick={() => handleDecision('REJECT')}
-                      >
-                        {selectedRequestBusy ? 'Saving...' : 'Reject'}
-                      </button>
-                    </div>
-                  )}
-
-                  {!canDecide && selectedRequest?.requestStatus !== 'PENDING' && (
-                    <p className="mail-state" aria-live="polite">
-                      This request has already been {formatStatus(selectedRequest.requestStatus).toLowerCase()}.
-                    </p>
-                  )}
-
-                  {feedback.message && (
-                    <p className={`mail-state mail-state-${feedback.type || 'info'}`} aria-live="polite">
-                      {feedback.message}
-                    </p>
-                  )}
-                </>
-              ) : (
-                <p className="mail-detail-empty">Select a request to review its details.</p>
-              )}
-            </section>
-          </div>
+                </div>
+              </article>
+            ))}
+          </section>
         )}
       </section>
     </main>

--- a/frontend/src/ProfessorHomePage.jsx
+++ b/frontend/src/ProfessorHomePage.jsx
@@ -1,0 +1,84 @@
+import { useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useNotification } from './contexts/NotificationContext';
+
+function getProfessorName() {
+  try {
+    const storedUser = window.localStorage.getItem('professorUser');
+    if (!storedUser) {
+      return 'Professor';
+    }
+
+    const parsed = JSON.parse(storedUser);
+    return parsed.fullName || parsed.email || 'Professor';
+  } catch {
+    return 'Professor';
+  }
+}
+
+const professorTools = [
+  {
+    eyebrow: 'Inbox',
+    title: 'Advisor Requests',
+    description: 'Review incoming advisor requests from team leaders and open assigned groups from one place.',
+    href: '/professors/notifications',
+    cta: 'Open Advisor Inbox',
+    status: 'Ready',
+  },
+  {
+    eyebrow: 'Account',
+    title: 'Password Setup',
+    description: 'Create or update the password used to sign in to the professor workspace.',
+    href: '/professors/password-setup',
+    cta: 'Open Password Setup',
+    status: 'Ready',
+  },
+];
+
+export default function ProfessorHomePage() {
+  const navigate = useNavigate();
+  const { notify } = useNotification();
+  const professorName = getProfessorName();
+  const token = window.localStorage.getItem('professorToken') || '';
+
+  useEffect(() => {
+    if (token) {
+      return;
+    }
+
+    notify({
+      type: 'warning',
+      title: 'Professor login required',
+      message: 'Please sign in before opening the professor workspace.',
+    });
+    navigate('/professors/login', { replace: true });
+  }, [navigate, notify, token]);
+
+  return (
+    <main className="page">
+      <section className="hero">
+        <p className="eyebrow">Professor Workspace</p>
+        <h1>{professorName}</h1>
+        <p className="subtitle">
+          Open your advisor inbox or manage your account setup from the professor workspace.
+        </p>
+      </section>
+
+      <section className="gateway-grid">
+        {professorTools.map((tool) => (
+          <article key={tool.href} className="gateway-card">
+            <p className="gateway-eyebrow">{tool.eyebrow}</p>
+            <div className="gateway-header">
+              <h2>{tool.title}</h2>
+              <span className={`gateway-status gateway-status-${tool.status.toLowerCase()}`}>{tool.status}</span>
+            </div>
+            <p className="gateway-copy">{tool.description}</p>
+            <Link className="gateway-link" to={tool.href}>
+              {tool.cta}
+            </Link>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/StudentGroupShellPage.jsx
+++ b/frontend/src/StudentGroupShellPage.jsx
@@ -2,6 +2,12 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useGroupFormation } from './hooks/useGroupFormation';
 
+const initialFeedback = {
+  type: '',
+  title: '',
+  message: '',
+};
+
 export default function StudentGroupShellPage() {
   const {
     createGroupShell,
@@ -21,10 +27,12 @@ export default function StudentGroupShellPage() {
   const [inviteIds, setInviteIds] = useState([]);
   const [selectedInviteIds, setSelectedInviteIds] = useState([]);
   const [selectedKickMemberId, setSelectedKickMemberId] = useState('');
-  const [manageError, setManageError] = useState('');
+  const [manageFeedback, setManageFeedback] = useState(initialFeedback);
 
   const selectedGroup = groups.find((item) => String(item.groupId) === String(selectedGroupId)) || null;
   const selectedIsLeader = selectedGroup?.membershipRole === 'LEADER';
+  const leaderManagedGroups = groups.filter((item) => item.membershipRole === 'LEADER');
+  const advisorRequestEligibleGroups = leaderManagedGroups.filter((item) => !item.advisor?.id);
 
   const memberRows = (() => {
     if (!selectedGroup) {
@@ -67,6 +75,14 @@ export default function StudentGroupShellPage() {
     return (selectedGroup.members || []).filter((member) => String(member.id) !== leaderId);
   })();
 
+  const currentMemberCount = memberRows.length;
+  const availableInviteSlots = selectedGroup ? Math.max(Number(selectedGroup.maxMembers || 0) - currentMemberCount, 0) : 0;
+  const selectedGroupIsFull = Boolean(selectedGroup) && availableInviteSlots === 0;
+
+  function showFeedback(type, title, message) {
+    setManageFeedback({ type, title, message });
+  }
+
   async function loadGroupDirectory() {
     setGroupsLoading(true);
 
@@ -94,6 +110,7 @@ export default function StudentGroupShellPage() {
     } catch (loadError) {
       setGroups([]);
       setSelectedGroupId('');
+      showFeedback('error', 'Groups unavailable', loadError.message || 'Could not load groups.');
     } finally {
       setGroupsLoading(false);
     }
@@ -117,7 +134,7 @@ export default function StudentGroupShellPage() {
 
   async function handleSubmit(event) {
     event.preventDefault();
-    setManageError('');
+    setManageFeedback(initialFeedback);
 
     try {
       await createGroupShell(newGroupName, newGroupMaxMembers);
@@ -125,17 +142,18 @@ export default function StudentGroupShellPage() {
       setNewGroupMaxMembers(4);
       setShowAddGroupModal(false);
       await loadGroupDirectory();
+      showFeedback('success', 'Group created', 'Your new group shell is ready.');
     } catch (createError) {
-      setManageError(createError.response?.data?.message || createError.message || 'Failed to create group.');
+      showFeedback('error', 'Create failed', createError.response?.data?.message || createError.message || 'Failed to create group.');
     }
   }
 
-  async function updateSelectedGroup(payload) {
+  async function updateSelectedGroup(payload, successTitle, successMessage) {
     if (!selectedGroup || !selectedIsLeader) {
       return;
     }
 
-    setManageError('');
+    setManageFeedback(initialFeedback);
 
     try {
       const token = window.localStorage.getItem('studentToken') || window.localStorage.getItem('authToken');
@@ -148,35 +166,40 @@ export default function StudentGroupShellPage() {
         body: JSON.stringify(payload),
       });
 
-      const payload = await response.json().catch(() => ({}));
+      const responsePayload = await response.json().catch(() => ({}));
       if (!response.ok) {
-        throw new Error(payload.message || 'Failed to rename group.');
+        throw new Error(responsePayload.message || 'Failed to update group.');
       }
 
       await loadGroupDirectory();
-    } catch (renameError) {
-      setManageError(renameError.message || 'Failed to rename group.');
+      showFeedback('success', successTitle, successMessage);
+    } catch (updateError) {
+      showFeedback('error', 'Update failed', updateError.message || 'Failed to update group.');
     }
   }
 
   async function handleChangeGroupName() {
     const nextName = renameGroupName.trim();
     if (!nextName) {
-      setManageError('Group name is required.');
+      showFeedback('error', 'Invalid group name', 'Group name is required.');
       return;
     }
 
-    await updateSelectedGroup({ groupName: nextName });
+    await updateSelectedGroup({ groupName: nextName }, 'Group renamed', `Group name updated to "${nextName}".`);
   }
 
   async function handleChangeMaxMembers() {
     const nextMax = Number(editGroupMaxMembers);
     if (!Number.isInteger(nextMax) || nextMax < 1 || nextMax > 10) {
-      setManageError('Max members must be between 1 and 10.');
+      showFeedback('error', 'Invalid max members', 'Max members must be between 1 and 10.');
       return;
     }
 
-    await updateSelectedGroup({ maxMembers: nextMax });
+    await updateSelectedGroup(
+      { maxMembers: nextMax },
+      'Capacity updated',
+      `Group capacity is now ${nextMax} member${nextMax === 1 ? '' : 's'}.`,
+    );
   }
 
   async function handleDeleteSelectedGroup() {
@@ -189,7 +212,7 @@ export default function StudentGroupShellPage() {
       return;
     }
 
-    setManageError('');
+    setManageFeedback(initialFeedback);
 
     try {
       const token = window.localStorage.getItem('studentToken') || window.localStorage.getItem('authToken');
@@ -206,8 +229,9 @@ export default function StudentGroupShellPage() {
       }
 
       await loadGroupDirectory();
+      showFeedback('success', 'Group deleted', `"${selectedGroup.groupName}" was removed.`);
     } catch (deleteError) {
-      setManageError(deleteError.message || 'Failed to delete group.');
+      showFeedback('error', 'Delete failed', deleteError.message || 'Failed to delete group.');
     }
   }
 
@@ -216,7 +240,7 @@ export default function StudentGroupShellPage() {
       return;
     }
 
-    setManageError('');
+    setManageFeedback(initialFeedback);
 
     try {
       const token = window.localStorage.getItem('studentToken') || window.localStorage.getItem('authToken');
@@ -234,27 +258,42 @@ export default function StudentGroupShellPage() {
       }
 
       await loadGroupDirectory();
+      showFeedback('success', 'Left group', 'You have left the selected group.');
     } catch (leaveError) {
-      setManageError(leaveError.message || 'Failed to leave group.');
+      showFeedback('error', 'Leave failed', leaveError.message || 'Failed to leave group.');
     }
   }
 
   function addInviteId() {
     const id = inviteInput.trim();
     if (!/^\d{11}$/.test(id)) {
-      setManageError('Student ID must be exactly 11 digits.');
+      showFeedback('error', 'Invalid student ID', 'Student ID must be exactly 11 digits.');
       return;
     }
 
     if (inviteIds.includes(id)) {
-      setManageError('This student ID is already queued.');
+      showFeedback('error', 'Already queued', 'This student ID is already queued.');
+      return;
+    }
+
+    if (selectedGroupIsFull) {
+      showFeedback('warning', 'Group is full', 'This group is already at full capacity.');
+      return;
+    }
+
+    if (inviteIds.length >= availableInviteSlots) {
+      showFeedback(
+        'warning',
+        'No invite slots left',
+        `Only ${availableInviteSlots} slot${availableInviteSlots === 1 ? '' : 's'} available for new members.`,
+      );
       return;
     }
 
     setInviteIds((prev) => [...prev, id]);
     setSelectedInviteIds((prev) => [...prev, id]);
     setInviteInput('');
-    setManageError('');
+    setManageFeedback(initialFeedback);
   }
 
   function removeSelectedInviteIds() {
@@ -273,19 +312,39 @@ export default function StudentGroupShellPage() {
     }
 
     if (inviteIds.length === 0) {
-      setManageError('Add at least one student ID to invite.');
+      showFeedback('error', 'Invite list empty', 'Add at least one student ID to invite.');
       return;
     }
 
-    setManageError('');
+    if (selectedGroupIsFull) {
+      showFeedback('warning', 'Group is full', 'This group is already at full capacity.');
+      return;
+    }
+
+    if (inviteIds.length > availableInviteSlots) {
+      showFeedback(
+        'warning',
+        'Invite limit exceeded',
+        `Only ${availableInviteSlots} slot${availableInviteSlots === 1 ? '' : 's'} available for new members.`,
+      );
+      return;
+    }
+
+    setManageFeedback(initialFeedback);
 
     try {
-      await dispatchInvites(selectedGroup.groupId, inviteIds);
+      const result = await dispatchInvites(selectedGroup.groupId, inviteIds);
+      const createdCount = Array.isArray(result) ? result.length : inviteIds.length;
       setInviteIds([]);
       setSelectedInviteIds([]);
       setInviteInput('');
+      showFeedback(
+        'success',
+        'Invites sent',
+        `${createdCount} invitation${createdCount === 1 ? '' : 's'} sent successfully.`,
+      );
     } catch (inviteError) {
-      setManageError(inviteError.response?.data?.message || inviteError.message || 'Failed to send invites.');
+      showFeedback('error', 'Invite failed', inviteError.response?.data?.message || inviteError.message || 'Failed to send invites.');
     }
   }
 
@@ -295,7 +354,7 @@ export default function StudentGroupShellPage() {
     }
 
     if (!selectedKickMemberId) {
-      setManageError('Select a member to kick.');
+      showFeedback('error', 'No member selected', 'Select a member to kick.');
       return;
     }
 
@@ -304,7 +363,7 @@ export default function StudentGroupShellPage() {
       return;
     }
 
-    setManageError('');
+    setManageFeedback(initialFeedback);
 
     try {
       const token = window.localStorage.getItem('studentToken') || window.localStorage.getItem('authToken');
@@ -322,8 +381,9 @@ export default function StudentGroupShellPage() {
 
       await loadGroupDirectory();
       setSelectedKickMemberId('');
+      showFeedback('success', 'Member removed', 'Selected member was removed from the group.');
     } catch (kickError) {
-      setManageError(kickError.message || 'Failed to remove member.');
+      showFeedback('error', 'Kick failed', kickError.message || 'Failed to remove member.');
     }
   }
 
@@ -352,30 +412,45 @@ export default function StudentGroupShellPage() {
           <button type="button" onClick={() => setShowAddGroupModal(true)}>
             Create Group
           </button>
-          <Link to="/team-leader/advisor-requests/new">Request Advisor</Link>
+          {advisorRequestEligibleGroups.length > 0 ? (
+            <Link to="/team-leader/advisor-requests/new">Request Advisor</Link>
+          ) : (
+            <span className="workspace-button workspace-button-secondary workspace-button-disabled">
+              Request Advisor
+            </span>
+          )}
         </div>
+
+        {leaderManagedGroups.length === 0 && (
+          <div className="feedback feedback-warning" aria-live="polite">
+            <div className="feedback-label">restricted</div>
+            <h2>Leader action required</h2>
+            <p>Only team leaders can submit advisor requests. Create a group first to unlock this flow.</p>
+          </div>
+        )}
 
         {selectedGroup && (
           <section className="manage-group-layout">
             <section className="form">
-            <h2 className="group-manage-title">{selectedGroup.groupName}</h2>
-            <p className="token-note">Members</p>
+              <h2 className="group-manage-title">{selectedGroup.groupName}</h2>
+              <p className="token-note">
+                Members {currentMemberCount} / {selectedGroup.maxMembers}
+              </p>
 
-            <div className="group-directory-members">
-              {memberRows.map((member) => (
-                <article key={member.id} className="group-member-row">
-                  <div>
-                    <strong>{member.fullName || member.studentId || 'Student'}</strong>
-                    <span>{member.studentId || member.role}</span>
-                  </div>
+              <div className="group-directory-members">
+                {memberRows.map((member) => (
+                  <article key={member.id} className="group-member-row">
+                    <div>
+                      <strong>{member.fullName || member.studentId || 'Student'}</strong>
+                      <span>{member.studentId || member.role}</span>
+                    </div>
 
-                  <div className="group-member-actions">
-                    <span className="member-role-badge">{member.role}</span>
-                  </div>
-                </article>
-              ))}
-            </div>
-
+                    <div className="group-member-actions">
+                      <span className="member-role-badge">{member.role}</span>
+                    </div>
+                  </article>
+                ))}
+              </div>
             </section>
 
             <section className="form">
@@ -391,7 +466,9 @@ export default function StudentGroupShellPage() {
                         minLength={1}
                         maxLength={255}
                       />
-                      <button type="button" className="invite-add-button" onClick={handleChangeGroupName}>Change Name</button>
+                      <button type="button" className="invite-add-button" onClick={handleChangeGroupName}>
+                        Change Name
+                      </button>
                     </div>
                   </label>
 
@@ -405,12 +482,19 @@ export default function StudentGroupShellPage() {
                         min={1}
                         max={10}
                       />
-                      <button type="button" className="invite-add-button" onClick={handleChangeMaxMembers}>Change Max</button>
+                      <button type="button" className="invite-add-button" onClick={handleChangeMaxMembers}>
+                        Change Max
+                      </button>
                     </div>
                   </label>
 
                   <label className="field">
                     <span>Invite Student Number</span>
+                    <div className="field-help" role="note">
+                      {selectedGroupIsFull
+                        ? 'This group is full, so new invites are disabled.'
+                        : `${availableInviteSlots} slot${availableInviteSlots === 1 ? '' : 's'} available for new members.`}
+                    </div>
                     <div className="invite-input-row">
                       <input
                         type="text"
@@ -418,8 +502,11 @@ export default function StudentGroupShellPage() {
                         onChange={(event) => setInviteInput(event.target.value)}
                         placeholder="11-digit student ID"
                         maxLength={11}
+                        disabled={selectedGroupIsFull}
                       />
-                      <button type="button" className="invite-add-button" onClick={addInviteId}>Add</button>
+                      <button type="button" className="invite-add-button" onClick={addInviteId} disabled={selectedGroupIsFull}>
+                        Add
+                      </button>
                     </div>
                   </label>
 
@@ -442,7 +529,11 @@ export default function StudentGroupShellPage() {
                   </label>
 
                   <div className="invite-form-actions">
-                    <button type="button" onClick={handleSendInvites} disabled={invitesPending || inviteIds.length === 0}>
+                    <button
+                      type="button"
+                      onClick={handleSendInvites}
+                      disabled={invitesPending || inviteIds.length === 0 || selectedGroupIsFull}
+                    >
                       {invitesPending ? 'Sending...' : 'Invite Users'}
                     </button>
                     <button type="button" onClick={removeSelectedInviteIds} disabled={selectedInviteIds.length === 0}>
@@ -486,10 +577,15 @@ export default function StudentGroupShellPage() {
           </section>
         )}
 
-        {(manageError || groupsLoading) && (
-          <p className="token-note">
-            {groupsLoading ? 'Refreshing groups...' : manageError}
-          </p>
+        {(groupsLoading || manageFeedback.message) && (
+          <div
+            className={groupsLoading ? 'feedback feedback-loading' : `feedback feedback-${manageFeedback.type || 'idle'}`}
+            aria-live="polite"
+          >
+            <div className="feedback-label">{groupsLoading ? 'loading' : manageFeedback.type || 'info'}</div>
+            {!groupsLoading && manageFeedback.title && <h2>{manageFeedback.title}</h2>}
+            <p>{groupsLoading ? 'Refreshing groups...' : manageFeedback.message}</p>
+          </div>
         )}
 
         <p className="token-note">
@@ -536,7 +632,6 @@ export default function StudentGroupShellPage() {
           </section>
         </div>
       )}
-
     </main>
   );
 }

--- a/frontend/src/SubmitAdvisorRequestPage.jsx
+++ b/frontend/src/SubmitAdvisorRequestPage.jsx
@@ -29,6 +29,8 @@ export default function SubmitAdvisorRequestPage() {
   const selectedGroup = groups.find((group) => String(group.id) === String(form.groupId)) || null;
   const selectedGroupHasAdvisor = Boolean(selectedGroup?.advisorId);
   const eligibleGroups = groups.filter((group) => !group.advisorId);
+  const hasLeaderGroup = groups.length > 0;
+  const canSubmit = hasLeaderGroup && eligibleGroups.length > 0 && professors.length > 0;
 
   useEffect(() => {
     async function loadData() {
@@ -124,13 +126,21 @@ export default function SubmitAdvisorRequestPage() {
 
       <div className="panel">
         <form className="form" onSubmit={handleSubmit}>
+          {!hasLeaderGroup && (
+            <div className="feedback feedback-warning" role="status" aria-live="polite">
+              <div className="feedback-label">restricted</div>
+              <h2>Team leader access required</h2>
+              <p>You can submit an advisor request only for a group that you lead.</p>
+            </div>
+          )}
+
           <label className="field">
             <span>Your Group *</span>
             <select
               name="groupId"
               value={form.groupId}
               onChange={handleChange}
-              disabled={isSubmitting}
+              disabled={isSubmitting || !hasLeaderGroup}
               aria-invalid={fieldErrors.groupId.length > 0}
               required
             >
@@ -142,7 +152,12 @@ export default function SubmitAdvisorRequestPage() {
                 </option>
               ))}
             </select>
-            {groups.length > 0 && eligibleGroups.length === 0 && (
+            {!hasLeaderGroup && (
+              <div className="field-help" role="note">
+                No team-leader group was found for your account.
+              </div>
+            )}
+            {hasLeaderGroup && eligibleGroups.length === 0 && (
               <div className="field-help" role="note">
                 All of your groups already have advisors, so no new advisor request can be created.
               </div>
@@ -162,7 +177,7 @@ export default function SubmitAdvisorRequestPage() {
               name="professorId"
               value={form.professorId}
               onChange={handleChange}
-              disabled={isSubmitting || !form.groupId || selectedGroupHasAdvisor}
+              disabled={isSubmitting || !form.groupId || selectedGroupHasAdvisor || !hasLeaderGroup}
               aria-invalid={fieldErrors.professorId.length > 0}
               required
             >
@@ -194,9 +209,7 @@ export default function SubmitAdvisorRequestPage() {
               isSubmitting
               || !form.groupId
               || !form.professorId
-              || groups.length === 0
-              || eligibleGroups.length === 0
-              || professors.length === 0
+              || !canSubmit
               || selectedGroupHasAdvisor
             }
           >

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -16,7 +16,7 @@ const roleMenuSections = {
     {
       title: 'Workspace',
       items: [
-        { to: '/home', label: 'Professor Home', icon: 'HM' },
+        { to: '/professors', label: 'Professor Home', icon: 'HM' },
         { to: '/professors/notifications', label: 'Advisor Requests', icon: 'AR' },
       ],
     },
@@ -25,7 +25,7 @@ const roleMenuSections = {
     {
       title: 'Workspace',
       items: [
-        { to: '/home', label: 'Coordinator Home', icon: 'HM' },
+        { to: '/coordinator', label: 'Coordinator Home', icon: 'HM' },
       ],
     },
     {
@@ -42,7 +42,7 @@ const roleMenuSections = {
     {
       title: 'Workspace',
       items: [
-        { to: '/home', label: 'Admin Home', icon: 'HM' },
+        { to: '/admin', label: 'Admin Home', icon: 'HM' },
       ],
     },
     {
@@ -92,6 +92,21 @@ function readAuthenticatedUser() {
   }
 
   return null;
+}
+
+function homeRouteForViewer(role) {
+  switch (role) {
+    case 'Admin':
+      return '/admin';
+    case 'Coordinator':
+      return '/coordinator';
+    case 'Professor':
+      return '/professors';
+    case 'Student':
+      return '/home';
+    default:
+      return '/';
+  }
 }
 
 export default function AppShell() {
@@ -144,7 +159,7 @@ export default function AppShell() {
             </div>
 
             <div className="app-brand-wrap">
-              <Link className="app-brand" to="/">
+              <Link className="app-brand" to={homeRouteForViewer(viewer.role)}>
                 Senior App
               </Link>
               <span className="app-brand-subtitle">Home</span>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -652,6 +652,11 @@ textarea {
   box-shadow: 0 12px 20px rgba(17, 94, 89, 0.16);
 }
 
+.workspace-button-disabled {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
 .home-footer-note {
   border: 1px dashed rgba(31, 42, 31, 0.22);
   border-radius: 18px;
@@ -1558,6 +1563,17 @@ button:disabled {
   max-width: 1200px;
 }
 
+.mail-workspace {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(320px, 0.92fr) minmax(0, 1.08fr);
+  align-items: start;
+}
+
+.professor-mail-summary {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .mail-summary-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -1831,6 +1847,26 @@ button:disabled {
   min-width: 110px;
 }
 
+.professor-mail-detail {
+  min-height: 100%;
+}
+
+.professor-transfer-panel {
+  margin-top: 18px;
+  overflow: hidden;
+}
+
+.professor-transfer-list {
+  padding: 14px;
+  display: grid;
+  gap: 12px;
+}
+
+.professor-transfer-card {
+  display: grid;
+  gap: 12px;
+}
+
 .mail-overlay {
   position: fixed;
   inset: 0;
@@ -1919,6 +1955,11 @@ button:disabled {
   margin: 0 auto;
 }
 
+.page-group-view {
+  width: calc(100% - 32px);
+  max-width: 880px;
+}
+
 .group-page-header {
   margin-bottom: 2rem;
 }
@@ -1945,6 +1986,33 @@ button:disabled {
   margin-top: 0;
 }
 
+.group-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.group-summary-item {
+  border: 1px solid rgba(168, 183, 206, 0.16);
+  border-radius: 14px;
+  background: rgba(65, 79, 102, 0.16);
+  padding: 12px;
+  display: grid;
+  gap: 6px;
+}
+
+.group-summary-item span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.group-summary-item strong {
+  color: var(--ink);
+  font-size: 1rem;
+}
+
 .group-muted {
   color: var(--muted);
 }
@@ -1962,6 +2030,10 @@ button:disabled {
   background: rgba(65, 79, 102, 0.22);
   border-radius: 10px;
   border: 1px solid rgba(168, 183, 206, 0.16);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .group-member-you {
@@ -1986,6 +2058,102 @@ button:disabled {
 
 .cleanup-hint {
   margin: 0;
+}
+
+.group-action-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.group-action-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.group-action-row button {
+  width: auto;
+  min-width: 140px;
+}
+
+.group-callout {
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  padding: 14px 16px;
+}
+
+.group-callout-success {
+  background: var(--success-bg);
+  border-color: var(--success-line);
+  color: var(--success-ink);
+}
+
+.group-callout-warning {
+  background: var(--warning-bg);
+  border-color: var(--warning-line);
+  color: var(--warning-ink);
+}
+
+.group-callout-error {
+  background: var(--error-bg);
+  border-color: var(--error-line);
+  color: var(--error-ink);
+}
+
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.dialog-backdrop {
+  position: absolute;
+  inset: 0;
+  border: none;
+  border-radius: 0;
+  background: rgba(8, 12, 20, 0.62);
+  box-shadow: none;
+}
+
+.dialog-backdrop:hover,
+.dialog-backdrop:focus-visible {
+  transform: none;
+  filter: none;
+  box-shadow: none;
+}
+
+.dialog-card {
+  position: relative;
+  z-index: 1;
+  width: min(460px, 92vw);
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at top right, rgba(56, 195, 204, 0.08), transparent 28%),
+    linear-gradient(180deg, rgba(27, 36, 50, 0.98), rgba(18, 26, 38, 0.98));
+  box-shadow: var(--shadow);
+  padding: 24px;
+  display: grid;
+  gap: 14px;
+}
+
+.dialog-card h2,
+.dialog-card p {
+  margin: 0;
+}
+
+.dialog-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.dialog-actions button {
+  width: auto;
+  min-width: 130px;
 }
 
 .audit-log-list {
@@ -2209,5 +2377,11 @@ button:disabled {
 
   .app-profile-trigger {
     min-width: 160px;
+  }
+
+  .mail-workspace,
+  .professor-mail-summary,
+  .group-summary-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
This PR tightens the 3.0 mentor matching flow and related student/professor group workflows.

## What changed
- added missing audit logs for advisor release and coordinator advisor transfer
- passed actor context from controller/service boundaries so audit records are written with the correct user
- prevented group invite dispatch when the group is already full
- enforced available invite slot checks before sending invitations
- allowed re-inviting users by recycling non-pending invitations instead of hitting duplicate invitation constraints
- improved student advisor request UI so only eligible leader-owned groups can submit requests
- improved student group management feedback for rename, max members, invites, kick, leave, and delete actions
- refreshed professor advisor inbox and transfer notification UI
- restored professor-specific home routing and role-based redirects/navigation

## Validation
- backend tests: `52/52` passing
- frontend build: `vite build` passing

## Notes
- excluded unrelated local files and comment-only diffs from this PR
- demo database and runbook were prepared separately and are not included in this commit
