### PR TITLE
feat(#253): Store grades and committee review connector

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -20,6 +20,7 @@ const passwordSetupTokenStoreRoutes = require('./routes/passwordSetupTokenStore'
 const userDatabaseRoutes = require('./routes/userDatabase');
 const groupRoutes = require('./routes/groups');
 const groupDatabaseRoutes = require('./routes/groupDatabase');
+const committeeRoutes = require('./routes/committee');
 
 const app = express();
 const frontendDistPath = path.join(__dirname, '..', 'frontend', 'dist');
@@ -49,6 +50,7 @@ app.use('/api/v1/password-setup-token-store', passwordSetupTokenStoreRoutes);
 app.use('/api/v1/user-database', userDatabaseRoutes);
 app.use('/api/v1/group-database', groupDatabaseRoutes);
 app.use('/api/v1/groups', groupRoutes);
+app.use('/api/v1/committee', committeeRoutes);
 
 // Global error handler
 app.use((err, req, res, _next) => {

--- a/backend/controllers/committeeController.js
+++ b/backend/controllers/committeeController.js
@@ -43,8 +43,14 @@ exports.submitReview = async (req, res) => {
     if (err.code === 'SUBMISSION_NOT_FOUND') {
       return res.status(404).json({ code: 'SUBMISSION_NOT_FOUND', message: 'Submission not found' });
     }
+    if (err.code === 'DUPLICATE_CRITERION_ID') {
+      return res.status(400).json({ code: 'DUPLICATE_CRITERION_ID', message: err.message });
+    }
     if (err.code === 'INVALID_CRITERION_ID') {
       return res.status(400).json({ code: 'INVALID_CRITERION_ID', message: err.message, details: err.details || [] });
+    }
+    if (err.code === 'SCORE_EXCEEDS_MAX') {
+      return res.status(400).json({ code: 'SCORE_EXCEEDS_MAX', message: err.message, details: err.details });
     }
     console.error('[committeeController] submitReview error:', err);
     return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Internal server error' });

--- a/backend/controllers/committeeController.js
+++ b/backend/controllers/committeeController.js
@@ -1,0 +1,52 @@
+const { body, param, validationResult } = require('express-validator');
+const committeeService = require('../services/committeeService');
+
+exports.submitReviewValidation = [
+  param('submissionId').isString().trim().notEmpty().withMessage('submissionId is required'),
+  body('scores').isArray({ min: 1 }).withMessage('scores must be a non-empty array'),
+  body('scores.*.criterionId').isString().trim().notEmpty().withMessage('Each score must have a valid criterionId'),
+  body('scores.*.value').isFloat({ min: 0 }).withMessage('Each score value must be a non-negative number'),
+  body('comments').optional({ nullable: true }).isString().withMessage('comments must be a string'),
+];
+
+exports.submitReview = async (req, res) => {
+  try {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: 'Validation failed',
+        errors: errors.array(),
+      });
+    }
+
+    const { submissionId } = req.params;
+    const { scores, comments } = req.body;
+
+    const review = await committeeService.submitReview({
+      submissionId,
+      reviewerId: req.user.id,
+      scores,
+      comments,
+    });
+
+    return res.status(201).json({
+      id: review.id,
+      submissionId: review.submissionId,
+      reviewerId: review.reviewerId,
+      scores: review.scores,
+      comments: review.comments,
+      finalScore: review.finalScore,
+      createdAt: review.createdAt,
+    });
+  } catch (err) {
+    if (err.code === 'SUBMISSION_NOT_FOUND') {
+      return res.status(404).json({ code: 'SUBMISSION_NOT_FOUND', message: 'Submission not found' });
+    }
+    if (err.code === 'INVALID_CRITERION_ID') {
+      return res.status(400).json({ code: 'INVALID_CRITERION_ID', message: err.message, details: err.details || [] });
+    }
+    console.error('[committeeController] submitReview error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Internal server error' });
+  }
+};

--- a/backend/models/CommitteeReview.js
+++ b/backend/models/CommitteeReview.js
@@ -1,0 +1,39 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const CommitteeReview = sequelize.define(
+  'CommitteeReview',
+  {
+    id: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    submissionId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    reviewerId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    scores: {
+      type: DataTypes.JSON,
+      allowNull: false,
+    },
+    comments: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    finalScore: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+  },
+  {
+    tableName: 'CommitteeReviews',
+    timestamps: true,
+  }
+);
+
+module.exports = CommitteeReview;

--- a/backend/models/DeliverableSubmission.js
+++ b/backend/models/DeliverableSubmission.js
@@ -1,0 +1,45 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const DeliverableSubmission = sequelize.define(
+  'DeliverableSubmission',
+  {
+    id: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    groupId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    type: {
+      type: DataTypes.ENUM('PROPOSAL', 'SOW'),
+      allowNull: false,
+    },
+    content: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.ENUM('SUBMITTED', 'UNDER_REVIEW', 'GRADED'),
+      allowNull: false,
+      defaultValue: 'SUBMITTED',
+    },
+    submittedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    sprintNumber: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+  },
+  {
+    tableName: 'DeliverableSubmissions',
+    timestamps: true,
+  }
+);
+
+module.exports = DeliverableSubmission;

