### PR TITLE
feat(issue-231): add grading rubric configuration for coordinator

### DIFF
--- a/backend/controllers/coordinatorRubricController.js
+++ b/backend/controllers/coordinatorRubricController.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const { body, param, validationResult } = require('express-validator');
+const rubricService = require('../services/rubricService');
+
+const upsertRubricValidation = [
+  body('deliverableType')
+    .exists().withMessage('deliverableType is required')
+    .bail()
+    .isIn(['PROPOSAL', 'SOW']).withMessage('deliverableType must be PROPOSAL or SOW'),
+  body('criteria')
+    .exists().withMessage('criteria is required')
+    .bail()
+    .isArray({ min: 1 }).withMessage('criteria must be a non-empty array'),
+  body('criteria.*.name')
+    .isString().notEmpty().withMessage('each criterion must have a non-empty name'),
+  body('criteria.*.maxPoints')
+    .isFloat({ min: 0 }).withMessage('each criterion maxPoints must be >= 0'),
+];
+
+async function upsertRubric(req, res) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({
+      code: 'VALIDATION_ERROR',
+      message: 'Invalid rubric configuration',
+      errors: errors.array(),
+    });
+  }
+
+  const { deliverableType, criteria } = req.body;
+
+  const names = criteria.map((c) => c.name);
+  if (new Set(names).size !== names.length) {
+    return res.status(400).json({
+      code: 'DUPLICATE_CRITERION_NAME',
+      message: 'criteria must not contain duplicate name entries',
+    });
+  }
+
+  try {
+    const rubric = await rubricService.upsertRubric(deliverableType, criteria, req.user?.id ?? null);
+    return res.status(200).json({
+      code: 'SUCCESS',
+      message: 'Grading rubric updated successfully',
+      rubric: {
+        id: rubric.id,
+        deliverableType: rubric.deliverableType,
+        criteria: rubric.criteria,
+        updatedBy: rubric.updatedBy,
+        createdAt: rubric.createdAt,
+        updatedAt: rubric.updatedAt,
+      },
+    });
+  } catch (error) {
+    console.error('Error upserting rubric:', error);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to update grading rubric' });
+  }
+}
+
+async function getRubric(req, res) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ code: 'VALIDATION_ERROR', message: 'Invalid deliverableType', errors: errors.array() });
+  }
+
+  const { deliverableType } = req.params;
+
+  try {
+    const rubric = await rubricService.getRubric(deliverableType);
+    if (!rubric) {
+      return res.status(404).json({ code: 'RUBRIC_NOT_FOUND', message: `No rubric configured for ${deliverableType}` });
+    }
+    return res.status(200).json({ code: 'SUCCESS', rubric });
+  } catch (error) {
+    console.error('Error fetching rubric:', error);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to fetch grading rubric' });
+  }
+}
+
+const getRubricValidation = [
+  param('deliverableType')
+    .isIn(['PROPOSAL', 'SOW']).withMessage('deliverableType must be PROPOSAL or SOW'),
+];
+
+async function listRubrics(req, res) {
+  try {
+    const rubrics = await rubricService.listRubrics();
+    return res.status(200).json({ code: 'SUCCESS', rubrics });
+  } catch (error) {
+    console.error('Error listing rubrics:', error);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to list grading rubrics' });
+  }
+}
+
+module.exports = {
+  upsertRubricValidation,
+  upsertRubric,
+  getRubricValidation,
+  getRubric,
+  listRubrics,
+};

--- a/backend/models/GradingRubric.js
+++ b/backend/models/GradingRubric.js
@@ -1,0 +1,33 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const GradingRubric = sequelize.define(
+  'GradingRubric',
+  {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    deliverableType: {
+      type: DataTypes.ENUM('PROPOSAL', 'SOW'),
+      allowNull: false,
+    },
+    criteria: {
+      type: DataTypes.JSON,
+      allowNull: false,
+      defaultValue: [],
+    },
+    updatedBy: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+  },
+  {
+    tableName: 'GradingRubrics',
+    timestamps: true,
+    indexes: [{ unique: true, fields: ['deliverableType'] }],
+  },
+);
+
+module.exports = GradingRubric;

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -17,6 +17,7 @@ const GroupAdvisorAssignment = require('./GroupAdvisorAssignment');
 const Invitation = require('./Invitation');
 const AuditLog = require('./AuditLog');
 const Notification = require('./Notification');
