### PR TITLE
Standardize backend API error responses

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -3,8 +3,14 @@ const fs = require('fs');
 const path = require('path');
 
 require('dotenv').config({ path: path.join(__dirname, '.env') });
+require('./middleware/asyncRouteErrors');
 
 const { User, Group, AuditLog } = require('./models');
+const {
+  errorResponseNormalizer,
+  globalErrorHandler,
+  notFoundHandler,
+} = require('./middleware/errorResponse');
 
 const adminRoutes = require('./routes/admin');
 const coordinatorRoutes = require('./routes/coordinator');
@@ -27,6 +33,7 @@ const app = express();
 const frontendDistPath = path.join(__dirname, '..', 'frontend', 'dist');
 
 app.use(express.json());
+app.use(errorResponseNormalizer);
 
 // Serve frontend if exists
 if (fs.existsSync(frontendDistPath)) {
@@ -54,10 +61,7 @@ app.use('/api/v1/groups', groupRoutes);
 app.use('/api/v1/committee/submissions', submissionsRoutes);
 app.use('/api/v1/committee', committeeRoutes);
 
-// Global error handler
-app.use((err, req, res, _next) => {
-  console.error(err.stack);
-  res.status(500).json({ message: 'Internal Server Error' });
-});
+app.use(notFoundHandler);
+app.use(globalErrorHandler);
 
 module.exports = app;

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -14,6 +14,7 @@ const registerRoleUser = [
       return res.status(400).json({
         code: 'INVALID_SIGNUP_INPUT',
         message: 'Sign up input is invalid.',
+        details: errors.array(),
       });
     }
 

--- a/backend/errors/apiError.js
+++ b/backend/errors/apiError.js
@@ -1,0 +1,37 @@
+class ApiError extends Error {
+  constructor(status, code, message, details) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code;
+    if (Array.isArray(details) && details.length > 0) {
+      this.details = details;
+    }
+  }
+
+  static badRequest(code, message, details) {
+    return new ApiError(400, code, message, details);
+  }
+
+  static unauthorized(code, message, details) {
+    return new ApiError(401, code, message, details);
+  }
+
+  static forbidden(code, message, details) {
+    return new ApiError(403, code, message, details);
+  }
+
+  static notFound(code, message, details) {
+    return new ApiError(404, code, message, details);
+  }
+
+  static conflict(code, message, details) {
+    return new ApiError(409, code, message, details);
+  }
+
+  static internal(message = 'Internal server error') {
+    return new ApiError(500, 'INTERNAL_ERROR', message);
+  }
+}
+
+module.exports = ApiError;