--- a/backend/models/RubricCriterion.js
+++ b/backend/models/RubricCriterion.js
@@ -1,0 +1,40 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const RubricCriterion = sequelize.define(
+  'RubricCriterion',
+  {
+    id: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    deliverableType: {
+      type: DataTypes.ENUM('PROPOSAL', 'SOW'),
+      allowNull: false,
+    },
+    question: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    criterionType: {
+      type: DataTypes.ENUM('BINARY', 'SOFT'),
+      allowNull: false,
+    },
+    maxPoints: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+    weight: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+  },
+  {
+    tableName: 'RubricCriteria',
+    timestamps: true,
+    indexes: [{ unique: true, fields: ['question', 'deliverableType'] }],
+  }
+);
+
+module.exports = RubricCriterion;

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -17,6 +17,9 @@ const GroupAdvisorAssignment = require('./GroupAdvisorAssignment');
 const Invitation = require('./Invitation');
 const AuditLog = require('./AuditLog');
 const Notification = require('./Notification');
+const DeliverableSubmission = require('./DeliverableSubmission');
+const RubricCriterion = require('./RubricCriterion');
+const CommitteeReview = require('./CommitteeReview');
 
 module.exports = {
   User,
@@ -30,4 +33,7 @@ module.exports = {
   Invitation,
   AuditLog,
   Notification,
+  DeliverableSubmission,
+  RubricCriterion,
+  CommitteeReview,
 };

--- a/backend/routes/committee.js
+++ b/backend/routes/committee.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const { authenticate, authorize } = require('../middleware/auth');
+const committeeController = require('../controllers/committeeController');
+
+const router = express.Router();
+
+router.post(
+  '/submissions/:submissionId/review',
+  authenticate,
+  authorize(['PROFESSOR']),
+  committeeController.submitReviewValidation,
+  committeeController.submitReview,
+);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,7 @@ const Group = require('./models/Group');
 const app = require('./app');
 require('./models');
 const { ensureValidStudentRegistry } = require('./services/studentService');
+const { RubricCriterion } = require('./models');
 
 const ensureSqliteColumns = async () => {
   const queryInterface = sequelize.getQueryInterface();
@@ -75,6 +76,14 @@ const ensureSqliteColumns = async () => {
   }
 };
 
+const seedRubricCriteria = async () => {
+  await RubricCriterion.bulkCreate([
+    { deliverableType: 'PROPOSAL', question: 'Technical Feasibility', criterionType: 'SOFT', maxPoints: 10, weight: 0.4 },
+    { deliverableType: 'PROPOSAL', question: 'Project Scope Clarity', criterionType: 'SOFT', maxPoints: 10, weight: 0.4 },
+    { deliverableType: 'PROPOSAL', question: 'Team Qualification', criterionType: 'BINARY', maxPoints: 5, weight: 0.2 },
+  ], { ignoreDuplicates: true });
+};
+
 // Connect to SQLite and sync models
 sequelize.authenticate()
   .then(() => {
@@ -83,6 +92,7 @@ sequelize.authenticate()
   })
   .then(() => ensureSqliteColumns())
   .then(() => ensureValidStudentRegistry())
+  .then(() => seedRubricCriteria())
   .then(() => console.log("Database synced"))
   .catch(err => console.log("Database error:", err));
 

--- a/backend/services/committeeService.js
+++ b/backend/services/committeeService.js
@@ -24,7 +24,16 @@ async function submitReview({ submissionId, reviewerId, scores, comments }) {
   }
 
   const criterionIds = scores.map((s) => s.criterionId);
-  const criteria = await RubricCriterion.findAll({ where: { id: criterionIds } });
+  const uniqueCriterionIds = new Set(criterionIds);
+  if (uniqueCriterionIds.size !== criterionIds.length) {
+    const err = new Error('Duplicate criterionIds are not allowed in a single review');
+    err.code = 'DUPLICATE_CRITERION_ID';
+    throw err;
+  }
+
+  const criteria = await RubricCriterion.findAll({
+    where: { id: criterionIds, deliverableType: submission.type },
+  });
 
   if (criteria.length !== criterionIds.length) {
     const foundIds = new Set(criteria.map((c) => c.id));
@@ -36,6 +45,19 @@ async function submitReview({ submissionId, reviewerId, scores, comments }) {
   }
 
   const criteriaMap = new Map(criteria.map((c) => [c.id, c]));
+
+  for (const score of scores) {
+    const criterion = criteriaMap.get(score.criterionId);
+    if (score.value > criterion.maxPoints) {
+      const err = new Error(
+        `Score ${score.value} exceeds maxPoints ${criterion.maxPoints} for criterion ${score.criterionId}`
+      );
+      err.code = 'SCORE_EXCEEDS_MAX';
+      err.details = { criterionId: score.criterionId, value: score.value, maxPoints: criterion.maxPoints };
+      throw err;
+    }
+  }
+
   const finalScore = calculateFinalScore(scores, criteriaMap);
 
   const transaction = await sequelize.transaction();

--- a/backend/services/committeeService.js
+++ b/backend/services/committeeService.js
@@ -1,0 +1,61 @@
+const sequelize = require('../db');
+const { DeliverableSubmission, RubricCriterion, CommitteeReview } = require('../models');
+
+function calculateFinalScore(scores, criteriaMap) {
+  let weightedSum = 0;
+  let totalWeight = 0;
+
+  for (const score of scores) {
+    const criterion = criteriaMap.get(score.criterionId);
+    weightedSum += (score.value / criterion.maxPoints) * criterion.weight;
+    totalWeight += criterion.weight;
+  }
+
+  if (totalWeight === 0) return 0;
+  return (weightedSum / totalWeight) * 100;
+}
+
+async function submitReview({ submissionId, reviewerId, scores, comments }) {
+  const submission = await DeliverableSubmission.findByPk(submissionId);
+  if (!submission) {
+    const err = new Error('Submission not found');
+    err.code = 'SUBMISSION_NOT_FOUND';
+    throw err;
+  }
+
+  const criterionIds = scores.map((s) => s.criterionId);
+  const criteria = await RubricCriterion.findAll({ where: { id: criterionIds } });
+
+  if (criteria.length !== criterionIds.length) {
+    const foundIds = new Set(criteria.map((c) => c.id));
+    const missing = criterionIds.filter((id) => !foundIds.has(id));
+    const err = new Error(`Invalid criterion IDs: ${missing.join(', ')}`);
+    err.code = 'INVALID_CRITERION_ID';
+    err.details = missing;
+    throw err;
+  }
+
+  const criteriaMap = new Map(criteria.map((c) => [c.id, c]));
+  const finalScore = calculateFinalScore(scores, criteriaMap);
+
+  const transaction = await sequelize.transaction();
+  try {
+    const review = await CommitteeReview.create(
+      { submissionId, reviewerId, scores, comments: comments || null, finalScore },
+      { transaction }
+    );
+
+    await DeliverableSubmission.update(
+      { status: 'GRADED' },
+      { where: { id: submissionId }, transaction }
+    );
+
+    await transaction.commit();
+    return review;
+  } catch (err) {
+    if (!transaction.finished) await transaction.rollback();
+    throw err;
+  }
+}
+
+module.exports = { submitReview };

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -3794,3 +3794,90 @@ test('invalid criterionId in scores returns 400 INVALID_CRITERION_ID', async () 
   assert.equal(response.status, 400);
   assert.equal(json.code, 'INVALID_CRITERION_ID');
 });
+
+test('duplicate criterionId in scores returns 400 DUPLICATE_CRITERION_ID', async () => {
+  const criteria = await seedTestRubric();
+  const professor = await createProfessorUser({ email: 'dup-crit@example.edu', fullName: 'Dup Crit' });
+  const submission = await DeliverableSubmission.create({
+    groupId: 'group-dup-crit',
+    type: 'PROPOSAL',
+    content: 'content',
+    status: 'SUBMITTED',
+  });
+
+  const { response, json } = await request(
+    `/api/v1/committee/submissions/${submission.id}/review`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await authHeaderFor(professor)) },
+      body: JSON.stringify({
+        scores: [
+          { criterionId: criteria[0].id, value: 5 },
+          { criterionId: criteria[0].id, value: 8 },
+        ],
+      }),
+    }
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'DUPLICATE_CRITERION_ID');
+});
+
+test('score exceeding maxPoints returns 400 SCORE_EXCEEDS_MAX', async () => {
+  const criteria = await seedTestRubric();
+  const professor = await createProfessorUser({ email: 'oob-score@example.edu', fullName: 'OOB Score' });
+  const submission = await DeliverableSubmission.create({
+    groupId: 'group-oob-score',
+    type: 'PROPOSAL',
+    content: 'content',
+    status: 'SUBMITTED',
+  });
+
+  const { response, json } = await request(
+    `/api/v1/committee/submissions/${submission.id}/review`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await authHeaderFor(professor)) },
+      body: JSON.stringify({
+        scores: [
+          { criterionId: criteria[0].id, value: criteria[0].maxPoints + 1 },
+          { criterionId: criteria[1].id, value: criteria[1].maxPoints },
+          { criterionId: criteria[2].id, value: criteria[2].maxPoints },
+        ],
+      }),
+    }
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'SCORE_EXCEEDS_MAX');
+});
+
+test('criteria from wrong deliverableType returns 400 INVALID_CRITERION_ID', async () => {
+  const proposalCriteria = await seedTestRubric();
+  const sowCriteria = await RubricCriterion.bulkCreate([
+    { deliverableType: 'SOW', question: 'SOW Budget Clarity', criterionType: 'SOFT', maxPoints: 10, weight: 1.0 },
+  ]);
+  const professor = await createProfessorUser({ email: 'wrong-type@example.edu', fullName: 'Wrong Type' });
+  const submission = await DeliverableSubmission.create({
+    groupId: 'group-wrong-type',
+    type: 'PROPOSAL',
+    content: 'content',
+    status: 'SUBMITTED',
+  });
+
+  const { response, json } = await request(
+    `/api/v1/committee/submissions/${submission.id}/review`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await authHeaderFor(professor)) },
+      body: JSON.stringify({
+        scores: [
+          { criterionId: sowCriteria[0].id, value: 5 },
+        ],
+      }),
+    }
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'INVALID_CRITERION_ID');
+});

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -20,6 +20,9 @@ const {
   ValidStudentId,
   LinkedGitHubAccount,
   OAuthState,
+  DeliverableSubmission,
+  RubricCriterion,
+  CommitteeReview,
 } = require('../models');
 const StudentRegistrationError = require('../errors/studentRegistrationError');
 const studentRegistrationService = require('../services/studentRegistrationService');
