### PR TITLE
add request body validation middleware

### DIFF
--- a/backend/middleware/requestValidation.js
+++ b/backend/middleware/requestValidation.js
@@ -1,0 +1,37 @@
+function buildEmptyBodyErrorResponse() {
+  return {
+    code: 'VALIDATION_ERROR',
+    message: 'Request body must not be null or empty',
+    errors: {
+      body: ['Request body must not be null or empty'],
+    },
+  };
+}
+
+function isEmptyBody(body) {
+  if (body == null) {
+    return true;
+  }
+
+  if (Array.isArray(body)) {
+    return true;
+  }
+
+  if (typeof body !== 'object') {
+    return true;
+  }
+
+  return Object.keys(body).length === 0;
+}
+
+function requireNonEmptyBody(req, res, next) {
+  if (isEmptyBody(req.body)) {
+    return res.status(400).json(buildEmptyBodyErrorResponse());
+  }
+
+  return next();
+}
+
+module.exports = {
+  requireNonEmptyBody,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test test/api.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue224-coordinator-weights-api.test.js test/issue231-coordinator-rubric.test.js test/issue219-submission-metadata.test.js test/issue220-deliverables-storage.test.js test/issue254-committee-review-persistence.test.js test/issue259-deliverables-audit-dispatch.test.js test/issue256-coordinator-rubrics-audit.test.js test/issue261-committee-review-audit-logging.test.js test/QA.test.js"
+    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test test/api.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue224-coordinator-weights-api.test.js test/issue231-coordinator-rubric.test.js test/issue219-submission-metadata.test.js test/issue220-deliverables-storage.test.js test/issue254-committee-review-persistence.test.js test/issue259-deliverables-audit-dispatch.test.js test/issue256-coordinator-rubrics-audit.test.js test/issue261-committee-review-audit-logging.test.js test/issue280-request-body-validation.test.js test/QA.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -1,12 +1,13 @@
 const express = require('express');
 const router = express.Router();
 const { authenticate, authorize } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const { adminLogin, registerProfessor, registerCoordinator } = require('../controllers/adminController.js');
 const { listAuditLogs } = require('../controllers/auditLogController');
 
-router.post('/login', adminLogin);
-router.post('/professors', authenticate, authorize(['ADMIN']), registerProfessor);
-router.post('/coordinators', authenticate, authorize(['ADMIN']), registerCoordinator);
+router.post('/login', requireNonEmptyBody, adminLogin);
+router.post('/professors', authenticate, authorize(['ADMIN']), requireNonEmptyBody, registerProfessor);
+router.post('/coordinators', authenticate, authorize(['ADMIN']), requireNonEmptyBody, registerCoordinator);
 router.get('/audit-logs', authenticate, authorize(['ADMIN']), listAuditLogs);
 
 module.exports = router;

--- a/backend/routes/advisorRequests.js
+++ b/backend/routes/advisorRequests.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { body, validationResult } = require('express-validator');
 const { authenticate, authorize } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const NotificationService = require('../services/notificationService');
 const sequelize = require('../db');
 const { syncAdvisorAssignmentsForGroup } = require('../services/mentorMatchingService');
@@ -21,6 +22,7 @@ router.post(
   '/advisor-requests',
   authenticate,
   authorize(['STUDENT']),
+  requireNonEmptyBody,
   createAdvisorRequest,
 );
 
@@ -49,6 +51,7 @@ router.patch(
   '/pending-advisor-requests/:requestId/status',
   authenticate,
   authorize(['PROFESSOR']),
+  requireNonEmptyBody,
   body('status').isString().trim().notEmpty(),
   async (req, res, next) => {
     const errors = validationResult(req);
@@ -66,6 +69,7 @@ router.patch(
   '/advisor-requests/:requestId/decision',
   authenticate,
   authorize(['PROFESSOR']),
+  requireNonEmptyBody,
   body('decision')
     .isString()
     .trim()

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const { registerRoleUser } = require('../controllers/authController');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 
 const router = express.Router();
 
-router.post('/register', registerRoleUser);
+router.post('/register', requireNonEmptyBody, registerRoleUser);
 
 module.exports = router;

--- a/backend/routes/committee.js
+++ b/backend/routes/committee.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { authenticate, authorize } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const committeeController = require('../controllers/committeeController');
 
 const router = express.Router();
@@ -22,6 +23,7 @@ router.post(
   '/submissions/:submissionId/grade',
   authenticate,
   authorize(['PROFESSOR']),
+  requireNonEmptyBody,
   committeeController.submitReviewValidation,
   committeeController.submitReview,
 );

--- a/backend/routes/coordinator.js
+++ b/backend/routes/coordinator.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { authenticate, authorize } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const { coordinatorLogin } = require('../controllers/adminController');
 const { importValidStudentIds } = require('../controllers/userDatabaseController');
 const { updateGroupMembership, createRubric } = require('../controllers/coordinatorController');
@@ -13,25 +14,27 @@ const coordinatorRubricController = require('../controllers/coordinatorRubricCon
 
 const router = express.Router();
 
-router.post('/login', coordinatorLogin);
+router.post('/login', requireNonEmptyBody, coordinatorLogin);
 router.post(
   '/student-id-registry/import',
   authenticate,
   authorize(['COORDINATOR']),
+  requireNonEmptyBody,
   importValidStudentIds,
 );
-router.post('/rubrics', authenticate, authorize(['COORDINATOR']), createRubric);
+router.post('/rubrics', authenticate, authorize(['COORDINATOR']), requireNonEmptyBody, createRubric);
 
 router.get('/advisors', authenticate, authorize(['COORDINATOR']), listCoordinatorAdvisors);
 router.get('/groups', authenticate, authorize(['COORDINATOR']), groupController.listGroups);
-router.patch('/groups/:groupId/advisor-transfer', authenticate, authorize(['COORDINATOR']), transferByCoordinator);
-router.patch('/groups/:groupId/members', authenticate, authorize(['COORDINATOR']), updateGroupMembership);
-router.patch('/groups/:groupId/membership/coordinator', authenticate, authorize(['COORDINATOR']), updateGroupMembership);
+router.patch('/groups/:groupId/advisor-transfer', authenticate, authorize(['COORDINATOR']), requireNonEmptyBody, transferByCoordinator);
+router.patch('/groups/:groupId/members', authenticate, authorize(['COORDINATOR']), requireNonEmptyBody, updateGroupMembership);
+router.patch('/groups/:groupId/membership/coordinator', authenticate, authorize(['COORDINATOR']), requireNonEmptyBody, updateGroupMembership);
 
 router.put(
   '/weights',
   authenticate,
   authorize(['COORDINATOR']),
+  requireNonEmptyBody,
   coordinatorWeightsController.updateWeightsValidation,
   coordinatorWeightsController.updateWeights,
 );
@@ -53,6 +56,7 @@ router.put(
   '/rubrics',
   authenticate,
   authorize(['COORDINATOR']),
+  requireNonEmptyBody,
   coordinatorRubricController.upsertRubricValidation,
   coordinatorRubricController.upsertRubric,
 );

--- a/backend/routes/groupDatabase.js
+++ b/backend/routes/groupDatabase.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { authenticate, authorize } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const {
   deleteOrphanGroup,
   transferInGroupDatabase,
@@ -12,6 +13,7 @@ router.patch(
   '/groups/:groupId/advisor-transfer',
   authenticate,
   authorize(['COORDINATOR']),
+  requireNonEmptyBody,
   transferInGroupDatabase,
 );
 router.delete(

--- a/backend/routes/groups.js
+++ b/backend/routes/groups.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { authenticate, authorize } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const groupController = require('../controllers/groupController');
 const { updateGroupMembership } = require('../controllers/coordinatorController');
 const submissionController = require('../controllers/submissionController');
@@ -11,7 +12,7 @@ const router = express.Router();
  * Create a new group
  * Auth: Required (student who will be the leader)
  */
-router.post('/', authenticate, groupController.createGroupValidation, groupController.createGroup);
+router.post('/', authenticate, requireNonEmptyBody, groupController.createGroupValidation, groupController.createGroup);
 
 router.get('/', authenticate, groupController.listGroups);
 router.get('/joined', authenticate, groupController.listJoinedGroups);
@@ -26,7 +27,7 @@ router.patch(
   groupController.advisorRelease,
 );
 
-router.patch('/:groupId', authenticate, groupController.renameGroupValidation, groupController.renameGroup);
+router.patch('/:groupId', authenticate, requireNonEmptyBody, groupController.renameGroupValidation, groupController.renameGroup);
 router.delete('/:groupId', authenticate, groupController.deleteGroupValidation, groupController.deleteGroup);
 
 router.delete(
@@ -39,7 +40,7 @@ router.delete(
 router.post('/:groupId/leave', authenticate, groupController.leaveGroupValidation, groupController.leaveGroup);
 router.post('/:groupId/members/:memberId/kick', authenticate, groupController.kickMemberValidation, groupController.kickMember);
 
-router.post('/:groupId/invitations', authenticate, groupController.dispatchInvitesValidation, groupController.dispatchInvites);
+router.post('/:groupId/invitations', authenticate, requireNonEmptyBody, groupController.dispatchInvitesValidation, groupController.dispatchInvites);
 
 router.patch(
   '/:groupId/membership/coordinator',
@@ -53,7 +54,7 @@ router.patch(
  * Finalize membership for a student in a group
  * Auth: Optional (for leader reference)
  */
-router.post('/:groupId/membership/finalize', groupController.finalizeMembershipValidation, groupController.finalizeMembership);
+router.post('/:groupId/membership/finalize', requireNonEmptyBody, groupController.finalizeMembershipValidation, groupController.finalizeMembership);
 
 /**
  * GET /api/v1/groups/:groupId/membership
@@ -71,6 +72,7 @@ router.post(
   '/:groupId/deliverables',
   authenticate,
   authorize(['STUDENT']),
+  requireNonEmptyBody,
   submissionController.submitDeliverableValidation,
   submissionController.submitDeliverable
 );

--- a/backend/routes/invitations.js
+++ b/backend/routes/invitations.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { authenticate } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const { respondToInvitation, getMyInvitations } = require('../controllers/invitationController');
 
 const router = express.Router();
@@ -7,8 +8,7 @@ const router = express.Router();
 router.get('/invitations/me', authenticate, getMyInvitations);
 
 // Keep both spellings for compatibility with existing docs while backend converges.
-router.patch('/invitations/:invitationId/respond', authenticate, respondToInvitation);
-router.patch('/invitations/:invitationId/response', authenticate, respondToInvitation);
+router.patch('/invitations/:invitationId/respond', authenticate, requireNonEmptyBody, respondToInvitation);
+router.patch('/invitations/:invitationId/response', authenticate, requireNonEmptyBody, respondToInvitation);
 
 module.exports = router;
-

--- a/backend/routes/passwordSetupTokenStore.js
+++ b/backend/routes/passwordSetupTokenStore.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const { authenticate, authorize } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const { verifySetupToken } = require('../controllers/passwordSetupTokenController');
 
 const router = express.Router();
 
-router.post('/verify', authenticate, authorize(['ADMIN']), verifySetupToken);
+router.post('/verify', authenticate, authorize(['ADMIN']), requireNonEmptyBody, verifySetupToken);
 
 module.exports = router;

--- a/backend/routes/professors.js
+++ b/backend/routes/professors.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { authenticate, authorize } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const {
   loginProfessor,
   setupProfessorPassword,
@@ -8,8 +9,8 @@ const {
 
 const router = express.Router();
 
-router.post('/login', loginProfessor);
-router.post('/password-setup', setupProfessorPassword);
+router.post('/login', requireNonEmptyBody, loginProfessor);
+router.post('/password-setup', requireNonEmptyBody, setupProfessorPassword);
 router.get('/', authenticate, authorize(['STUDENT', 'PROFESSOR', 'ADMIN', 'COORDINATOR']), listProfessors);
 router.get('/list', authenticate, authorize(['STUDENT', 'PROFESSOR', 'ADMIN', 'COORDINATOR']), listProfessors);
 

--- a/backend/routes/students.js
+++ b/backend/routes/students.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { authenticate } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const {
   getCurrentStudent,
   getStudentValidation,
@@ -15,15 +16,15 @@ const { Group } = require('../models');
 
 const router = express.Router();
 
-router.post('/students/login', loginStudent);
-router.post('/students/registration-validation', registerStudentValidation);
-router.post('/students/register', registerStudent);
+router.post('/students/login', requireNonEmptyBody, loginStudent);
+router.post('/students/registration-validation', requireNonEmptyBody, registerStudentValidation);
+router.post('/students/register', requireNonEmptyBody, registerStudent);
 router.get('/students/me', authenticate, getCurrentStudent);
 router.get('/user-database/students/:studentId/validation', getStudentValidation);
-router.patch('/user-database/students/:studentId/github-link', updateStudentGitHubLink);
+router.patch('/user-database/students/:studentId/github-link', requireNonEmptyBody, updateStudentGitHubLink);
 router.get('/students/me/github/link', authenticate, startGitHubLink);
 router.get('/auth/github/callback', handleGitHubCallback);
-router.post('/linked-github-account-store/links', storeLinkedGitHubAccount);
+router.post('/linked-github-account-store/links', requireNonEmptyBody, storeLinkedGitHubAccount);
 
 /**
  * GET /api/v1/groups/my-groups

--- a/backend/routes/submissions.js
+++ b/backend/routes/submissions.js
@@ -6,6 +6,7 @@
 
 const express = require('express');
 const { authenticate, authorize } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const submissionController = require('../controllers/submissionController');
 const gradingController = require('../controllers/gradingController');
 
@@ -28,6 +29,7 @@ router.post(
   '/:submissionId/grade',
   authenticate,
   authorize(['PROFESSOR']),
+  requireNonEmptyBody,
   gradingController.submitGradeValidation,
   gradingController.submitGrade
 );

--- a/backend/routes/userDatabase.js
+++ b/backend/routes/userDatabase.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { authenticate, authorize } = require('../middleware/auth');
+const { requireNonEmptyBody } = require('../middleware/requestValidation');
 const {
   createProfessorRecord,
   createStudentRecord,
@@ -10,19 +11,21 @@ const { syncUserDatabaseAssignment } = require('../controllers/mentorMatchingCon
 
 const router = express.Router();
 
-router.post('/students', authenticate, authorize(['ADMIN']), createStudentRecord);
-router.post('/valid-student-ids', authenticate, authorize(['ADMIN']), importValidStudentIds);
-router.post('/professors', authenticate, authorize(['ADMIN']), createProfessorRecord);
+router.post('/students', authenticate, authorize(['ADMIN']), requireNonEmptyBody, createStudentRecord);
+router.post('/valid-student-ids', authenticate, authorize(['ADMIN']), requireNonEmptyBody, importValidStudentIds);
+router.post('/professors', authenticate, authorize(['ADMIN']), requireNonEmptyBody, createProfessorRecord);
 router.patch(
   '/professors/:professorId/password',
   authenticate,
   authorize(['ADMIN']),
+  requireNonEmptyBody,
   updateProfessorPassword
 );
 router.patch(
   '/groups/:groupId/advisor-assignment',
   authenticate,
   authorize(['COORDINATOR']),
+  requireNonEmptyBody,
   syncUserDatabaseAssignment,
 );
 

--- a/backend/test/issue280-request-body-validation.test.js
+++ b/backend/test/issue280-request-body-validation.test.js
@@ -1,0 +1,150 @@
+require('./setupTestEnv');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const jwt = require('jsonwebtoken');
+
+const sequelize = require('../db');
+const app = require('../app');
+const models = require('../models');
+const { createStudent, ensureValidStudentRegistry } = require('../services/studentService');
+
+const {
+  CommitteeReview,
+  Grade,
+  DeliverableSubmission,
+  GroupDeliverable,
+  Deliverable,
+  DeliverableRubric,
+  DeliverableWeightConfiguration,
+  SprintWeightConfiguration,
+  GradingRubric,
+  GroupAdvisorAssignment,
+  Invitation,
+  AdvisorRequest,
+  Notification,
+  AuditLog,
+  LinkedGitHubAccount,
+  OAuthState,
+  Group,
+  Professor,
+  User,
+} = models;
+
+let server;
+let baseUrl;
+
+async function request(path, options = {}) {
+  const response = await fetch(`${baseUrl}${path}`, options);
+  const json = await response.json();
+  return { response, json };
+}
+
+function authHeaderFor(user) {
+  const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET);
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function destroyIfPresent(Model) {
+  if (Model) {
+    await Model.destroy({ where: {} });
+  }
+}
+
+test.before(async () => {
+  await sequelize.sync({ force: true });
+  await ensureValidStudentRegistry();
+  server = app.listen(0);
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+
+  await sequelize.close();
+});
+
+test.beforeEach(async () => {
+  await destroyIfPresent(CommitteeReview);
+  await destroyIfPresent(Grade);
+  await destroyIfPresent(DeliverableSubmission);
+  await destroyIfPresent(GroupDeliverable);
+  await destroyIfPresent(Deliverable);
+  await destroyIfPresent(DeliverableRubric);
+  await destroyIfPresent(DeliverableWeightConfiguration);
+  await destroyIfPresent(SprintWeightConfiguration);
+  await destroyIfPresent(GradingRubric);
+  await destroyIfPresent(GroupAdvisorAssignment);
+  await destroyIfPresent(Invitation);
+  await destroyIfPresent(AdvisorRequest);
+  await destroyIfPresent(Notification);
+  await destroyIfPresent(AuditLog);
+  await destroyIfPresent(LinkedGitHubAccount);
+  await destroyIfPresent(OAuthState);
+  await destroyIfPresent(Group);
+  await destroyIfPresent(Professor);
+  await destroyIfPresent(User);
+});
+
+test('rejects missing JSON body on admin login with a standardized 400 response', async () => {
+  const { response, json } = await request('/api/v1/admin/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'VALIDATION_ERROR');
+  assert.equal(json.message, 'Request body must not be null or empty');
+  assert.deepEqual(json.errors, {
+    body: ['Request body must not be null or empty'],
+  });
+});
+
+test('rejects missing JSON body before invitation response handler reads req.body', async () => {
+  const student = await createStudent({
+    studentId: '11070001991',
+    email: 'issue280-student@example.edu',
+    fullName: 'Issue 280 Student',
+    password: 'StrongPass1!',
+  });
+
+  const { response, json } = await request('/api/v1/invitations/invite-1/respond', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaderFor(student),
+    },
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'VALIDATION_ERROR');
+  assert.equal(json.message, 'Request body must not be null or empty');
+});
+
+test('rejects empty object payloads on body-backed routes', async () => {
+  const { response, json } = await request('/api/v1/groups/group-1/membership/finalize', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'VALIDATION_ERROR');
+  assert.equal(json.message, 'Request body must not be null or empty');
+});
+
+test('does not enforce the middleware on bodyless write routes', async () => {
+  const { response, json } = await request('/api/v1/groups/group-1/leave', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  assert.equal(response.status, 401);
+  assert.equal(json.message, 'Access denied');
+});


### PR DESCRIPTION
## What changed
- added a shared backend middleware to reject null or empty request bodies with a standardized `400` validation response
- applied the middleware to body-backed `POST`, `PATCH`, and `PUT` routes across the backend API
- added backend test coverage for Issue #280 and wired the new test file into the backend test script

## Why
Some endpoints accessed `req.body` fields directly, which left the API exposed to null or empty payloads and inconsistent failure behavior. This change adds a single guard at the route boundary so invalid requests fail early and safely.

## Impact
- endpoints that require a request body now return `400` for null or empty payloads
- error responses for this case now follow a consistent validation shape
- reduces the risk of null-pointer-style runtime failures caused by missing payloads

## Validation
- `node --check` passed for the updated backend files
- `node -e "require('./backend/app'); console.log('backend app loads')"` passed
- full backend HTTP tests could not be executed in this sandbox because `app.listen(0)` fails with `EPERM: operation not permitted 0.0.0.0`
