### PR TITLE
Add PR metrics data model

### DIFF
--- a/backend/models/PrMetric.js
+++ b/backend/models/PrMetric.js
@@ -1,0 +1,91 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+const IntegrationBinding = require('./IntegrationBinding');
+
+const PrMetric = sequelize.define(
+  'PrMetric',
+  {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    teamId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      references: {
+        model: 'IntegrationBindings',
+        key: 'teamId',
+      },
+      validate: {
+        notEmpty: true,
+      },
+    },
+    sprintId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    prNumber: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      validate: {
+        isInt: true,
+        min: 1,
+      },
+    },
+    metricName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    metricValue: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+      validate: {
+        isFloat: true,
+        min: 0,
+      },
+    },
+    unit: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+  },
+  {
+    tableName: 'PrMetrics',
+    timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['teamId', 'sprintId', 'prNumber', 'metricName'],
+      },
+      {
+        fields: ['teamId', 'sprintId'],
+      },
+      {
+        fields: ['teamId', 'sprintId', 'prNumber'],
+      },
+    ],
+  },
+);
+
+IntegrationBinding.hasMany(PrMetric, {
+  foreignKey: 'teamId',
+  sourceKey: 'teamId',
+  as: 'prMetrics',
+});
+PrMetric.belongsTo(IntegrationBinding, {
+  foreignKey: 'teamId',
+  targetKey: 'teamId',
+  as: 'teamIntegration',
+});
+
+module.exports = PrMetric;

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -28,6 +28,7 @@ const SprintWeightConfiguration = require('./SprintWeightConfiguration');
 const DeliverableSubmission = require('./DeliverableSubmission');
 const DeliverableWeightConfiguration = require('./DeliverableWeightConfiguration');
 const GroupDeliverable = require('./GroupDeliverable');
+const PrMetric = require('./PrMetric');
 
 module.exports = {
   User,
@@ -52,4 +53,5 @@ module.exports = {
   DeliverableSubmission,
   DeliverableWeightConfiguration,
   GroupDeliverable,
+  PrMetric,
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test test/api.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue224-coordinator-weights-api.test.js test/issue231-coordinator-rubric.test.js test/issue219-submission-metadata.test.js test/issue220-deliverables-storage.test.js test/issue254-committee-review-persistence.test.js test/issue259-deliverables-audit-dispatch.test.js test/issue256-coordinator-rubrics-audit.test.js test/issue261-committee-review-audit-logging.test.js test/issue280-request-body-validation.test.js test/QA.test.js"
+    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test test/api.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue224-coordinator-weights-api.test.js test/issue231-coordinator-rubric.test.js test/issue219-submission-metadata.test.js test/issue220-deliverables-storage.test.js test/issue254-committee-review-persistence.test.js test/issue259-deliverables-audit-dispatch.test.js test/issue256-coordinator-rubrics-audit.test.js test/issue261-committee-review-audit-logging.test.js test/issue280-request-body-validation.test.js test/issue292-pr-metrics-model.test.js test/QA.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/backend/test/issue292-pr-metrics-model.test.js
+++ b/backend/test/issue292-pr-metrics-model.test.js
@@ -1,0 +1,123 @@
+require('./setupTestEnv');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const sequelize = require('../db');
+const { IntegrationBinding, PrMetric } = require('../models');
+
+test.before(async () => {
+  await sequelize.sync({ force: true });
+});
+
+test.after(async () => {
+  await sequelize.close();
+});
+
+test.beforeEach(async () => {
+  await PrMetric.destroy({ where: {} });
+  await IntegrationBinding.destroy({ where: {} });
+});
+
+async function createTeamBinding(teamId = 'team_01HR9W2Q6NQ7G6M3K4J8') {
+  return IntegrationBinding.create({
+    teamId,
+    providerSet: ['github'],
+    organizationName: 'senior-project',
+    repositoryName: 'senior-app-1',
+    jiraWorkspaceId: 'workspace-acme',
+    jiraProjectKey: 'SPM',
+    defaultBranch: 'main',
+    initiatedBy: 'student-1',
+    status: 'ACTIVE',
+  });
+}
+
+test('PR metric model stores required sprint PR metrics for evaluation queries', async () => {
+  await createTeamBinding();
+
+  const metric = await PrMetric.create({
+    teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+    sprintId: 'sprint_2026_03',
+    prNumber: 142,
+    metricName: 'reviewReadinessScore',
+    metricValue: 0.92,
+    unit: 'ratio',
+  });
+
+  assert.equal(metric.teamId, 'team_01HR9W2Q6NQ7G6M3K4J8');
+  assert.equal(metric.sprintId, 'sprint_2026_03');
+  assert.equal(metric.prNumber, 142);
+
+  const sprintMetrics = await PrMetric.findAll({
+    where: {
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+    },
+  });
+
+  assert.equal(sprintMetrics.length, 1);
+  assert.equal(sprintMetrics[0].metricValue, 0.92);
+});
+
+test('PR metric model rejects missing required fields and invalid metric values', async () => {
+  await createTeamBinding();
+
+  await assert.rejects(
+    PrMetric.create({
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      prNumber: 142,
+      metricName: 'reviewReadinessScore',
+      metricValue: -1,
+      unit: 'ratio',
+    }),
+    /Validation/,
+  );
+
+  await assert.rejects(
+    PrMetric.create({
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      prNumber: 0,
+      metricName: 'reviewReadinessScore',
+      metricValue: 0.92,
+      unit: 'ratio',
+    }),
+    /Validation/,
+  );
+
+  await assert.rejects(
+    PrMetric.create({
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      prNumber: 142,
+      metricName: 'reviewReadinessScore',
+      metricValue: 0.92,
+    }),
+    /notNull Violation/,
+  );
+});
+
+test('PR metric model keeps one value per team sprint PR metric name', async () => {
+  await createTeamBinding();
+
+  const payload = {
+    teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+    sprintId: 'sprint_2026_03',
+    prNumber: 142,
+    metricName: 'reviewReadinessScore',
+    metricValue: 0.92,
+    unit: 'ratio',
+  };
+
+  await PrMetric.create(payload);
+
+  await assert.rejects(
+    PrMetric.create({
+      ...payload,
+      metricValue: 0.95,
+    }),
+    /UniqueConstraintError|Validation error/,
+  );
+});


### PR DESCRIPTION
## Description

Implements Issue #292 by adding a backend data model for storing pull request-level sprint metrics collected from GitHub PR verification data.

## Changes

- Added `PrMetric` Sequelize model.
- Added required fields:
  - `teamId`
  - `sprintId`
  - `prNumber`
  - `metricName`
  - `metricValue`
  - `unit`
- Added validation so required fields cannot be null or empty.
- Added positive integer validation for `prNumber`.
- Added non-negative validation for `metricValue`.
- Added unique constraint on `teamId + sprintId + prNumber + metricName`.
- Added indexes for sprint evaluation queries by team, sprint, and PR number.
- Added relationship between `PrMetric` and `IntegrationBinding`.
- Registered `PrMetric` in backend model exports.
- Added model tests for persistence, validation, uniqueness, and sprint metric querying.

## Testing

```bash
env JWT_SECRET=test-backend-jwt-not-for-production node --test test/issue292-pr-metrics-model.test.js