@@ -77,6 +80,9 @@ test.after(async () => {
 });
 
 test.beforeEach(async () => {
+  await CommitteeReview.destroy({ where: {} });
+  await DeliverableSubmission.destroy({ where: {} });
+  await RubricCriterion.destroy({ where: {} });
   await GroupAdvisorAssignment.destroy({ where: {} });
   await AdvisorRequest.destroy({ where: {} });
   await Notification.destroy({ where: {} });
@@ -3622,4 +3628,169 @@ test('team leader can submit a new request to the same advisor after advisor rel
   assert.equal(retryResponse.response.status, 201);
   assert.equal(retryResponse.json.status, 'PENDING');
   assert.equal(retryResponse.json.advisorId, advisor.id);
+});
+
+// ─── Committee Review ───────────────────────────────────────────────────────
+
+async function seedTestRubric() {
+  return RubricCriterion.bulkCreate([
+    { deliverableType: 'PROPOSAL', question: 'Technical Feasibility', criterionType: 'SOFT', maxPoints: 10, weight: 0.4 },
+    { deliverableType: 'PROPOSAL', question: 'Project Scope Clarity', criterionType: 'SOFT', maxPoints: 10, weight: 0.4 },
+    { deliverableType: 'PROPOSAL', question: 'Team Qualification', criterionType: 'BINARY', maxPoints: 5, weight: 0.2 },
+  ]);
+}
+
+test('PROFESSOR can submit a review and finalScore is mathematically correct', async () => {
+  const criteria = await seedTestRubric();
+  const professor = await createProfessorUser({ email: 'reviewer1@example.edu', fullName: 'Reviewer One' });
+  const submission = await DeliverableSubmission.create({
+    groupId: 'group-test-1',
+    type: 'PROPOSAL',
+    content: 'Proposal content',
+    status: 'SUBMITTED',
+  });
+
+  const scores = [
+    { criterionId: criteria[0].id, value: 8 },
+    { criterionId: criteria[1].id, value: 7 },
+    { criterionId: criteria[2].id, value: 5 },
+  ];
+
+  const { response, json } = await request(
+    `/api/v1/committee/submissions/${submission.id}/review`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await authHeaderFor(professor)) },
+      body: JSON.stringify({ scores, comments: 'Good work' }),
+    }
+  );
+
+  assert.equal(response.status, 201);
+  assert.ok(json.id);
+  assert.equal(json.submissionId, submission.id);
+  assert.equal(json.reviewerId, professor.id);
+  assert.equal(json.comments, 'Good work');
+  // (8/10)*0.4 + (7/10)*0.4 + (5/5)*0.2 = 0.32 + 0.28 + 0.20 = 0.80 / 1.0 * 100 = 80.0
+  assert.ok(Math.abs(json.finalScore - 80.0) < 0.001);
+});
+
+test('non-PROFESSOR gets 403 when submitting a committee review', async () => {
+  const criteria = await seedTestRubric();
+  const student = await createStudent({
+    studentId: '11070001011',
+    email: 'student-committee@example.edu',
+    fullName: 'Student User',
+    password: 'StrongPass1!',
+  });
+  const submission = await DeliverableSubmission.create({
+    groupId: 'group-test-2',
+    type: 'PROPOSAL',
+    content: 'content',
+    status: 'SUBMITTED',
+  });
+
+  const { response } = await request(
+    `/api/v1/committee/submissions/${submission.id}/review`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await authHeaderFor(student)) },
+      body: JSON.stringify({ scores: [{ criterionId: criteria[0].id, value: 8 }] }),
+    }
+  );
+
+  assert.equal(response.status, 403);
+});
+
+test('review for nonexistent submission returns 404 SUBMISSION_NOT_FOUND', async () => {
+  const criteria = await seedTestRubric();
+  const professor = await createProfessorUser({ email: 'reviewer2@example.edu', fullName: 'Reviewer Two' });
+
+  const { response, json } = await request(
+    '/api/v1/committee/submissions/nonexistent-uuid/review',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await authHeaderFor(professor)) },
+      body: JSON.stringify({ scores: [{ criterionId: criteria[0].id, value: 5 }] }),
+    }
+  );
+
+  assert.equal(response.status, 404);
+  assert.equal(json.code, 'SUBMISSION_NOT_FOUND');
+});
+
+test('two professors can each submit a review; CommitteeReviews table gets 2 rows', async () => {
+  const criteria = await seedTestRubric();
+  const prof1 = await createProfessorUser({ email: 'multi-prof1@example.edu', fullName: 'Prof One' });
+  const prof2 = await createProfessorUser({ email: 'multi-prof2@example.edu', fullName: 'Prof Two' });
+  const submission = await DeliverableSubmission.create({
+    groupId: 'group-multi',
+    type: 'PROPOSAL',
+    content: 'multi-reviewer content',
+    status: 'SUBMITTED',
+  });
+
+  const scores = criteria.map((c) => ({ criterionId: c.id, value: c.maxPoints }));
+
+  const r1 = await request(`/api/v1/committee/submissions/${submission.id}/review`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(await authHeaderFor(prof1)) },
+    body: JSON.stringify({ scores }),
+  });
+  const r2 = await request(`/api/v1/committee/submissions/${submission.id}/review`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(await authHeaderFor(prof2)) },
+    body: JSON.stringify({ scores }),
+  });
+
+  assert.equal(r1.response.status, 201);
+  assert.equal(r2.response.status, 201);
+  assert.notEqual(r1.json.id, r2.json.id);
+
+  const reviews = await CommitteeReview.findAll({ where: { submissionId: submission.id } });
+  assert.equal(reviews.length, 2);
+});
+
+test('submission status becomes GRADED after a committee review', async () => {
+  const criteria = await seedTestRubric();
+  const professor = await createProfessorUser({ email: 'grade-check@example.edu', fullName: 'Grade Checker' });
+  const submission = await DeliverableSubmission.create({
+    groupId: 'group-grade',
+    type: 'PROPOSAL',
+    content: 'content',
+    status: 'SUBMITTED',
+  });
+
+  const scores = criteria.map((c) => ({ criterionId: c.id, value: c.maxPoints / 2 }));
+
+  await request(`/api/v1/committee/submissions/${submission.id}/review`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(await authHeaderFor(professor)) },
+    body: JSON.stringify({ scores }),
+  });
+
+  await submission.reload();
+  assert.equal(submission.status, 'GRADED');
+});
+
+test('invalid criterionId in scores returns 400 INVALID_CRITERION_ID', async () => {
+  await seedTestRubric();
+  const professor = await createProfessorUser({ email: 'invalid-crit@example.edu', fullName: 'Bad Crit' });
+  const submission = await DeliverableSubmission.create({
+    groupId: 'group-invalid',
+    type: 'PROPOSAL',
+    content: 'content',
+    status: 'SUBMITTED',
+  });
+
+  const { response, json } = await request(
+    `/api/v1/committee/submissions/${submission.id}/review`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await authHeaderFor(professor)) },
+      body: JSON.stringify({ scores: [{ criterionId: 'does-not-exist-uuid', value: 5 }] }),
+    }
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'INVALID_CRITERION_ID');
 });


