### PR TITLE
feat: add POST /api/v1/groups/:groupId/deliverables endpoint

### DIFF
--- a/backend/controllers/groupDeliverableController.js
+++ b/backend/controllers/groupDeliverableController.js
@@ -1,11 +1,8 @@
 const { body, param, validationResult } = require('express-validator');
+const { GroupDeliverable, Group } = require('../models'); // direkt import
 
 const STORAGE_TIMEOUT_MS = 5000;
 
-/**
- * Wraps the DB persist in a timeout to handle network/storage latency gracefully.
- * Acceptance criteria: D5 storage functions handle network latency gracefully using timeouts.
- */
 function withTimeout(promise, ms) {
   const timeout = new Promise((_, reject) =>
     setTimeout(() => {
@@ -22,13 +19,10 @@ exports.submitDeliverableValidation = [
   body('markdownContent').optional().isString(),
   body('imageUrls').optional().isArray(),
   body('imageUrls.*').optional().isURL().withMessage('Each imageUrl must be a valid URL'),
+  body('sprintNumber').optional().isInt({ min: 1 }).withMessage('sprintNumber must be a positive integer'),
+  body('deliverableType').optional().isString().trim().notEmpty().withMessage('deliverableType must be a string'),
 ];
 
-/**
- * POST /api/v1/groups/:groupId/deliverables
- * Extracts markdown content and image URLs from payload,
- * persists to D5 Document Storage, returns unique documentRef.
- */
 exports.submitDeliverable = async (req, res) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
@@ -41,13 +35,29 @@ exports.submitDeliverable = async (req, res) => {
 
   try {
     const { groupId } = req.params;
-    const { markdownContent, imageUrls } = req.body;
+    const { markdownContent, imageUrls, sprintNumber, deliverableType } = req.body;
+
+    // Group membership check
+    const group = await Group.findByPk(groupId);
+    if (!group) {
+      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
+    }
+
+    const userId = String(req.user.id);
+    const isLeader = String(group.leaderId) === userId;
+    const isMember = Array.isArray(group.memberIds) && group.memberIds.map((id) => String(id)).includes(userId);
+
+    if (!isLeader && !isMember) {
+      return res.status(403).json({ code: 'FORBIDDEN', message: 'You are not a member of this group' });
+    }
 
     const deliverable = await withTimeout(
-      req.app.locals.models.GroupDeliverable.create({
+      GroupDeliverable.create({
         groupId,
         markdownContent: markdownContent ?? null,
         imageUrls: imageUrls ?? [],
+        sprintNumber: sprintNumber ?? null,
+        deliverableType: deliverableType ?? null,
       }),
       STORAGE_TIMEOUT_MS
     );
@@ -58,6 +68,8 @@ exports.submitDeliverable = async (req, res) => {
       data: {
         documentRef: deliverable.documentRef,
         groupId: deliverable.groupId,
+        sprintNumber: deliverable.sprintNumber,
+        deliverableType: deliverable.deliverableType,
         createdAt: deliverable.createdAt,
       },
     });
@@ -69,11 +81,7 @@ exports.submitDeliverable = async (req, res) => {
         message: 'Document storage timed out. Please try again.',
       });
     }
-
     console.error('Error in submitDeliverable:', error);
-    return res.status(500).json({
-      code: 'INTERNAL_ERROR',
-      message: 'Internal server error',
-    });
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Internal server error' });
   }
 };

--- a/backend/controllers/groupDeliverableController.js
+++ b/backend/controllers/groupDeliverableController.js
@@ -1,0 +1,79 @@
+const { body, param, validationResult } = require('express-validator');
+
+const STORAGE_TIMEOUT_MS = 5000;
+
+/**
+ * Wraps the DB persist in a timeout to handle network/storage latency gracefully.
+ * Acceptance criteria: D5 storage functions handle network latency gracefully using timeouts.
+ */
+function withTimeout(promise, ms) {
+  const timeout = new Promise((_, reject) =>
+    setTimeout(() => {
+      const err = new Error('Document storage timed out.');
+      err.code = 'STORAGE_TIMEOUT';
+      reject(err);
+    }, ms)
+  );
+  return Promise.race([promise, timeout]);
+}
+
+exports.submitDeliverableValidation = [
+  param('groupId').isString().trim().notEmpty().withMessage('Group ID is required'),
+  body('markdownContent').optional().isString(),
+  body('imageUrls').optional().isArray(),
+  body('imageUrls.*').optional().isURL().withMessage('Each imageUrl must be a valid URL'),
+];
+
+/**
+ * POST /api/v1/groups/:groupId/deliverables
+ * Extracts markdown content and image URLs from payload,
+ * persists to D5 Document Storage, returns unique documentRef.
+ */
+exports.submitDeliverable = async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({
+      code: 'INVALID_DELIVERABLE_INPUT',
+      message: 'Deliverable payload failed validation.',
+      errors: errors.array(),
+    });
+  }
+
+  try {
+    const { groupId } = req.params;
+    const { markdownContent, imageUrls } = req.body;
+
+    const deliverable = await withTimeout(
+      req.app.locals.models.GroupDeliverable.create({
+        groupId,
+        markdownContent: markdownContent ?? null,
+        imageUrls: imageUrls ?? [],
+      }),
+      STORAGE_TIMEOUT_MS
+    );
+
+    return res.status(201).json({
+      code: 'SUCCESS',
+      message: 'Deliverable stored successfully.',
+      data: {
+        documentRef: deliverable.documentRef,
+        groupId: deliverable.groupId,
+        createdAt: deliverable.createdAt,
+      },
+    });
+  } catch (error) {
+    if (error.code === 'STORAGE_TIMEOUT') {
+      console.error('D5 storage timeout:', error);
+      return res.status(500).json({
+        code: 'STORAGE_TIMEOUT',
+        message: 'Document storage timed out. Please try again.',
+      });
+    }
+
+    console.error('Error in submitDeliverable:', error);
+    return res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      message: 'Internal server error',
+    });
+  }
+};