+const GradingRubric = require('./GradingRubric');
 
 module.exports = {
   User,
@@ -30,4 +31,5 @@ module.exports = {
   Invitation,
   AuditLog,
   Notification,
+  GradingRubric,
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test test/api.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js"
+    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test test/api.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue231-coordinator-rubric.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/backend/routes/coordinator.js
+++ b/backend/routes/coordinator.js
@@ -8,6 +8,7 @@ const {
   transferByCoordinator,
 } = require('../controllers/mentorMatchingController');
 const groupController = require('../controllers/groupController');
+const coordinatorRubricController = require('../controllers/coordinatorRubricController');
 
 const router = express.Router();
 
@@ -23,5 +24,26 @@ router.get('/groups', authenticate, authorize(['COORDINATOR']), groupController.
 router.patch('/groups/:groupId/advisor-transfer', authenticate, authorize(['COORDINATOR']), transferByCoordinator);
 router.patch('/groups/:groupId/members', authenticate, authorize(['COORDINATOR']), updateGroupMembership);
 router.patch('/groups/:groupId/membership/coordinator', authenticate, authorize(['COORDINATOR']), updateGroupMembership);
+
+router.get(
+  '/rubrics',
+  authenticate,
+  authorize(['COORDINATOR']),
+  coordinatorRubricController.listRubrics,
+);
+router.get(
+  '/rubrics/:deliverableType',
+  authenticate,
+  authorize(['COORDINATOR']),
+  coordinatorRubricController.getRubricValidation,
+  coordinatorRubricController.getRubric,
+);
+router.put(
+  '/rubrics',
+  authenticate,
+  authorize(['COORDINATOR']),
+  coordinatorRubricController.upsertRubricValidation,
+  coordinatorRubricController.upsertRubric,
+);
 
 module.exports = router;

--- a/backend/services/rubricService.js
+++ b/backend/services/rubricService.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const { GradingRubric } = require('../models');
+
+async function upsertRubric(deliverableType, criteria, userId) {
+  const [rubric] = await GradingRubric.upsert({
+    deliverableType,
+    criteria,
+    updatedBy: userId ?? null,
+  });
+  return rubric;
+}
+
+async function getRubric(deliverableType) {
+  return GradingRubric.findOne({ where: { deliverableType } });
+}
+
+async function listRubrics() {
+  return GradingRubric.findAll();
+}
+
+module.exports = { upsertRubric, getRubric, listRubrics };

--- a/backend/test/issue231-coordinator-rubric.test.js
+++ b/backend/test/issue231-coordinator-rubric.test.js
@@ -1,0 +1,219 @@
+require('./setupTestEnv');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+
+const sequelize = require('../db');
+const app = require('../app');
+require('../models');
+const { User, GradingRubric } = require('../models');
+
+let server;
+let baseUrl;
+
+function authHeader(user) {
+  const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET);
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function createCoordinator(email) {
+  return User.create({
+    email,
+    fullName: 'Test Coordinator',
+    role: 'COORDINATOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('Pass1!', 10),
+  });
+}
+
+async function createStudent(email) {
+  return User.create({
+    email,
+    fullName: 'Test Student',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('Pass1!', 10),
+  });
+}
+
+async function req(path, options = {}) {
+  const response = await fetch(`${baseUrl}${path}`, options);
+  const json = await response.json();
+  return { response, json };
+}
+
+const validCriteria = [
+  { name: 'Problem Statement', maxPoints: 20 },
+  { name: 'Technical Approach', maxPoints: 30 },
+  { name: 'Team Plan', maxPoints: 50 },
+];
+
+test.before(async () => {
+  await sequelize.sync({ force: true });
+  server = app.listen(0);
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+  await sequelize.close();
+});
+
+test.beforeEach(async () => {
+  await GradingRubric.destroy({ where: {} });
+  await User.destroy({ where: {} });
+});
+
+test('PUT /api/v1/coordinator/rubrics — 401 when unauthenticated', async () => {
+  const { response } = await req('/api/v1/coordinator/rubrics', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deliverableType: 'PROPOSAL', criteria: validCriteria }),
+  });
+  assert.equal(response.status, 401);
+});
+
+test('PUT /api/v1/coordinator/rubrics — 403 when authenticated as STUDENT', async () => {
+  const student = await createStudent('student@test.com');
+  const { response } = await req('/api/v1/coordinator/rubrics', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeader(student) },
+    body: JSON.stringify({ deliverableType: 'PROPOSAL', criteria: validCriteria }),
+  });
+  assert.equal(response.status, 403);
+});
+
+test('PUT /api/v1/coordinator/rubrics — 400 when deliverableType missing', async () => {
+  const coordinator = await createCoordinator('coord@test.com');
+  const { response, json } = await req('/api/v1/coordinator/rubrics', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeader(coordinator) },
+    body: JSON.stringify({ criteria: validCriteria }),
+  });
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'VALIDATION_ERROR');
+});
+
+test('PUT /api/v1/coordinator/rubrics — 400 when criteria is empty array', async () => {
+  const coordinator = await createCoordinator('coord@test.com');
+  const { response, json } = await req('/api/v1/coordinator/rubrics', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeader(coordinator) },
+    body: JSON.stringify({ deliverableType: 'PROPOSAL', criteria: [] }),
+  });
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'VALIDATION_ERROR');
+});
+
+test('PUT /api/v1/coordinator/rubrics — 400 when criteria has duplicate names', async () => {
+  const coordinator = await createCoordinator('coord@test.com');
+  const { response, json } = await req('/api/v1/coordinator/rubrics', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeader(coordinator) },
+    body: JSON.stringify({
+      deliverableType: 'PROPOSAL',
+      criteria: [
+        { name: 'Design', maxPoints: 50 },
+        { name: 'Design', maxPoints: 50 },
+      ],
+    }),
+  });
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'DUPLICATE_CRITERION_NAME');
+});
+
+test('PUT /api/v1/coordinator/rubrics — 200 creates rubric and returns persisted data', async () => {
+  const coordinator = await createCoordinator('coord@test.com');
+  const { response, json } = await req('/api/v1/coordinator/rubrics', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeader(coordinator) },
+    body: JSON.stringify({ deliverableType: 'PROPOSAL', criteria: validCriteria }),
+  });
+  assert.equal(response.status, 200);
+  assert.equal(json.code, 'SUCCESS');
+  assert.equal(json.rubric.deliverableType, 'PROPOSAL');
+  assert.deepEqual(json.rubric.criteria, validCriteria);
+  assert.ok(json.rubric.id);
+});
+
+test('PUT /api/v1/coordinator/rubrics — second PUT for same deliverableType updates, not duplicates', async () => {
+  const coordinator = await createCoordinator('coord@test.com');
+  const headers = { 'Content-Type': 'application/json', ...authHeader(coordinator) };
+
+  await req('/api/v1/coordinator/rubrics', {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({ deliverableType: 'SOW', criteria: validCriteria }),
+  });
+
+  const updated = [{ name: 'Updated Criterion', maxPoints: 100 }];
+  const { response, json } = await req('/api/v1/coordinator/rubrics', {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({ deliverableType: 'SOW', criteria: updated }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(json.rubric.criteria, updated);
+
+  const count = await GradingRubric.count({ where: { deliverableType: 'SOW' } });
+  assert.equal(count, 1);
+});
+
+test('GET /api/v1/coordinator/rubrics — 200 returns list of all rubrics', async () => {
+  const coordinator = await createCoordinator('coord@test.com');
+  const headers = { 'Content-Type': 'application/json', ...authHeader(coordinator) };
+
+  await req('/api/v1/coordinator/rubrics', {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({ deliverableType: 'PROPOSAL', criteria: validCriteria }),
+  });
+
+  const { response, json } = await req('/api/v1/coordinator/rubrics', {
+    method: 'GET',
+    headers,
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(json.code, 'SUCCESS');
+  assert.equal(json.rubrics.length, 1);
+  assert.equal(json.rubrics[0].deliverableType, 'PROPOSAL');
+});
+
+test('GET /api/v1/coordinator/rubrics/:deliverableType — 404 when no rubric configured', async () => {
+  const coordinator = await createCoordinator('coord@test.com');
+  const { response, json } = await req('/api/v1/coordinator/rubrics/PROPOSAL', {
+    method: 'GET',
+    headers: authHeader(coordinator),
+  });
+  assert.equal(response.status, 404);
+  assert.equal(json.code, 'RUBRIC_NOT_FOUND');
+});
+
+test('GET /api/v1/coordinator/rubrics/:deliverableType — 200 returns specific rubric', async () => {
+  const coordinator = await createCoordinator('coord@test.com');
+  const headers = { 'Content-Type': 'application/json', ...authHeader(coordinator) };
+
+  await req('/api/v1/coordinator/rubrics', {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({ deliverableType: 'SOW', criteria: validCriteria }),
+  });
+
+  const { response, json } = await req('/api/v1/coordinator/rubrics/SOW', {
+    method: 'GET',
+    headers,
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(json.rubric.deliverableType, 'SOW');
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import GroupCleanupPage from './GroupCleanupPage';
 import CoordinatorHomePage from './CoordinatorHomePage';
 import CoordinatorLoginPage from './CoordinatorLoginPage';
 import CoordinatorStudentIdUploadPage from './CoordinatorStudentIdUploadPage';
+import CoordinatorRubricPage from './CoordinatorRubricPage';
 import GroupPage from './GroupPage';
 import HomePage from './HomePage';
 import ProfessorHomePage from './ProfessorHomePage';
@@ -64,6 +65,7 @@ export default function App() {
               <Route path="/coordinator/groups/manage" element={<CoordinatorGroupMembershipPage />} />
               <Route path="/coordinator/groups/transfer" element={<CoordinatorAdvisorTransferPage />} />
               <Route path="/coordinator/groups/cleanup" element={<GroupCleanupPage role="COORDINATOR" />} />
+              <Route path="/coordinator/rubrics" element={<CoordinatorRubricPage />} />
               <Route path="/groups/:groupId" element={<GroupPage />} />
               <Route path="/advisor/requests" element={<AdvisorRequestsPage />} />
               <Route path="*" element={<HomePage />} />

--- a/frontend/src/CoordinatorHomePage.jsx
+++ b/frontend/src/CoordinatorHomePage.jsx
@@ -49,6 +49,14 @@ const coordinatorTools = [
     cta: 'Open Cleanup Tool',
     status: 'Ready',
   },
+  {
+    eyebrow: 'Grading',
+    title: 'Grading Rubric Configuration',
+    description: 'Define the grading criteria and maximum points for PROPOSAL and SOW deliverable types.',
+    href: '/coordinator/rubrics',
+    cta: 'Configure Rubrics',
+    status: 'Ready',
+  },
 ];
 
 export default function CoordinatorHomePage() {

--- a/frontend/src/CoordinatorRubricPage.jsx
+++ b/frontend/src/CoordinatorRubricPage.jsx
@@ -1,0 +1,181 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useNotification } from './contexts/NotificationContext';
+import apiClient from './services/apiClient';
+
+const DELIVERABLE_TYPES = ['PROPOSAL', 'SOW'];
+
+function emptyCriterion() {
+  return { name: '', maxPoints: '' };
+}
+
+export default function CoordinatorRubricPage() {
+  const navigate = useNavigate();
+  const { notify } = useNotification();
+
+  const [deliverableType, setDeliverableType] = useState('PROPOSAL');
+  const [criteria, setCriteria] = useState([emptyCriterion()]);
+  const [loading, setLoading] = useState(false);
+  const [fetching, setFetching] = useState(false);
+
+  const token = window.localStorage.getItem('coordinatorToken') || '';
+
+  useEffect(() => {
+    if (!token) {
+      notify({ type: 'warning', title: 'Login required', message: 'Please sign in as coordinator.' });
+      navigate('/coordinator/login', { replace: true });
+    }
+  }, [navigate, notify, token]);
+
+  useEffect(() => {
+    async function load() {
+      setFetching(true);
+      try {
+        const { data } = await apiClient.get(`/v1/coordinator/rubrics/${deliverableType}`);
+        if (data.rubric?.criteria?.length) {
+          setCriteria(data.rubric.criteria.map((c) => ({ name: c.name, maxPoints: String(c.maxPoints) })));
+        } else {
+          setCriteria([emptyCriterion()]);
+        }
+      } catch (err) {
+        if (err.response?.status === 404) {
+          setCriteria([emptyCriterion()]);
+        } else {
+          notify({ type: 'error', title: 'Failed to load rubric', message: err.message });
+        }
+      } finally {
+        setFetching(false);
+      }
+    }
+    load();
+  }, [deliverableType, notify]);
+
+  function updateCriterion(index, field, value) {
+    setCriteria((prev) => prev.map((c, i) => (i === index ? { ...c, [field]: value } : c)));
+  }
+
+  function addCriterion() {
+    setCriteria((prev) => [...prev, emptyCriterion()]);
+  }
+
+  function removeCriterion(index) {
+    setCriteria((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+
+    const parsed = criteria.map((c) => ({ name: c.name.trim(), maxPoints: Number(c.maxPoints) }));
+
+    const names = parsed.map((c) => c.name);
+    if (new Set(names).size !== names.length) {
+      notify({ type: 'error', title: 'Duplicate criterion names', message: 'Each criterion must have a unique name.' });
+      return;
+    }
+
+    if (parsed.some((c) => !c.name || isNaN(c.maxPoints) || c.maxPoints < 0)) {
+      notify({ type: 'error', title: 'Invalid criteria', message: 'Each criterion needs a name and a non-negative max points value.' });
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await apiClient.put('/v1/coordinator/rubrics', { deliverableType, criteria: parsed });
+      notify({ type: 'success', title: 'Rubric saved', message: `${deliverableType} rubric updated successfully.` });
+    } catch (err) {
+      const code = err.response?.data?.code;
+      if (code === 'DUPLICATE_CRITERION_NAME') {
+        notify({ type: 'error', title: 'Duplicate criterion names', message: err.message });
+      } else {
+        notify({ type: 'error', title: 'Save failed', message: err.message || 'Could not save rubric.' });
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="page">
+      <section className="hero">
+        <p className="eyebrow">Coordinator Workspace</p>
+        <h1>Grading Rubric Configuration</h1>
+        <p className="subtitle">
+          Define the grading criteria and maximum points for each deliverable type. Changes take effect immediately.
+        </p>
+      </section>
+
+      <section className="form-section">
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="deliverableType">Deliverable Type</label>
+            <select
+              id="deliverableType"
+              value={deliverableType}
+              onChange={(e) => setDeliverableType(e.target.value)}
+              disabled={fetching || loading}
+            >
+              {DELIVERABLE_TYPES.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="form-group">
+            <label>Criteria</label>
+            {fetching ? (
+              <p>Loading current rubric…</p>
+            ) : (
+              <>
+                {criteria.map((criterion, index) => (
+                  <div key={index} className="rubric-criterion-row">
+                    <input
+                      type="text"
+                      placeholder="Criterion name"
+                      value={criterion.name}
+                      onChange={(e) => updateCriterion(index, 'name', e.target.value)}
+                      disabled={loading}
+                      required
+                    />
+                    <input
+                      type="number"
+                      placeholder="Max points"
+                      min="0"
+                      step="0.5"
+                      value={criterion.maxPoints}
+                      onChange={(e) => updateCriterion(index, 'maxPoints', e.target.value)}
+                      disabled={loading}
+                      required
+                    />
+                    {criteria.length > 1 && (
+                      <button
+                        type="button"
+                        className="btn-secondary"
+                        onClick={() => removeCriterion(index)}
+                        disabled={loading}
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
+                ))}
+
+                <button type="button" className="btn-secondary" onClick={addCriterion} disabled={loading}>
+                  + Add Criterion
+                </button>
+              </>
+            )}
+          </div>
+
+          <div className="form-actions">
+            <button type="submit" className="btn-primary" disabled={loading || fetching}>
+              {loading ? 'Saving…' : 'Save Rubric'}
+            </button>
+            <button type="button" className="btn-secondary" onClick={() => navigate('/coordinator')} disabled={loading}>
+              Back
+            </button>
+          </div>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -35,6 +35,7 @@ const roleMenuSections = {
         { to: '/coordinator/groups/manage', label: 'Group Membership Edit', icon: 'GM' },
         { to: '/coordinator/groups/transfer', label: 'Advisor Transfer', icon: 'AT' },
         { to: '/coordinator/groups/cleanup', label: 'Group Cleanup', icon: 'GC' },
+        { to: '/coordinator/rubrics', label: 'Grading Rubrics', icon: 'RB' },
       ],
     },
   ],

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -63,6 +63,9 @@ const apiClient = {
   post(path, body) {
     return request('POST', path, body);
   },
+  put(path, body) {
+    return request('PUT', path, body);
+  },
   patch(path, body) {
     return request('PATCH', path, body);
   },


### PR DESCRIPTION
## What this PR does

Adds a full-stack grading rubric configuration feature for coordinators. A coordinator can now define named criteria with maximum point values for each deliverable type (`PROPOSAL` or `SOW`) via a new page at `/coordinator/rubrics`. The endpoint is an upsert — posting again for the same deliverable type replaces the existing rubric. Also fixes a gap in `apiClient.js` where the `put` method was missing, which would have blocked any future PUT call from the frontend.

## Files added / changed

| Action | File | Why |
|--------|------|-----|
| Created | `backend/models/GradingRubric.js` | Sequelize model — UUID PK, ENUM deliverableType (unique), JSON criteria, INTEGER updatedBy |
| Modified | `backend/models/index.js` | Registered `GradingRubric` so `sequelize.sync()` sees it |
| Created | `backend/services/rubricService.js` | Business logic — `upsertRubric`, `getRubric`, `listRubrics` |
| Created | `backend/controllers/coordinatorRubricController.js` | express-validator rules + handlers for GET list, GET by type, PUT upsert |
| Modified | `backend/routes/coordinator.js` | Three new routes: `GET /rubrics`, `GET /rubrics/:deliverableType`, `PUT /rubrics` — all COORDINATOR-gated |
| Created | `backend/test/issue231-coordinator-rubric.test.js` | 10 integration tests covering auth, validation, upsert idempotency, 404 |
| Modified | `backend/package.json` | Added test file to `"test"` script |
| Modified | `frontend/src/services/apiClient.js` | Added missing `put` method |
| Created | `frontend/src/CoordinatorRubricPage.jsx` | Page with deliverable type selector, dynamic criteria rows, auto-loads existing rubric on type switch |
| Modified | `frontend/src/App.jsx` | Registered `/coordinator/rubrics` route |
| Modified | `frontend/src/components/AppShell.jsx` | Added "Grading Rubrics" sidebar entry under Coordinator → Operations |
| Modified | `frontend/src/CoordinatorHomePage.jsx` | Added "Grading Rubric Configuration" card to coordinator workspace |

## How to test

1. `npm test` — 10 new tests should all pass. The 3 pre-existing failures are unrelated advisor notification tests already broken on `main`.
2. Manual:
   - Log in as coordinator at `/coordinator/login`
   - Navigate to **Grading Rubrics** from the sidebar or home card
   - Select `PROPOSAL`, add criteria (name + max points), click **Save Rubric** — expect success notification
   - Switch to `SOW`, add different criteria, save — expect success
   - Switch back to `PROPOSAL` — the saved criteria should reload automatically
   - Try saving with two criteria that share a name — expect duplicate name error

## Acceptance criteria

- [x] `GET /api/v1/coordinator/rubrics` returns all configured rubrics
- [x] `GET /api/v1/coordinator/rubrics/:deliverableType` returns the rubric for that type or 404
- [x] `PUT /api/v1/coordinator/rubrics` creates or replaces the rubric for a given deliverable type
- [x] Duplicate criterion names rejected with `400 DUPLICATE_CRITERION_NAME`
- [x] Unauthenticated requests return `401`
- [x] Non-COORDINATOR roles return `403`
- [x] A second PUT for the same `deliverableType` updates the record, does not duplicate
- [x] Frontend page loads existing rubric when switching deliverable type
- [x] `apiClient.put` added so all future PUT endpoints can be called from the frontend
- [x] All 10 integration tests pass

## Notes

- The `put` method was absent from `apiClient.js` before this PR — any page calling a PUT endpoint would have thrown `apiClient.put is not a function`. Fixed as part of this branch.
- Rubric criteria are stored as a JSON array; no separate `Criterion` table — criteria are always read and written together as a unit.
- The `deliverableType` unique constraint is enforced at the DB level via the `indexes` option, not via `addConstraint`.