### PR DESCRIPTION
## Summary

Closes #253. Implements the full backend pipeline for **DFD Process P44 → f11**: receiving committee grading scores, calculating a weighted `finalScore`, persisting `CommitteeReview` records to the D3 (Grading) database, and transitioning the submission status to `GRADED`.

---

## What Was Added

### New Models (D3 Database Tables)

| Model | Table | Purpose |
|---|---|---|
| `DeliverableSubmission` | `DeliverableSubmissions` | Stores team deliverable submissions with `SUBMITTED / UNDER_REVIEW / GRADED` lifecycle status |
| `RubricCriterion` | `RubricCriteria` | Defines rubric questions with `maxPoints` and `weight` per deliverable type (`PROPOSAL / SOW`) |
| `CommitteeReview` | `CommitteeReviews` | Stores each committee member's submitted scores, comments, and calculated `finalScore` |

### New Endpoint

```
POST /api/v1/committee/submissions/:submissionId/review
Authorization: Bearer <JWT>  (PROFESSOR role required)
```

**Request body:**
```json
{
  "scores": [
    { "criterionId": "<uuid>", "value": 8 },
    { "criterionId": "<uuid>", "value": 7 }
  ],
  "comments": "Strong proposal overall."
}
```

**Success response (201):**
```json
{
  "id": "<uuid>",
  "submissionId": "<uuid>",
  "reviewerId": 42,
  "scores": [...],
  "comments": "Strong proposal overall.",
  "finalScore": 80.0,
  "createdAt": "2026-04-22T..."
}
```

