### PR TITLE
Add story metrics data model

### DIFF
--- a/backend/models/StoryMetric.js
+++ b/backend/models/StoryMetric.js
@@ -1,0 +1,90 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+const IntegrationBinding = require('./IntegrationBinding');
+
+const StoryMetric = sequelize.define(
+  'StoryMetric',
+  {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    teamId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      references: {
+        model: 'IntegrationBindings',
+        key: 'teamId',
+      },
+      validate: {
+        notEmpty: true,
+      },
+    },
+    sprintId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    issueKey: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    metricName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    metricValue: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+      validate: {
+        isFloat: true,
+        min: 0,
+      },
+    },
+    unit: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+  },
+  {
+    tableName: 'StoryMetrics',
+    timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['teamId', 'sprintId', 'issueKey', 'metricName'],
+      },
+      {
+        fields: ['teamId', 'sprintId'],
+      },
+      {
+        fields: ['teamId', 'sprintId', 'issueKey'],
+      },
+    ],
+  },
+);
+
+IntegrationBinding.hasMany(StoryMetric, {
+  foreignKey: 'teamId',
+  sourceKey: 'teamId',
+  as: 'storyMetrics',
+});
+StoryMetric.belongsTo(IntegrationBinding, {
+  foreignKey: 'teamId',
+  targetKey: 'teamId',
+  as: 'teamIntegration',
+});
+
+module.exports = StoryMetric;

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -28,6 +28,7 @@ const SprintWeightConfiguration = require('./SprintWeightConfiguration');
 const DeliverableSubmission = require('./DeliverableSubmission');
 const DeliverableWeightConfiguration = require('./DeliverableWeightConfiguration');
 const GroupDeliverable = require('./GroupDeliverable');
+const StoryMetric = require('./StoryMetric');
 
 module.exports = {
   User,
@@ -52,4 +53,5 @@ module.exports = {
   DeliverableSubmission,
   DeliverableWeightConfiguration,
   GroupDeliverable,
+  StoryMetric,
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test test/api.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue224-coordinator-weights-api.test.js test/issue231-coordinator-rubric.test.js test/issue219-submission-metadata.test.js test/issue220-deliverables-storage.test.js test/issue254-committee-review-persistence.test.js test/issue259-deliverables-audit-dispatch.test.js test/issue256-coordinator-rubrics-audit.test.js test/issue261-committee-review-audit-logging.test.js test/issue280-request-body-validation.test.js test/QA.test.js"
+    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test test/api.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue224-coordinator-weights-api.test.js test/issue231-coordinator-rubric.test.js test/issue219-submission-metadata.test.js test/issue220-deliverables-storage.test.js test/issue254-committee-review-persistence.test.js test/issue259-deliverables-audit-dispatch.test.js test/issue256-coordinator-rubrics-audit.test.js test/issue261-committee-review-audit-logging.test.js test/issue280-request-body-validation.test.js test/issue290-story-metrics-model.test.js test/QA.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/backend/test/issue290-story-metrics-model.test.js
+++ b/backend/test/issue290-story-metrics-model.test.js
@@ -1,0 +1,110 @@
+require('./setupTestEnv');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const sequelize = require('../db');
+const { IntegrationBinding, StoryMetric } = require('../models');
+
+test.before(async () => {
+  await sequelize.sync({ force: true });
+});
+
+test.after(async () => {
+  await sequelize.close();
+});
+
+test.beforeEach(async () => {
+  await StoryMetric.destroy({ where: {} });
+  await IntegrationBinding.destroy({ where: {} });
+});
+
+async function createTeamBinding(teamId = 'team_01HR9W2Q6NQ7G6M3K4J8') {
+  return IntegrationBinding.create({
+    teamId,
+    providerSet: ['jira'],
+    organizationName: 'senior-project',
+    repositoryName: 'senior-app-1',
+    jiraWorkspaceId: 'workspace-acme',
+    jiraProjectKey: 'SPM',
+    initiatedBy: 'student-1',
+    status: 'ACTIVE',
+  });
+}
+
+test('story metric model stores required sprint story metrics for evaluation queries', async () => {
+  await createTeamBinding();
+
+  const metric = await StoryMetric.create({
+    teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+    sprintId: 'sprint_2026_03',
+    issueKey: 'SPM-214',
+    metricName: 'storyCompletionScore',
+    metricValue: 0.85,
+    unit: 'ratio',
+  });
+
+  assert.equal(metric.teamId, 'team_01HR9W2Q6NQ7G6M3K4J8');
+  assert.equal(metric.sprintId, 'sprint_2026_03');
+  assert.equal(metric.issueKey, 'SPM-214');
+
+  const sprintMetrics = await StoryMetric.findAll({
+    where: {
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+    },
+  });
+
+  assert.equal(sprintMetrics.length, 1);
+  assert.equal(sprintMetrics[0].metricValue, 0.85);
+});
+
+test('story metric model rejects missing required fields and invalid metric values', async () => {
+  await createTeamBinding();
+
+  await assert.rejects(
+    StoryMetric.create({
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      issueKey: 'SPM-214',
+      metricName: 'storyCompletionScore',
+      metricValue: -1,
+      unit: 'ratio',
+    }),
+    /Validation/,
+  );
+
+  await assert.rejects(
+    StoryMetric.create({
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      issueKey: 'SPM-214',
+      metricName: 'storyCompletionScore',
+      metricValue: 0.85,
+    }),
+    /notNull Violation/,
+  );
+});
+
+test('story metric model keeps one value per team sprint issue metric name', async () => {
+  await createTeamBinding();
+
+  const payload = {
+    teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+    sprintId: 'sprint_2026_03',
+    issueKey: 'SPM-214',
+    metricName: 'storyCompletionScore',
+    metricValue: 0.85,
+    unit: 'ratio',
+  };
+
+  await StoryMetric.create(payload);
+
+  await assert.rejects(
+    StoryMetric.create({
+      ...payload,
+      metricValue: 0.95,
+    }),
+    /UniqueConstraintError|Validation error/,
+  );
+});


### PR DESCRIPTION
## Description

Implements Issue #290 by adding a backend data model for storing story-level sprint metrics synchronized from JIRA story data.

## Changes

- Added `StoryMetric` Sequelize model.
- Added required fields:
  - `teamId`
  - `sprintId`
  - `issueKey`
  - `metricName`
  - `metricValue`
  - `unit`
- Added validation so required fields cannot be null or empty.
- Added non-negative validation for `metricValue`.
- Added unique constraint on `teamId + sprintId + issueKey + metricName`.
- Added indexes for sprint evaluation queries by team, sprint, and issue.
- Added relationship between `StoryMetric` and `IntegrationBinding`.
- Registered `StoryMetric` in backend model exports.
- Added model tests for persistence, validation, uniqueness, and sprint metric querying.

## Testing

```bash
env JWT_SECRET=test-backend-jwt-not-for-production node --test test/issue290-story-metrics-model.test.js
