### PR TITLE
fix sprint metric validation

### DIFF
--- a/backend/controllers/prMetricController.js
+++ b/backend/controllers/prMetricController.js
@@ -1,7 +1,7 @@
 const { randomUUID } = require('crypto');
 const { body, validationResult } = require('express-validator');
 const sequelize = require('../db');
-const { PrMetric } = require('../models');
+const { IntegrationBinding, PrMetric } = require('../models');
 
 const storePrMetricsValidation = [
   body('teamId')
@@ -43,6 +43,10 @@ const storePrMetricsValidation = [
     .withMessage('unit is required'),
 ];
 
+function buildMetricKey(metric) {
+  return [metric.prNumber, metric.metricName].join('::');
+}
+
 async function storePrMetrics(req, res) {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
@@ -63,8 +67,27 @@ async function storePrMetrics(req, res) {
     metricValue: Number(pullRequest.metricValue),
     unit: pullRequest.unit.trim(),
   }));
+  const uniqueMetricKeys = new Set(metrics.map(buildMetricKey));
+
+  if (uniqueMetricKeys.size !== metrics.length) {
+    return res.status(400).json({
+      code: 'VALIDATION_ERROR',
+      message: 'Duplicate PR metrics in request payload',
+    });
+  }
 
   try {
+    const binding = await IntegrationBinding.findOne({
+      where: { teamId },
+    });
+
+    if (!binding) {
+      return res.status(404).json({
+        code: 'INTEGRATION_BINDING_NOT_FOUND',
+        message: 'No integration binding exists for this team',
+      });
+    }
+
     await sequelize.transaction(async (transaction) => {
       for (const metric of metrics) {
         await PrMetric.upsert(metric, { transaction });
@@ -78,7 +101,7 @@ async function storePrMetrics(req, res) {
       recordedAt: new Date().toISOString(),
       teamId,
       sprintId,
-      storedCount: metrics.length,
+      storedCount: uniqueMetricKeys.size,
     });
   } catch (error) {
     console.error('Error in storePrMetrics:', error);

--- a/backend/controllers/storyMetricController.js
+++ b/backend/controllers/storyMetricController.js
@@ -1,7 +1,7 @@
 const { randomUUID } = require('crypto');
 const { body, validationResult } = require('express-validator');
 const sequelize = require('../db');
-const { StoryMetric } = require('../models');
+const { IntegrationBinding, StoryMetric } = require('../models');
 
 const storeStoryMetricsValidation = [
   body('teamId')
@@ -47,6 +47,10 @@ const storeStoryMetricsValidation = [
     .withMessage('unit is required'),
 ];
 
+function buildMetricKey(metric) {
+  return [metric.issueKey, metric.metricName].join('::');
+}
+
 async function storeStoryMetrics(req, res) {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
@@ -67,8 +71,27 @@ async function storeStoryMetrics(req, res) {
     metricValue: Number(story.metricValue),
     unit: story.unit.trim(),
   }));
+  const uniqueMetricKeys = new Set(metrics.map(buildMetricKey));
+
+  if (uniqueMetricKeys.size !== metrics.length) {
+    return res.status(400).json({
+      code: 'VALIDATION_ERROR',
+      message: 'Duplicate story metrics in request payload',
+    });
+  }
 
   try {
+    const binding = await IntegrationBinding.findOne({
+      where: { teamId },
+    });
+
+    if (!binding) {
+      return res.status(404).json({
+        code: 'INTEGRATION_BINDING_NOT_FOUND',
+        message: 'No integration binding exists for this team',
+      });
+    }
+
     await sequelize.transaction(async (transaction) => {
       for (const metric of metrics) {
         await StoryMetric.upsert(metric, { transaction });
@@ -82,7 +105,7 @@ async function storeStoryMetrics(req, res) {
       recordedAt: new Date().toISOString(),
       teamId,
       sprintId,
-      storedCount: metrics.length,
+      storedCount: uniqueMetricKeys.size,
     });
   } catch (error) {
     console.error('Error in storeStoryMetrics:', error);

--- a/backend/test/issue290-story-metrics-model.test.js
+++ b/backend/test/issue290-story-metrics-model.test.js
@@ -64,6 +64,18 @@ test('story metric model rejects missing required fields and invalid metric valu
 
   await assert.rejects(
     StoryMetric.create({
+      teamId: '',
+      sprintId: 'sprint_2026_03',
+      issueKey: 'SPM-214',
+      metricName: 'storyCompletionScore',
+      metricValue: 0.85,
+      unit: 'ratio',
+    }),
+    /Validation/,
+  );
+
+  await assert.rejects(
+    StoryMetric.create({
       teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
       sprintId: 'sprint_2026_03',
       issueKey: 'SPM-214',
@@ -107,4 +119,36 @@ test('story metric model keeps one value per team sprint issue metric name', asy
     }),
     /UniqueConstraintError|Validation error/,
   );
+});
+
+test('story metric model requires an existing integration binding and supports eager loading', async () => {
+  await assert.rejects(
+    StoryMetric.create({
+      teamId: 'missing-team',
+      sprintId: 'sprint_2026_03',
+      issueKey: 'SPM-214',
+      metricName: 'storyCompletionScore',
+      metricValue: 0.85,
+      unit: 'ratio',
+    }),
+    /ForeignKeyConstraintError/,
+  );
+
+  await createTeamBinding('team_assoc');
+  await StoryMetric.create({
+    teamId: 'team_assoc',
+    sprintId: 'sprint_2026_03',
+    issueKey: 'SPM-214',
+    metricName: 'storyCompletionScore',
+    metricValue: 0.85,
+    unit: 'ratio',
+  });
+
+  const binding = await IntegrationBinding.findOne({
+    where: { teamId: 'team_assoc' },
+    include: 'storyMetrics',
+  });
+
+  assert.equal(binding.storyMetrics.length, 1);
+  assert.equal(binding.storyMetrics[0].issueKey, 'SPM-214');
 });

--- a/backend/test/issue291-story-metrics-persistence.test.js
+++ b/backend/test/issue291-story-metrics-persistence.test.js
@@ -188,6 +188,60 @@ test('safely handles repeated metric submissions by updating existing metric row
   assert.equal(storedMetrics[0].metricValue, 0.95);
 });
 
+test('rejects story metrics for teams without an integration binding', async () => {
+  const { response, json } = await request('/internal/sprint-sync/stories', {
+    method: 'POST',
+    headers: internalHeaders(),
+    body: JSON.stringify({
+      teamId: 'missing-team',
+      sprintId: 'sprint_2026_03',
+      stories: [
+        {
+          issueKey: 'SPM-214',
+          metricName: 'storyCompletionScore',
+          metricValue: 0.85,
+          unit: 'ratio',
+        },
+      ],
+    }),
+  });
+
+  assert.equal(response.status, 404);
+  assert.equal(json.code, 'INTEGRATION_BINDING_NOT_FOUND');
+});
+
+test('rejects duplicate story metrics in the same payload', async () => {
+  await createTeamBinding();
+
+  const { response, json } = await request('/internal/sprint-sync/stories', {
+    method: 'POST',
+    headers: internalHeaders(),
+    body: JSON.stringify({
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      stories: [
+        {
+          issueKey: 'SPM-214',
+          metricName: 'storyCompletionScore',
+          metricValue: 0.85,
+          unit: 'ratio',
+        },
+        {
+          issueKey: 'SPM-214',
+          metricName: 'storyCompletionScore',
+          metricValue: 0.95,
+          unit: 'ratio',
+        },
+      ],
+    }),
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'VALIDATION_ERROR');
+  assert.equal(json.message, 'Duplicate story metrics in request payload');
+  assert.equal(await StoryMetric.count(), 0);
+});
+
 test('requires internal API key for story metric persistence', async () => {
   const { response, json } = await request('/internal/sprint-sync/stories', {
     method: 'POST',

--- a/backend/test/issue292-pr-metrics-model.test.js
+++ b/backend/test/issue292-pr-metrics-model.test.js
@@ -68,6 +68,18 @@ test('PR metric model rejects missing required fields and invalid metric values'
       teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
       sprintId: 'sprint_2026_03',
       prNumber: 142,
+      metricName: '',
+      metricValue: 0.92,
+      unit: 'ratio',
+    }),
+    /Validation/,
+  );
+
+  await assert.rejects(
+    PrMetric.create({
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      prNumber: 142,
       metricName: 'reviewReadinessScore',
       metricValue: -1,
       unit: 'ratio',
@@ -120,4 +132,36 @@ test('PR metric model keeps one value per team sprint PR metric name', async () 
     }),
     /UniqueConstraintError|Validation error/,
   );
+});
+
+test('PR metric model requires an existing integration binding and supports eager loading', async () => {
+  await assert.rejects(
+    PrMetric.create({
+      teamId: 'missing-team',
+      sprintId: 'sprint_2026_03',
+      prNumber: 142,
+      metricName: 'reviewReadinessScore',
+      metricValue: 0.92,
+      unit: 'ratio',
+    }),
+    /ForeignKeyConstraintError/,
+  );
+
+  await createTeamBinding('team_assoc');
+  await PrMetric.create({
+    teamId: 'team_assoc',
+    sprintId: 'sprint_2026_03',
+    prNumber: 142,
+    metricName: 'reviewReadinessScore',
+    metricValue: 0.92,
+    unit: 'ratio',
+  });
+
+  const binding = await IntegrationBinding.findOne({
+    where: { teamId: 'team_assoc' },
+    include: 'prMetrics',
+  });
+
+  assert.equal(binding.prMetrics.length, 1);
+  assert.equal(binding.prMetrics[0].prNumber, 142);
 });

--- a/backend/test/issue293-pr-metrics-persistence.test.js
+++ b/backend/test/issue293-pr-metrics-persistence.test.js
@@ -189,6 +189,60 @@ test('safely handles repeated PR metric submissions by updating existing rows', 
   assert.equal(storedMetrics[0].metricValue, 0.95);
 });
 
+test('rejects PR metrics for teams without an integration binding', async () => {
+  const { response, json } = await request('/internal/sprint-sync/pr-metrics', {
+    method: 'POST',
+    headers: internalHeaders(),
+    body: JSON.stringify({
+      teamId: 'missing-team',
+      sprintId: 'sprint_2026_03',
+      pullRequests: [
+        {
+          prNumber: 142,
+          metricName: 'reviewReadinessScore',
+          metricValue: 0.92,
+          unit: 'ratio',
+        },
+      ],
+    }),
+  });
+
+  assert.equal(response.status, 404);
+  assert.equal(json.code, 'INTEGRATION_BINDING_NOT_FOUND');
+});
+
+test('rejects duplicate PR metrics in the same payload', async () => {
+  await createTeamBinding();
+
+  const { response, json } = await request('/internal/sprint-sync/pr-metrics', {
+    method: 'POST',
+    headers: internalHeaders(),
+    body: JSON.stringify({
+      teamId: 'team_01HR9W2Q6NQ7G6M3K4J8',
+      sprintId: 'sprint_2026_03',
+      pullRequests: [
+        {
+          prNumber: 142,
+          metricName: 'reviewReadinessScore',
+          metricValue: 0.92,
+          unit: 'ratio',
+        },
+        {
+          prNumber: 142,
+          metricName: 'reviewReadinessScore',
+          metricValue: 0.95,
+          unit: 'ratio',
+        },
+      ],
+    }),
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(json.code, 'VALIDATION_ERROR');
+  assert.equal(json.message, 'Duplicate PR metrics in request payload');
+  assert.equal(await PrMetric.count(), 0);
+});
+
 test('requires internal API key for PR metric persistence', async () => {
   const { response, json } = await request('/internal/sprint-sync/pr-metrics', {
     method: 'POST',


### PR DESCRIPTION
 ## What changed

This PR hardens the sprint metric persistence flows for both story metrics and PR metrics.

It adds:
- explicit integration binding checks before persistence
- duplicate metric rejection within a single request payload
- more complete model coverage for foreign keys, eager loading, and not-empty validation
- persistence coverage for missing binding and duplicate payload scenarios

## Why it changed

The merged metric persistence work had two behavior gaps:
- unknown `teamId` values could fall through to a generic `500` instead of returning a proper client-facing error
- duplicate metrics within the same payload were handled implicitly by upsert, which made the result order-dependent and could mislead callers about what was actually stored

## Impact

- internal sprint-sync callers now receive a clear `404 INTEGRATION_BINDING_NOT_FOUND` when the team has no binding
- duplicate metric entries in one request are rejected with `400 VALIDATION_ERROR`
- tests now cover the relationship and validation cases that were previously missing

## Validation

```bash
env JWT_SECRET=test-backend-jwt-not-for-production node --test test/issue290-story-metrics-model.test.js test/issue292-pr-metrics-model.test.js
