### PR TITLE
Issue 291 story metrics persistence

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -27,6 +27,7 @@ const userDatabaseRoutes = require('./routes/userDatabase');
 const groupRoutes = require('./routes/groups');
 const groupDatabaseRoutes = require('./routes/groupDatabase');
 const internalIntegrationsRoutes = require('./routes/internalIntegrations');
+const internalSprintSyncRoutes = require('./routes/internalSprintSync');
 const teamRoutes = require('./routes/teams');
 const submissionsRoutes = require('./routes/submissions');
 const committeeRoutes = require('./routes/committee');
@@ -62,6 +63,7 @@ app.use('/api/v1/group-database', groupDatabaseRoutes);
 app.use('/api/v1/groups', groupRoutes);
 app.use('/api/v1/teams', teamRoutes);
 app.use('/internal/integrations', internalIntegrationsRoutes);
+app.use('/internal/sprint-sync', internalSprintSyncRoutes);
 app.use('/api/v1/committee/submissions', submissionsRoutes);
 app.use('/api/v1/committee', committeeRoutes);
 

--- a/backend/controllers/storyMetricController.js
+++ b/backend/controllers/storyMetricController.js
@@ -1,0 +1,99 @@
+const { randomUUID } = require('crypto');
+const { body, validationResult } = require('express-validator');
+const sequelize = require('../db');
+const { StoryMetric } = require('../models');
+
+const storeStoryMetricsValidation = [
+  body('teamId')
+    .isString()
+    .withMessage('teamId must be a string')
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage('teamId is required'),
+  body('sprintId')
+    .isString()
+    .withMessage('sprintId must be a string')
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage('sprintId is required'),
+  body('stories')
+    .isArray({ min: 1 })
+    .withMessage('stories must be a non-empty array'),
+  body('stories.*.issueKey')
+    .isString()
+    .withMessage('issueKey must be a string')
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage('issueKey is required'),
+  body('stories.*.metricName')
+    .isString()
+    .withMessage('metricName must be a string')
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage('metricName is required'),
+  body('stories.*.metricValue')
+    .isFloat({ min: 0 })
+    .withMessage('metricValue must be a non-negative number'),
+  body('stories.*.unit')
+    .isString()
+    .withMessage('unit must be a string')
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage('unit is required'),
+];
+
+async function storeStoryMetrics(req, res) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({
+      code: 'VALIDATION_ERROR',
+      message: 'Validation failed',
+      errors: errors.array(),
+    });
+  }
+
+  const teamId = req.body.teamId.trim();
+  const sprintId = req.body.sprintId.trim();
+  const metrics = req.body.stories.map((story) => ({
+    teamId,
+    sprintId,
+    issueKey: story.issueKey.trim(),
+    metricName: story.metricName.trim(),
+    metricValue: Number(story.metricValue),
+    unit: story.unit.trim(),
+  }));
+
+  try {
+    await sequelize.transaction(async (transaction) => {
+      for (const metric of metrics) {
+        await StoryMetric.upsert(metric, { transaction });
+      }
+    });
+
+    return res.status(201).json({
+      id: `op_${randomUUID()}`,
+      status: 'STORED',
+      message: 'Story metrics stored successfully.',
+      recordedAt: new Date().toISOString(),
+      teamId,
+      sprintId,
+      storedCount: metrics.length,
+    });
+  } catch (error) {
+    console.error('Error in storeStoryMetrics:', error);
+    return res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      message: 'Failed to store story metrics',
+    });
+  }
+}
+
+module.exports = {
+  storeStoryMetricsValidation,
+  storeStoryMetrics,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test test/api.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue224-coordinator-weights-api.test.js test/issue231-coordinator-rubric.test.js test/issue219-submission-metadata.test.js test/issue220-deliverables-storage.test.js test/issue254-committee-review-persistence.test.js test/issue259-deliverables-audit-dispatch.test.js test/issue256-coordinator-rubrics-audit.test.js test/issue261-committee-review-audit-logging.test.js test/issue280-request-body-validation.test.js test/issue290-story-metrics-model.test.js test/QA.test.js"
+    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test test/api.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue224-coordinator-weights-api.test.js test/issue231-coordinator-rubric.test.js test/issue219-submission-metadata.test.js test/issue220-deliverables-storage.test.js test/issue254-committee-review-persistence.test.js test/issue259-deliverables-audit-dispatch.test.js test/issue256-coordinator-rubrics-audit.test.js test/issue261-committee-review-audit-logging.test.js test/issue280-request-body-validation.test.js test/issue290-story-metrics-model.test.js test/issue291-story-metrics-persistence.test.js test/QA.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/backend/routes/internalSprintSync.js
+++ b/backend/routes/internalSprintSync.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const { authenticateInternalApiKey } = require('../middleware/internalApiKey');
+const {
+  storeStoryMetricsValidation,
+  storeStoryMetrics,
+} = require('../controllers/storyMetricController');
+
+const router = express.Router();
+
+router.post(
+  '/stories',
+  authenticateInternalApiKey,
+  storeStoryMetricsValidation,
+  storeStoryMetrics,
+);
+
+module.exports = router;

--- a/backend/test/issue291-story-metrics-persistence.test.js
+++ b/backend/test/issue291-story-metrics-persistence.test.js
@@ -1,0 +1,204 @@
+require('./setupTestEnv');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const sequelize = require('../db');
+const app = require('../app');
+const { IntegrationBinding, StoryMetric } = require('../models');
+
+let server;
+let baseUrl;
+
+async function request(path, options = {}) {
+  const response = await fetch(`${baseUrl}${path}`, options);
+  const json = await response.json();
+  return { response, json };
+}
+
+function internalHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    'x-internal-api-key': process.env.INTERNAL_API_KEY,
+  };
+}
+
+async function createTeamBinding(teamId = 'team_01HR9W2Q6NQ7G6M3K4J8') {
+  return IntegrationBinding.create({
+    teamId,
+    providerSet: ['jira'],
+    organizationName: 'senior-project',
+    repositoryName: 'senior-app-1',
+    jiraWorkspaceId: 'workspace-acme',
+    jiraProjectKey: 'SPM',
+    initiatedBy: 'student-1',
+    status: 'ACTIVE',
+  });
+}
+
+test.before(async () => {
+  await sequelize.sync({ force: true });
+  server = app.listen(0);
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+
+  await sequelize.close();
+});
+
+test.beforeEach(async () => {
+  await StoryMetric.destroy({ where: {} });
+  await IntegrationBinding.destroy({ where: {} });
+});
+
+test('stores synchronized story metrics and returns ActionResponse status', async () => {
+  await createTeamBinding();
+
+  const { response, json } = await request('/internal/sprint-sync/stories', {
+    method: 'POST',
+    headers: internalHeaders(),
+    body: JSON.stringify({
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      stories: [
+        {
+          issueKey: 'SPM-214',
+          metricName: 'storyCompletionScore',
+          metricValue: 0.85,
+          unit: 'ratio',
+        },
+        {
+          issueKey: 'SPM-214',
+          metricName: 'cycleTimeDays',
+          metricValue: 3,
+          unit: 'days',
+        },
+      ],
+    }),
+  });
+
+  assert.equal(response.status, 201);
+  assert.match(json.id, /^op_/);
+  assert.equal(json.status, 'STORED');
+  assert.equal(json.message, 'Story metrics stored successfully.');
+  assert.equal(json.teamId, 'team_01HR9W2Q6NQ7G6M3K4J8');
+  assert.equal(json.sprintId, 'sprint_2026_03');
+  assert.equal(json.storedCount, 2);
+  assert.ok(json.recordedAt);
+
+  const storedMetrics = await StoryMetric.findAll({
+    where: {
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      issueKey: 'SPM-214',
+    },
+    order: [['metricName', 'ASC']],
+  });
+
+  assert.equal(storedMetrics.length, 2);
+  assert.equal(storedMetrics[0].metricName, 'cycleTimeDays');
+  assert.equal(storedMetrics[0].metricValue, 3);
+  assert.equal(storedMetrics[1].metricName, 'storyCompletionScore');
+  assert.equal(storedMetrics[1].metricValue, 0.85);
+});
+
+test('rejects invalid story metric payloads with validation error response', async () => {
+  const { response, json } = await request('/internal/sprint-sync/stories', {
+    method: 'POST',
+    headers: internalHeaders(),
+    body: JSON.stringify({
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: '',
+      stories: [
+        {
+          issueKey: 'SPM-214',
+          metricName: 'storyCompletionScore',
+          metricValue: -1,
+          unit: 'ratio',
+        },
+      ],
+    }),
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(json.success, false);
+  assert.equal(json.code, 'VALIDATION_ERROR');
+  assert.equal(json.message, 'Validation failed');
+
+  const storedMetrics = await StoryMetric.findAll();
+  assert.equal(storedMetrics.length, 0);
+});
+
+test('safely handles repeated metric submissions by updating existing metric rows', async () => {
+  await createTeamBinding();
+
+  const payload = {
+    teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+    sprintId: 'sprint_2026_03',
+    stories: [
+      {
+        issueKey: 'SPM-214',
+        metricName: 'storyCompletionScore',
+        metricValue: 0.85,
+        unit: 'ratio',
+      },
+    ],
+  };
+
+  await request('/internal/sprint-sync/stories', {
+    method: 'POST',
+    headers: internalHeaders(),
+    body: JSON.stringify(payload),
+  });
+
+  const { response } = await request('/internal/sprint-sync/stories', {
+    method: 'POST',
+    headers: internalHeaders(),
+    body: JSON.stringify({
+      ...payload,
+      stories: [
+        {
+          ...payload.stories[0],
+          metricValue: 0.95,
+        },
+      ],
+    }),
+  });
+
+  assert.equal(response.status, 201);
+
+  const storedMetrics = await StoryMetric.findAll({
+    where: {
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      issueKey: 'SPM-214',
+      metricName: 'storyCompletionScore',
+    },
+  });
+
+  assert.equal(storedMetrics.length, 1);
+  assert.equal(storedMetrics[0].metricValue, 0.95);
+});
+
+test('requires internal API key for story metric persistence', async () => {
+  const { response, json } = await request('/internal/sprint-sync/stories', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      stories: [],
+    }),
+  });
+
+  assert.equal(response.status, 401);
+  assert.equal(json.code, 'UNAUTHORIZED');
+});


### PR DESCRIPTION
## Description

Implements Issue #291 by adding persistence logic for synchronized story-level sprint metrics.

This PR adds the internal `/internal/sprint-sync/stories` endpoint, validates `StoryMetricStoreRequest` payloads, stores story metrics in the sprint monitoring database, and safely handles repeated submissions using upsert behavior.

## Changes

- Added internal endpoint:
  - `POST /internal/sprint-sync/stories`
- Added story metric persistence controller.
- Added request validation for:
  - `teamId`
  - `sprintId`
  - `stories`
  - `issueKey`
  - `metricName`
  - `metricValue`
  - `unit`
- Persists story metrics with:
  - `teamId`
  - `sprintId`
  - `issueKey`
  - `metricName`
  - `metricValue`
  - `unit`
- Uses transactional upsert logic so duplicate or repeated metric submissions update existing rows safely.
- Returns `ActionResponse` style response after successful persistence.
- Added internal API key protection.
- Added tests for:
  - successful persistence
  - validation errors
  - repeated submissions
  - internal API key requirement
  - queryability for sprint evaluation

## Testing

```bash
env JWT_SECRET=test-backend-jwt-not-for-production node --test test/issue290-story-metrics-model.test.js test/issue291-story-metrics-persistence.test.js