--- a/backend/middleware/asyncRouteErrors.js
+++ b/backend/middleware/asyncRouteErrors.js
@@ -1,0 +1,25 @@
+const Layer = require('express/lib/router/layer');
+
+if (!Layer.prototype.__asyncErrorsPatched) {
+  const originalHandleRequest = Layer.prototype.handle_request;
+
+  Layer.prototype.handle_request = function patchedHandleRequest(req, res, next) {
+    const fn = this.handle;
+
+    if (fn.length > 3) {
+      return originalHandleRequest.call(this, req, res, next);
+    }
+
+    try {
+      const result = fn(req, res, next);
+      if (result && typeof result.then === 'function') {
+        result.catch(next);
+      }
+      return result;
+    } catch (error) {
+      return next(error);
+    }
+  };
+
+  Layer.prototype.__asyncErrorsPatched = true;
+}

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,5 +1,6 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const ApiError = require('../errors/apiError');
 
 const authenticate = async (req, res, next) => {
   const authHeader = req.header('Authorization');
@@ -8,7 +9,7 @@ const authenticate = async (req, res, next) => {
     : null;
 
   if (!token) {
-    return res.status(401).json({ message: 'Access denied' });
+    return next(ApiError.unauthorized('AUTH_TOKEN_MISSING', 'Access denied'));
   }
 
   try {
@@ -16,23 +17,23 @@ const authenticate = async (req, res, next) => {
     const user = await User.findByPk(decoded.id);
 
     if (!user) {
-      return res.status(401).json({ message: 'Invalid token' });
+      return next(ApiError.unauthorized('INVALID_TOKEN', 'Invalid token'));
     }
 
     req.user = user;
     return next();
   } catch (err) {
-    return res.status(401).json({ message: 'Invalid token' });
+    return next(ApiError.unauthorized('INVALID_TOKEN', 'Invalid token'));
   }
 };
 
 const authorize = (roles) => (req, res, next) => {
   if (!req.user) {
-    return res.status(401).json({ message: 'Unauthorized' });
+    return next(ApiError.unauthorized('UNAUTHORIZED', 'Unauthorized'));
   }
 
   if (!roles.includes(req.user.role)) {
-    return res.status(403).json({ message: 'Forbidden' });
+    return next(ApiError.forbidden('FORBIDDEN', 'Forbidden'));
   }
 
   return next();

--- a/backend/middleware/errorResponse.js
+++ b/backend/middleware/errorResponse.js
@@ -1,0 +1,148 @@
+const ApiError = require('../errors/apiError');
+
+const DEFAULT_ERROR_CODES = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  500: 'INTERNAL_ERROR',
+};
+
+function inferErrorCode(statusCode, body) {
+  if (body && typeof body === 'object') {
+    if (typeof body.code === 'string' && body.code.trim()) {
+      return body.code;
+    }
+    if (Array.isArray(body.errors) && body.errors.length > 0) {
+      return 'VALIDATION_ERROR';
+    }
+  }
+
+  return DEFAULT_ERROR_CODES[statusCode] || 'REQUEST_FAILED';
+}
+
+function inferErrorMessage(statusCode, body) {
+  if (body && typeof body === 'object' && typeof body.message === 'string' && body.message.trim()) {
+    return body.message;
+  }
+
+  if (typeof body === 'string' && body.trim()) {
+    return body;
+  }
+
+  if (statusCode >= 500) {
+    return 'Internal server error';
+  }
+
+  return 'Request failed';
+}
+
+function normalizeValidationDetail(detail) {
+  if (!detail || typeof detail !== 'object' || Array.isArray(detail)) {
+    return detail;
+  }
+
+  if (typeof detail.msg === 'string') {
+    return {
+      field: detail.path || null,
+      message: detail.msg,
+      location: detail.location || null,
+      value: Object.prototype.hasOwnProperty.call(detail, 'value') ? detail.value : undefined,
+    };
+  }
+
+  return detail;
+}
+
+function normalizeDetails(details) {
+  if (!Array.isArray(details) || details.length === 0) {
+    return undefined;
+  }
+
+  return details.map(normalizeValidationDetail);
+}
+
+function buildErrorResponse(statusCode, payload) {
+  const source = payload && typeof payload === 'object' && !Array.isArray(payload)
+    ? payload
+    : {};
+
+  const response = {
+    success: false,
+    code: inferErrorCode(statusCode, payload),
+    message: inferErrorMessage(statusCode, payload),
+  };
+
+  const details = normalizeDetails(source.details || source.errors);
+  if (details) {
+    response.details = details;
+  }
+
+  Object.entries(source).forEach(([key, value]) => {
+    if (['success', 'code', 'message', 'details', 'errors'].includes(key)) {
+      return;
+    }
+    response[key] = value;
+  });
+
+  return response;
+}
+
+function errorResponseNormalizer(req, res, next) {
+  const originalJson = res.json.bind(res);
+
+  res.json = function normalizedJson(payload) {
+    if (res.statusCode >= 400) {
+      return originalJson(buildErrorResponse(res.statusCode, payload));
+    }
+
+    return originalJson(payload);
+  };
+
+  next();
+}
+
+function notFoundHandler(req, res) {
+  if (!req.originalUrl.startsWith('/api/')) {
+    return res.status(404).json({
+      code: 'NOT_FOUND',
+      message: 'Resource not found',
+    });
+  }
+
+  return res.status(404).json({
+    code: 'ROUTE_NOT_FOUND',
+    message: 'API route not found',
+  });
+}
+
+function globalErrorHandler(err, req, res, next) {
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  const status = Number.isInteger(err?.status) ? err.status : 500;
+  const message = status >= 500 ? 'Internal server error' : err?.message || 'Request failed';
+  const code = typeof err?.code === 'string' && err.code.trim()
+    ? err.code
+    : inferErrorCode(status, err);
+
+  if (status >= 500) {
+    console.error(err?.stack || err);
+  }
+
+  return res.status(status).json({
+    code,
+    message,
+    details: Array.isArray(err?.details) ? err.details : undefined,
+  });
+}
+
+module.exports = {
+  ApiError,
+  buildErrorResponse,
+  errorResponseNormalizer,
+  globalErrorHandler,
+  notFoundHandler,
+};

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -159,6 +159,66 @@ test('admin can log in with email and password', async () => {
   assert.equal(invalidResult.json.code, 'INVALID_CREDENTIALS');
 });
 
+test('auth middleware returns standardized error payload when token is missing', async () => {
+  const response = await request('/api/v1/admin/audit-logs');
+
+  assert.equal(response.response.status, 401);
+  assert.equal(response.json.success, false);
+  assert.equal(response.json.code, 'AUTH_TOKEN_MISSING');
+  assert.equal(response.json.message, 'Access denied');
+});
+
+test('validation failures expose standardized details payload', async () => {
+  const result = await request('/api/v1/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      role: '',
+      email: 'not-an-email',
+      fullName: 'Al',
+      password: '123',
+      studentId: 'abc',
+    }),
+  });
+
+  assert.equal(result.response.status, 400);
+  assert.equal(result.json.success, false);
+  assert.equal(result.json.code, 'INVALID_SIGNUP_INPUT');
+  assert.equal(result.json.message, 'Sign up input is invalid.');
+  assert.ok(Array.isArray(result.json.details));
+  assert.ok(result.json.details.length > 0);
+  assert.equal(result.json.details[0].field !== undefined, true);
+  assert.equal(result.json.details[0].message !== undefined, true);
+});
+
+test('unexpected async controller errors are converted to standardized internal errors', async () => {
+  const originalValidateAndCreateStudent = studentRegistrationService.validateAndCreateStudent;
+  studentRegistrationService.validateAndCreateStudent = async () => {
+    throw new Error('database exploded');
+  };
+
+  try {
+    const result = await request('/api/v1/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        role: 'STUDENT',
+        email: 'new-student@example.edu',
+        fullName: 'New Student',
+        password: 'StrongPass1!',
+        studentId: '11070001999',
+      }),
+    });
+
+    assert.equal(result.response.status, 500);
+    assert.equal(result.json.success, false);
+    assert.equal(result.json.code, 'INTERNAL_ERROR');
+    assert.equal(result.json.message, 'Internal server error');
+  } finally {
+    studentRegistrationService.validateAndCreateStudent = originalValidateAndCreateStudent;
+  }
+});
+
 test('audit log feed is admin-only', async () => {
   const admin = await User.create({
     email: 'audit-admin@example.com',


### PR DESCRIPTION
## What changed
- added a common backend API error response model with `success`, `code`, `message`, and optional `details`
- added centralized not-found and global exception handling in the Express app
- ensured async route errors are forwarded to the global error handler instead of leaking raw exceptions
- updated auth middleware to return standardized error responses
- added validation details to the registration flow
- added API tests covering missing auth token, validation failure formatting, and unexpected async error handling
- removed `docs/tests`

## Why
This PR addresses issue #281 by introducing a shared error response structure for the backend API and a central exception handling flow. The goal is to make error payloads more consistent and prevent raw internal exceptions from being returned to clients.

## Impact
- backend clients can rely on a more predictable error response format
- server-side failures are now converted into standardized internal error responses
- validation failures can expose structured error details in a consistent way

## Validation
- added integration tests for standardized auth and validation error responses
- added coverage for unexpected async controller failures returning a standardized `500` response
- manually verified async exceptions are routed through the global error handler

## Related issue
- closes #281