**Error responses:**

| Status | Code | Condition |
|---|---|---|
| 400 | `VALIDATION_ERROR` | Missing or malformed fields |
| 400 | `INVALID_CRITERION_ID` | One or more `criterionId` values not found in rubric |
| 403 | — | Caller is not a PROFESSOR |
| 404 | `SUBMISSION_NOT_FOUND` | `submissionId` does not exist |
| 500 | `INTERNAL_ERROR` | Unexpected server error |

### finalScore Formula

```
finalScore = sum( (score.value / criterion.maxPoints) x criterion.weight )
             / sum(criterion.weight) x 100
```

Each criterion score is normalised to [0, 1], weighted, then expressed as a 0-100 float. The divisor (sum of weights) makes the formula safe even when weights do not sum to exactly 1.0.

**Example** (seed criteria, scores 8, 7, 5):

```
(8/10)x0.4 + (7/10)x0.4 + (5/5)x0.2  =  0.32 + 0.28 + 0.20  =  0.80
0.80 / 1.0 x 100  =  80.0
```

### Rubric Seed Data

Three default PROPOSAL criteria are seeded at server startup via `bulkCreate({ ignoreDuplicates: true })`. A unique index on `(question, deliverableType)` prevents duplicates across restarts:

| Question | Type | Max Points | Weight |
|---|---|---|---|
| Technical Feasibility | SOFT | 10 | 0.4 |
| Project Scope Clarity | SOFT | 10 | 0.4 |
| Team Qualification | BINARY | 5 | 0.2 |