--- a/backend/models/GroupDeliverable.js
+++ b/backend/models/GroupDeliverable.js
@@ -28,6 +28,14 @@ const GroupDeliverable = sequelize.define(
       allowNull: false,
       defaultValue: [],
     },
+    sprintNumber: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    deliverableType: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   },
   {
     tableName: 'GroupDeliverables',

--- a/backend/models/GroupDeliverable.js
+++ b/backend/models/GroupDeliverable.js
@@ -1,0 +1,38 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const GroupDeliverable = sequelize.define(
+  'GroupDeliverable',
+  {
+    id: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    documentRef: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    groupId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    markdownContent: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    imageUrls: {
+      type: DataTypes.JSON,
+      allowNull: false,
+      defaultValue: [],
+    },
+  },
+  {
+    tableName: 'GroupDeliverables',
+    timestamps: true,
+  },
+);
+
+module.exports = GroupDeliverable;

--- a/backend/routes/group.js
+++ b/backend/routes/group.js
@@ -1,0 +1,13 @@
+const {
+  submitDeliverableValidation,
+  submitDeliverable,
+} = require('../controllers/groupDeliverableController');
+
+// Add alongside other group routes:
+router.post(
+  '/:groupId/deliverables',
+  authenticate,
+  authorize(['STUDENT', 'PROFESSOR', 'COORDINATOR']),
+  submitDeliverableValidation,
+  submitDeliverable,
+);

--- a/backend/routes/group.js
+++ b/backend/routes/group.js
@@ -1,9 +1,47 @@
-const {
-  submitDeliverableValidation,
-  submitDeliverable,
-} = require('../controllers/groupDeliverableController');
+const express = require('express');
+const { authenticate, authorize } = require('../middleware/auth');
+const groupController = require('../controllers/groupController');
+const { updateGroupMembership } = require('../controllers/coordinatorController');
+const { submitDeliverableValidation, submitDeliverable } = require('../controllers/groupDeliverableController');
 
-// Add alongside other group routes:
+const router = express.Router();
+
+router.post('/', authenticate, groupController.createGroupValidation, groupController.createGroup);
+router.get('/', authenticate, groupController.listGroups);
+router.get('/joined', authenticate, groupController.listJoinedGroups);
+router.get('/mine', authenticate, groupController.getMyGroup);
+
+router.patch(
+  '/:groupId/advisor-release',
+  authenticate,
+  authorize(['PROFESSOR']),
+  groupController.advisorReleaseValidation,
+  groupController.advisorRelease,
+);
+router.patch('/:groupId', authenticate, groupController.renameGroupValidation, groupController.renameGroup);
+router.delete('/:groupId', authenticate, groupController.deleteGroupValidation, groupController.deleteGroup);
+router.delete(
+  '/:groupId/advisor-assignment',
+  authenticate,
+  groupController.removeAdvisorAssignmentValidation,
+  groupController.removeAdvisorAssignment,
+);
+
+router.post('/:groupId/leave', authenticate, groupController.leaveGroupValidation, groupController.leaveGroup);
+router.post('/:groupId/members/:memberId/kick', authenticate, groupController.kickMemberValidation, groupController.kickMember);
+router.post('/:groupId/invitations', authenticate, groupController.dispatchInvitesValidation, groupController.dispatchInvites);
+
+router.patch(
+  '/:groupId/membership/coordinator',
+  authenticate,
+  authorize(['COORDINATOR']),
+  updateGroupMembership,
+);
+
+router.post('/:groupId/membership/finalize', groupController.finalizeMembershipValidation, groupController.finalizeMembership);
+router.get('/:groupId/membership', groupController.getGroupMembershipValidation, groupController.getGroupMembership);
+
+// POST /api/v1/groups/:groupId/deliverables
 router.post(
   '/:groupId/deliverables',
   authenticate,
@@ -11,3 +49,5 @@ router.post(
   submitDeliverableValidation,
   submitDeliverable,
 );
+
+module.exports = router;


### PR DESCRIPTION
feat: add POST /api/v1/groups/:groupId/deliverables endpoint

- Add GroupDeliverable Sequelize model (GroupDeliverables table) with auto-generated documentRef UUID
- Register GroupDeliverable in models/index.js
- Add submitDeliverable handler in groupDeliverableController.js with express-validator schema validation
- Wrap D5 storage call in 5000ms timeout to handle network latency gracefully
- Add POST /:groupId/deliverables route to groups router with authenticate + authorize middleware

