### PR TITLE
add stale monitoring lifecycle

### DIFF
--- a/backend/controllers/sprintMonitoringController.js
+++ b/backend/controllers/sprintMonitoringController.js
@@ -1,4 +1,4 @@
-const { param, validationResult } = require('express-validator');
+const { param, query, validationResult } = require('express-validator');
 const {
   Group,
   IntegrationBinding,
@@ -14,6 +14,10 @@ const {
 const getSprintMonitoringSnapshotValidation = [
   param('teamId').isString().trim().notEmpty().withMessage('teamId is required'),
   param('sprintId').isString().trim().notEmpty().withMessage('sprintId is required'),
+  query('includeStale')
+    .optional()
+    .isBoolean()
+    .withMessage('includeStale must be a boolean'),
 ];
 
 async function getSprintMonitoringSnapshot(req, res) {
@@ -29,6 +33,7 @@ async function getSprintMonitoringSnapshot(req, res) {
   try {
     const teamId = req.params.teamId.trim();
     const sprintId = req.params.sprintId.trim();
+    const includeStale = String(req.query.includeStale || '').toLowerCase() === 'true';
 
     const group = await Group.findByPk(teamId);
     if (!group) {
@@ -59,11 +64,19 @@ async function getSprintMonitoringSnapshot(req, res) {
 
     const [stories, pullRequests] = await Promise.all([
       SprintStory.findAll({
-        where: { teamId, sprintId },
+        where: {
+          teamId,
+          sprintId,
+          ...(includeStale ? {} : { isActive: true }),
+        },
         order: [['issueKey', 'ASC']],
       }),
       SprintPullRequest.findAll({
-        where: { teamId, sprintId },
+        where: {
+          teamId,
+          sprintId,
+          ...(includeStale ? {} : { isActive: true }),
+        },
         order: [['prNumber', 'ASC']],
       }),
     ]);
@@ -81,6 +94,9 @@ async function getSprintMonitoringSnapshot(req, res) {
         title: pullRequest.title,
         prStatus: pullRequest.prStatus,
         mergeStatus: pullRequest.mergeStatus,
+        isActive: pullRequest.isActive,
+        lastSeenAt: pullRequest.lastSeenAt,
+        staleAt: pullRequest.staleAt,
         url: pullRequest.url,
       });
       prsByIssueKey.set(issueKey, existing);
@@ -98,6 +114,9 @@ async function getSprintMonitoringSnapshot(req, res) {
         reporterId: story.reporterId,
         status: story.status,
         storyPoints: story.storyPoints,
+        isActive: story.isActive,
+        lastSeenAt: story.lastSeenAt,
+        staleAt: story.staleAt,
         sourceCreatedAt: story.sourceCreatedAt,
         sourceUpdatedAt: story.sourceUpdatedAt,
         linkedPullRequests: prsByIssueKey.get(story.issueKey) || [],
@@ -110,6 +129,9 @@ async function getSprintMonitoringSnapshot(req, res) {
           title: pullRequest.title,
           prStatus: pullRequest.prStatus,
           mergeStatus: pullRequest.mergeStatus,
+          isActive: pullRequest.isActive,
+          lastSeenAt: pullRequest.lastSeenAt,
+          staleAt: pullRequest.staleAt,
           changedFiles: pullRequest.changedFiles,
           diffSummary: pullRequest.diffSummary,
           sourceCreatedAt: pullRequest.sourceCreatedAt,

--- a/backend/models/SprintPullRequest.js
+++ b/backend/models/SprintPullRequest.js
@@ -71,6 +71,19 @@ const SprintPullRequest = sequelize.define(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    isActive: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+    lastSeenAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    staleAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
   },
   {
     tableName: 'SprintPullRequests',
@@ -85,6 +98,9 @@ const SprintPullRequest = sequelize.define(
       },
       {
         fields: ['teamId', 'sprintId', 'relatedIssueKey'],
+      },
+      {
+        fields: ['teamId', 'sprintId', 'isActive'],
       },
     ],
   },

--- a/backend/models/SprintStory.js
+++ b/backend/models/SprintStory.js
@@ -58,6 +58,19 @@ const SprintStory = sequelize.define(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    isActive: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+    lastSeenAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    staleAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
   },
   {
     tableName: 'SprintStories',
@@ -69,6 +82,9 @@ const SprintStory = sequelize.define(
       },
       {
         fields: ['teamId', 'sprintId'],
+      },
+      {
+        fields: ['teamId', 'sprintId', 'isActive'],
       },
     ],
   },

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,8 @@ const sequelize = require('./db');
 const User = require('./models/User');
 const Professor = require('./models/Professor');
 const Group = require('./models/Group');
+const SprintPullRequest = require('./models/SprintPullRequest');
+const SprintStory = require('./models/SprintStory');
 const app = require('./app');
 require('./models');
 const { ensureValidStudentRegistry } = require('./services/studentService');
@@ -16,6 +18,10 @@ const ensureSqliteColumns = async () => {
   const professorAttributes = Professor.getAttributes();
   const groupTable = await queryInterface.describeTable('Groups');
   const groupAttributes = Group.getAttributes();
+  const sprintStoryTable = await queryInterface.describeTable('SprintStories');
+  const sprintStoryAttributes = SprintStory.getAttributes();
+  const sprintPullRequestTable = await queryInterface.describeTable('SprintPullRequests');
+  const sprintPullRequestAttributes = SprintPullRequest.getAttributes();
   const columnsToEnsure = [
     'studentId',
     'password',
@@ -74,6 +80,32 @@ const ensureSqliteColumns = async () => {
       defaultValue: attribute.defaultValue,
       unique: Boolean(attribute.unique),
     });
+  }
+
+  const sprintLifecycleColumnsToEnsure = [
+    'isActive',
+    'lastSeenAt',
+    'staleAt',
+  ];
+
+  for (const columnName of sprintLifecycleColumnsToEnsure) {
+    if (!sprintStoryTable[columnName]) {
+      const attribute = sprintStoryAttributes[columnName];
+      await queryInterface.addColumn('SprintStories', columnName, {
+        type: attribute.type,
+        allowNull: attribute.allowNull,
+        defaultValue: attribute.defaultValue,
+      });
+    }
+
+    if (!sprintPullRequestTable[columnName]) {
+      const attribute = sprintPullRequestAttributes[columnName];
+      await queryInterface.addColumn('SprintPullRequests', columnName, {
+        type: attribute.type,
+        allowNull: attribute.allowNull,
+        defaultValue: attribute.defaultValue,
+      });
+    }
   }
 };
 

--- a/backend/services/sprintMonitoringPersistenceService.js
+++ b/backend/services/sprintMonitoringPersistenceService.js
@@ -1,4 +1,5 @@
 const sequelize = require('../db');
+const { Op } = require('sequelize');
 const ApiError = require('../errors/apiError');
 const { SprintPullRequest, SprintStory } = require('../models');
 const { normalizeJiraIssue } = require('./jiraIssueNormalizer');
@@ -100,22 +101,50 @@ async function storeJiraIssues({ teamId, sprintId, issues }) {
     storyPoints: issue.storyPoints,
     sourceCreatedAt: issue.sourceCreatedAt,
     sourceUpdatedAt: issue.sourceUpdatedAt,
+    isActive: true,
+    lastSeenAt: new Date(),
+    staleAt: null,
   }));
 
   await sequelize.transaction(async (transaction) => {
-    await SprintStory.bulkCreate(storyRows, {
+    const syncedAt = new Date();
+    const currentIssueKeys = normalizedIssues.map((issue) => issue.issueKey);
+
+    if (storyRows.length > 0) {
+      await SprintStory.bulkCreate(storyRows.map((row) => ({
+        ...row,
+        lastSeenAt: syncedAt,
+      })), {
+        transaction,
+        updateOnDuplicate: [
+          'title',
+          'description',
+          'assigneeId',
+          'reporterId',
+          'status',
+          'storyPoints',
+          'sourceCreatedAt',
+          'sourceUpdatedAt',
+          'isActive',
+          'lastSeenAt',
+          'staleAt',
+          'updatedAt',
+        ],
+      });
+    }
+
+    await SprintStory.update({
+      isActive: false,
+      staleAt: syncedAt,
+    }, {
+      where: {
+        teamId,
+        sprintId,
+        ...(currentIssueKeys.length > 0
+          ? { issueKey: { [Op.notIn]: currentIssueKeys } }
+          : {}),
+      },
       transaction,
-      updateOnDuplicate: [
-        'title',
-        'description',
-        'assigneeId',
-        'reporterId',
-        'status',
-        'storyPoints',
-        'sourceCreatedAt',
-        'sourceUpdatedAt',
-        'updatedAt',
-      ],
     });
   });
 
@@ -194,26 +223,54 @@ async function storeGitHubPullRequests({ teamId, sprintId, pullRequests }) {
       sourceUpdatedAt: source.updated_at || source.updatedAt || null,
       sourceMergedAt: source.merged_at || source.mergedAt || null,
       url: source.html_url || source.url || null,
+      isActive: true,
+      lastSeenAt: new Date(),
+      staleAt: null,
     };
   });
 
   await sequelize.transaction(async (transaction) => {
-    await SprintPullRequest.bulkCreate(pullRequestRows, {
+    const syncedAt = new Date();
+    const currentPrNumbers = normalizedPullRequests.map((pullRequest) => pullRequest.prNumber);
+
+    if (pullRequestRows.length > 0) {
+      await SprintPullRequest.bulkCreate(pullRequestRows.map((row) => ({
+        ...row,
+        lastSeenAt: syncedAt,
+      })), {
+        transaction,
+        updateOnDuplicate: [
+          'relatedIssueKey',
+          'branchName',
+          'title',
+          'prStatus',
+          'mergeStatus',
+          'changedFiles',
+          'diffSummary',
+          'sourceCreatedAt',
+          'sourceUpdatedAt',
+          'sourceMergedAt',
+          'url',
+          'isActive',
+          'lastSeenAt',
+          'staleAt',
+          'updatedAt',
+        ],
+      });
+    }
+
+    await SprintPullRequest.update({
+      isActive: false,
+      staleAt: syncedAt,
+    }, {
+      where: {
+        teamId,
+        sprintId,
+        ...(currentPrNumbers.length > 0
+          ? { prNumber: { [Op.notIn]: currentPrNumbers } }
+          : {}),
+      },
       transaction,
-      updateOnDuplicate: [
-        'relatedIssueKey',
-        'branchName',
-        'title',
-        'prStatus',
-        'mergeStatus',
-        'changedFiles',
-        'diffSummary',
-        'sourceCreatedAt',
-        'sourceUpdatedAt',
-        'sourceMergedAt',
-        'url',
-        'updatedAt',
-      ],
     });
   });
 

--- a/backend/test/issue309-sprint-monitoring-snapshot.test.js
+++ b/backend/test/issue309-sprint-monitoring-snapshot.test.js
@@ -166,3 +166,98 @@ test('stores structured Jira and GitHub sprint monitoring data and returns linke
   assert.equal(snapshot.json.stories[0].linkedPullRequests[0].prNumber, 142);
   assert.equal(snapshot.json.unlinkedPullRequests.length, 0);
 });
+
+test('snapshot hides stale records by default and exposes them when includeStale=true', async () => {
+  const leader = await User.create({
+    email: 'monitoring-stale@example.edu',
+    fullName: 'Monitoring Stale Owner',
+    studentId: '11070003102',
+    role: 'STUDENT',
+    status: 'ACTIVE',
+    password: 'StrongPass1!',
+  });
+
+  await Group.create({
+    id: 'team-monitoring-stale',
+    name: 'Group team-monitoring-stale',
+    leaderId: String(leader.id),
+    memberIds: [String(leader.id)],
+    maxMembers: 4,
+  });
+
+  await IntegrationBinding.create({
+    teamId: 'team-monitoring-stale',
+    providerSet: ['GITHUB', 'JIRA'],
+    organizationName: 'acme-org',
+    repositoryName: 'senior-app',
+    jiraWorkspaceId: 'workspace-acme',
+    jiraProjectKey: 'SPM',
+    defaultBranch: 'main',
+    initiatedBy: String(leader.id),
+    status: 'ACTIVE',
+  });
+
+  await SprintStory.bulkCreate([
+    {
+      teamId: 'team-monitoring-stale',
+      sprintId: 'sprint-77',
+      issueKey: 'SPM-300',
+      title: 'Active story',
+      status: 'IN_PROGRESS',
+      isActive: true,
+      lastSeenAt: new Date(),
+      staleAt: null,
+    },
+    {
+      teamId: 'team-monitoring-stale',
+      sprintId: 'sprint-77',
+      issueKey: 'SPM-301',
+      title: 'Stale story',
+      status: 'DONE',
+      isActive: false,
+      lastSeenAt: new Date('2026-05-01T10:00:00Z'),
+      staleAt: new Date('2026-05-02T10:00:00Z'),
+    },
+  ]);
+
+  await SprintPullRequest.bulkCreate([
+    {
+      teamId: 'team-monitoring-stale',
+      sprintId: 'sprint-77',
+      prNumber: 300,
+      relatedIssueKey: null,
+      prStatus: 'OPEN',
+      mergeStatus: 'UNKNOWN',
+      isActive: true,
+      lastSeenAt: new Date(),
+      staleAt: null,
+    },
+    {
+      teamId: 'team-monitoring-stale',
+      sprintId: 'sprint-77',
+      prNumber: 301,
+      relatedIssueKey: null,
+      prStatus: 'CLOSED',
+      mergeStatus: 'NOT_MERGED',
+      isActive: false,
+      lastSeenAt: new Date('2026-05-01T10:00:00Z'),
+      staleAt: new Date('2026-05-02T10:00:00Z'),
+    },
+  ]);
+
+  const defaultSnapshot = await request('/api/v1/teams/team-monitoring-stale/sprints/sprint-77/monitoring', {
+    headers: await authHeadersFor(leader),
+  });
+  assert.equal(defaultSnapshot.response.status, 200);
+  assert.deepEqual(defaultSnapshot.json.stories.map((story) => story.issueKey), ['SPM-300']);
+  assert.deepEqual(defaultSnapshot.json.unlinkedPullRequests.map((pullRequest) => pullRequest.prNumber), [300]);
+
+  const staleSnapshot = await request('/api/v1/teams/team-monitoring-stale/sprints/sprint-77/monitoring?includeStale=true', {
+    headers: await authHeadersFor(leader),
+  });
+  assert.equal(staleSnapshot.response.status, 200);
+  assert.deepEqual(staleSnapshot.json.stories.map((story) => story.issueKey), ['SPM-300', 'SPM-301']);
+  assert.deepEqual(staleSnapshot.json.unlinkedPullRequests.map((pullRequest) => pullRequest.prNumber), [300, 301]);
+  assert.equal(staleSnapshot.json.stories[1].isActive, false);
+  assert.ok(staleSnapshot.json.stories[1].staleAt);
+});

--- a/backend/test/issue312-scheduled-sprint-monitoring-service.test.js
+++ b/backend/test/issue312-scheduled-sprint-monitoring-service.test.js
@@ -14,6 +14,10 @@ const {
   createScheduledSprintMonitoringRefresher,
   refreshAllTeamSprintMonitoring,
 } = require('../services/scheduledSprintMonitoringService');
+const {
+  storeGitHubPullRequests,
+  storeJiraIssues,
+} = require('../services/sprintMonitoringPersistenceService');
 
 const originalFetch = global.fetch;
 
@@ -184,6 +188,131 @@ test('scheduled refresher exposes config and can be disabled cleanly', async () 
   assert.equal(refresher.intervalMs, 5000);
   refresher.start();
   refresher.stop();
+});
+
+test('jira stories that disappear from upstream become inactive and reactivate when they return', async () => {
+  await IntegrationBinding.create({
+    teamId: 'team-story-lifecycle',
+    providerSet: ['JIRA'],
+    organizationName: 'acme-org',
+    repositoryName: 'senior-app-1',
+    jiraWorkspaceId: 'workspace-acme',
+    jiraProjectKey: 'SPM',
+    initiatedBy: 'student-1',
+    status: 'ACTIVE',
+  });
+
+  await storeJiraIssues({
+    teamId: 'team-story-lifecycle',
+    sprintId: 'sprint-1',
+    issues: [
+      {
+        issueKey: 'PROJ-1',
+        title: 'First issue',
+        status: 'IN_PROGRESS',
+        sprintId: 'sprint-1',
+      },
+      {
+        issueKey: 'PROJ-2',
+        title: 'Second issue',
+        status: 'DONE',
+        sprintId: 'sprint-1',
+      },
+    ],
+  });
+
+  await storeJiraIssues({
+    teamId: 'team-story-lifecycle',
+    sprintId: 'sprint-1',
+    issues: [
+      {
+        issueKey: 'PROJ-1',
+        title: 'First issue updated',
+        status: 'DONE',
+        sprintId: 'sprint-1',
+      },
+    ],
+  });
+
+  const staleStory = await SprintStory.findOne({
+    where: { teamId: 'team-story-lifecycle', sprintId: 'sprint-1', issueKey: 'PROJ-2' },
+  });
+  assert.equal(staleStory.isActive, false);
+  assert.ok(staleStory.staleAt);
+
+  await storeJiraIssues({
+    teamId: 'team-story-lifecycle',
+    sprintId: 'sprint-1',
+    issues: [
+      {
+        issueKey: 'PROJ-1',
+        title: 'First issue updated',
+        status: 'DONE',
+        sprintId: 'sprint-1',
+      },
+      {
+        issueKey: 'PROJ-2',
+        title: 'Second issue returns',
+        status: 'IN_PROGRESS',
+        sprintId: 'sprint-1',
+      },
+    ],
+  });
+
+  await staleStory.reload();
+  assert.equal(staleStory.isActive, true);
+  assert.ok(staleStory.lastSeenAt);
+  assert.equal(staleStory.staleAt, null);
+});
+
+test('github pull requests that disappear from upstream become inactive and reactivate when they return', async () => {
+  await IntegrationBinding.create({
+    teamId: 'team-pr-lifecycle',
+    providerSet: ['GITHUB'],
+    organizationName: 'acme-org',
+    repositoryName: 'senior-app-1',
+    jiraWorkspaceId: 'workspace-acme',
+    jiraProjectKey: 'SPM',
+    initiatedBy: 'student-1',
+    status: 'ACTIVE',
+  });
+
+  await storeGitHubPullRequests({
+    teamId: 'team-pr-lifecycle',
+    sprintId: 'sprint-1',
+    pullRequests: [
+      { prNumber: 12, title: 'PROJ-1 first', branchName: 'PROJ-1-first', prStatus: 'OPEN', mergeStatus: 'UNKNOWN' },
+      { prNumber: 15, title: 'PROJ-2 second', branchName: 'PROJ-2-second', prStatus: 'OPEN', mergeStatus: 'UNKNOWN' },
+    ],
+  });
+
+  await storeGitHubPullRequests({
+    teamId: 'team-pr-lifecycle',
+    sprintId: 'sprint-1',
+    pullRequests: [
+      { prNumber: 12, title: 'PROJ-1 first', branchName: 'PROJ-1-first', prStatus: 'MERGED', mergeStatus: 'MERGED' },
+    ],
+  });
+
+  const stalePullRequest = await SprintPullRequest.findOne({
+    where: { teamId: 'team-pr-lifecycle', sprintId: 'sprint-1', prNumber: 15 },
+  });
+  assert.equal(stalePullRequest.isActive, false);
+  assert.ok(stalePullRequest.staleAt);
+
+  await storeGitHubPullRequests({
+    teamId: 'team-pr-lifecycle',
+    sprintId: 'sprint-1',
+    pullRequests: [
+      { prNumber: 12, title: 'PROJ-1 first', branchName: 'PROJ-1-first', prStatus: 'MERGED', mergeStatus: 'MERGED' },
+      { prNumber: 15, title: 'PROJ-2 second returns', branchName: 'PROJ-2-second', prStatus: 'OPEN', mergeStatus: 'UNKNOWN' },
+    ],
+  });
+
+  await stalePullRequest.reload();
+  assert.equal(stalePullRequest.isActive, true);
+  assert.ok(stalePullRequest.lastSeenAt);
+  assert.equal(stalePullRequest.staleAt, null);
 });
 
 test('scheduled refresh bulk-loads token references for active bindings', async () => {


### PR DESCRIPTION
## What changed
This PR adds stale lifecycle tracking for sprint monitoring records so JIRA stories and GitHub pull requests no longer behave like append-only sync artifacts.

## Why it changed
Live sync and scheduled refresh were already able to add and update monitoring records, but records that disappeared from upstream remained visible as if they were still current. That made snapshots drift away from the real sprint state over time.

## Main updates
- Added `isActive`, `lastSeenAt`, and `staleAt` to sprint story and sprint pull request monitoring records
- Updated monitoring persistence so upstream-present records are marked active and upstream-missing records are marked stale instead of being hard-deleted
- Added reactivation behavior when a previously stale story or pull request appears again in a later sync
- Updated the monitoring snapshot endpoint to hide stale records by default
- Added `includeStale=true` support on the monitoring snapshot endpoint for debug visibility
- Extended runtime SQLite column ensuring so existing local databases gain the new lifecycle columns automatically
- Added focused tests for stale lifecycle transitions and snapshot filtering

## Impact
Monitoring data is now safer and more accurate over time. The system keeps historical records for debugging and audit purposes, while default snapshots show only currently active sprint data.

## Validation
- Ran `node --check` on updated models, persistence service, snapshot controller, and server entrypoint
- Ran `env JWT_SECRET=test-backend-jwt-not-for-production node --test backend/test/issue312-scheduled-sprint-monitoring-service.test.js`

## Notes
This PR intentionally uses soft lifecycle tracking instead of deleting disappeared upstream records. Snapshot consumers can opt into stale visibility with `includeStale=true`.