### Multi-Reviewer / Concurrency (Acceptance Criterion)

Each professor gets their own `CommitteeReview` row regardless of the submission's current status. The insert + status update are wrapped in a single `sequelize.transaction()`, making each review atomic and preventing partial writes or deadlocks under concurrent access.

---

## Files Changed

**Created:**
- `backend/models/DeliverableSubmission.js`
- `backend/models/RubricCriterion.js`
- `backend/models/CommitteeReview.js`
- `backend/services/committeeService.js`
- `backend/controllers/committeeController.js`
- `backend/routes/committee.js`

**Modified:**
- `backend/models/index.js` — registered 3 new models so `sequelize.sync()` creates tables
- `backend/app.js` — mounted `committeeRoutes` at `/api/v1/committee`
- `backend/server.js` — added `seedRubricCriteria()` to the startup chain

---

## Tests

6 new integration tests added to `backend/test/api.test.js` (all pass, in-memory SQLite):

| # | Test | Verifies |
|---|---|---|
| 1 | PROFESSOR submits review, finalScore is 80.0 | Weighted score math |
| 2 | Non-PROFESSOR gets 403 | Role-based auth guard |
| 3 | Nonexistent submissionId returns 404 SUBMISSION_NOT_FOUND | Input validation |
| 4 | Two professors each submit, CommitteeReviews table gets 2 rows | Multi-reviewer support |
| 5 | Submission status becomes GRADED after review | Status transition |
| 6 | Unknown criterionId returns 400 INVALID_CRITERION_ID | Rubric validation |

```
cd backend && npm test

OK  PROFESSOR can submit a review and finalScore is mathematically correct
OK  non-PROFESSOR gets 403 when submitting a committee review
OK  review for nonexistent submission returns 404 SUBMISSION_NOT_FOUND
OK  two professors can each submit a review; CommitteeReviews table gets 2 rows
OK  submission status becomes GRADED after a committee review
OK  invalid criterionId in scores returns 400 INVALID_CRITERION_ID
```

---

Story Points: 2 | Relates to: #254