### PR TITLE
add monitoring sync summary UI

### DIFF
--- a/frontend/src/IntegrationConfigurationPage.jsx
+++ b/frontend/src/IntegrationConfigurationPage.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { useAuth } from './contexts/AuthContext';
 import apiClient from './services/apiClient';
+import { getSprintMonitoringSnapshot } from './services/sprintMonitoring';
 
 const EMPTY_FORM = {
   providerSet: ['GITHUB', 'JIRA'],
@@ -57,6 +58,14 @@ function getDisplayStatus(configuration) {
     return 'Not Connected';
   }
 
+  if (configuration.status === 'INVALID') {
+    return 'Invalid';
+  }
+
+  if (configuration.status === 'PENDING_REAUTH') {
+    return 'Re-auth Required';
+  }
+
   if (configuration.status === 'PARTIAL') {
     return 'Partial';
   }
@@ -64,8 +73,105 @@ function getDisplayStatus(configuration) {
   return 'Connected';
 }
 
+function getMonitoringWarnings(configuration) {
+  if (!configuration) {
+    return [];
+  }
+
+  if (configuration.status === 'PENDING_REAUTH') {
+    return ['Integration requires re-authentication.'];
+  }
+
+  if (configuration.status === 'INVALID') {
+    return ['Integration configuration looks invalid. Verify the repository, workspace, and project settings.'];
+  }
+
+  if (configuration.status !== 'PARTIAL') {
+    return [];
+  }
+
+  const warnings = [];
+
+  if (configuration.providerSet?.includes('JIRA') && !configuration.hasJiraTokenRef) {
+    warnings.push('JIRA token missing.');
+  }
+
+  if (configuration.providerSet?.includes('GITHUB') && !configuration.hasGithubTokenRef) {
+    warnings.push('GitHub token missing.');
+  }
+
+  if (!warnings.length) {
+    warnings.push('Integration is partially configured.');
+  }
+
+  return warnings;
+}
+
+function flattenLinkedPullRequests(stories = []) {
+  return stories.flatMap((story) => story.linkedPullRequests || []);
+}
+
+function buildMonitoringSummary(snapshot) {
+  if (!snapshot) {
+    return null;
+  }
+
+  const stories = Array.isArray(snapshot.stories) ? snapshot.stories : [];
+  const linkedPullRequests = flattenLinkedPullRequests(stories);
+  const unlinkedPullRequests = Array.isArray(snapshot.unlinkedPullRequests) ? snapshot.unlinkedPullRequests : [];
+  const allPullRequests = [...linkedPullRequests, ...unlinkedPullRequests];
+
+  const activeStories = stories.filter((story) => story.isActive !== false);
+  const activePullRequests = allPullRequests.filter((pullRequest) => pullRequest.isActive !== false);
+  const activeLinkedPullRequests = linkedPullRequests.filter((pullRequest) => pullRequest.isActive !== false);
+
+  const lastSeenValues = [
+    ...stories.map((story) => story.lastSeenAt).filter(Boolean),
+    ...allPullRequests.map((pullRequest) => pullRequest.lastSeenAt).filter(Boolean),
+  ];
+
+  const latestSeenAt = lastSeenValues.reduce((currentLatest, candidate) => {
+    if (!candidate) {
+      return currentLatest;
+    }
+
+    if (!currentLatest) {
+      return candidate;
+    }
+
+    return new Date(candidate).getTime() > new Date(currentLatest).getTime() ? candidate : currentLatest;
+  }, '');
+
+  return {
+    lastSyncTime: latestSeenAt || '',
+    activeStoryCount: activeStories.length,
+    activePullRequestCount: activePullRequests.length,
+    matchedPullRequestCount: activeLinkedPullRequests.length,
+    mergedPullRequestCount: activeLinkedPullRequests.filter((pullRequest) => String(pullRequest.mergeStatus || '').toLowerCase() === 'merged').length,
+    staleRecordCount: stories.filter((story) => story.isActive === false).length
+      + allPullRequests.filter((pullRequest) => pullRequest.isActive === false).length,
+  };
+}
+
+function formatDateTime(value) {
+  if (!value) {
+    return 'Not synced yet';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Not synced yet';
+  }
+
+  return new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
 export default function IntegrationConfigurationPage() {
   const { teamId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { user } = useAuth();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -73,6 +179,11 @@ export default function IntegrationConfigurationPage() {
   const [form, setForm] = useState({ ...EMPTY_FORM });
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const [monitoringLoading, setMonitoringLoading] = useState(false);
+  const [monitoringSnapshot, setMonitoringSnapshot] = useState(null);
+  const [monitoringError, setMonitoringError] = useState('');
+
+  const selectedSprintId = searchParams.get('sprintId') || '';
 
   useEffect(() => {
     let isMounted = true;
@@ -121,11 +232,85 @@ export default function IntegrationConfigurationPage() {
     };
   }, [teamId]);
 
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadMonitoringSummary() {
+      if (!selectedSprintId) {
+        setMonitoringSnapshot(null);
+        setMonitoringError('');
+        setMonitoringLoading(false);
+        return;
+      }
+
+      try {
+        setMonitoringLoading(true);
+        setMonitoringError('');
+        const { data } = await getSprintMonitoringSnapshot(teamId, selectedSprintId, { includeStale: true });
+        if (!isMounted) {
+          return;
+        }
+
+        setMonitoringSnapshot(data);
+      } catch (loadError) {
+        if (!isMounted) {
+          return;
+        }
+
+        setMonitoringSnapshot(null);
+        setMonitoringError(loadError.response?.data?.message || loadError.message || 'Failed to load monitoring summary.');
+      } finally {
+        if (isMounted) {
+          setMonitoringLoading(false);
+        }
+      }
+    }
+
+    loadMonitoringSummary();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [teamId, selectedSprintId]);
+
+  async function refreshMonitoringSummary() {
+    if (!selectedSprintId) {
+      setMonitoringSnapshot(null);
+      setMonitoringError('');
+      return;
+    }
+
+    try {
+      setMonitoringLoading(true);
+      setMonitoringError('');
+      const { data } = await getSprintMonitoringSnapshot(teamId, selectedSprintId, { includeStale: true });
+      setMonitoringSnapshot(data);
+    } catch (loadError) {
+      setMonitoringSnapshot(null);
+      setMonitoringError(loadError.response?.data?.message || loadError.message || 'Failed to load monitoring summary.');
+    } finally {
+      setMonitoringLoading(false);
+    }
+  }
+
   function updateField(name, value) {
     setForm((current) => ({
       ...current,
       [name]: value,
     }));
+  }
+
+  function handleSprintIdChange(value) {
+    const nextValue = value.trim();
+    const nextParams = new URLSearchParams(searchParams);
+
+    if (nextValue) {
+      nextParams.set('sprintId', nextValue);
+    } else {
+      nextParams.delete('sprintId');
+    }
+
+    setSearchParams(nextParams, { replace: true });
   }
 
   async function handleSubmit(event) {
@@ -160,6 +345,10 @@ export default function IntegrationConfigurationPage() {
       setConfiguration(data);
       setForm(buildFormState(data));
       setSuccess('Integration settings saved successfully.');
+
+      if (selectedSprintId) {
+        await refreshMonitoringSummary();
+      }
     } catch (saveError) {
       setError(saveError.response?.data?.message || saveError.message || 'Failed to save integration settings.');
     } finally {
@@ -181,6 +370,11 @@ export default function IntegrationConfigurationPage() {
 
   const providerRows = buildProviderRows(configuration);
   const displayStatus = getDisplayStatus(configuration);
+  const monitoringWarnings = getMonitoringWarnings(configuration);
+  const monitoringSummary = buildMonitoringSummary(monitoringSnapshot);
+  const hasMonitoringData = monitoringSummary
+    ? (monitoringSummary.activeStoryCount + monitoringSummary.activePullRequestCount + monitoringSummary.staleRecordCount) > 0
+    : false;
 
   return (
     <main className="page page-group-view">
@@ -244,6 +438,86 @@ export default function IntegrationConfigurationPage() {
               </article>
             ))}
           </div>
+        </div>
+
+        <div className="group-details-summary">
+          <h3>Monitoring Status / Sync Summary</h3>
+          <label className="field">
+            <span>Sprint ID</span>
+            <input
+              value={selectedSprintId}
+              onChange={(event) => handleSprintIdChange(event.target.value)}
+              placeholder="sprint_2026_03"
+            />
+          </label>
+
+          {monitoringWarnings.length > 0 && (
+            <div className="feedback feedback-error">
+              <div className="feedback-label">warning</div>
+              {monitoringWarnings.map((warning) => (
+                <p key={warning}>{warning}</p>
+              ))}
+            </div>
+          )}
+
+          {monitoringLoading && (
+            <div className="feedback feedback-loading">
+              <div className="feedback-label">loading</div>
+              <p>Fetching monitoring summary for this sprint.</p>
+            </div>
+          )}
+
+          {!monitoringLoading && monitoringError && (
+            <div className="feedback feedback-error">
+              <div className="feedback-label">error</div>
+              <p>{monitoringError}</p>
+            </div>
+          )}
+
+          {!monitoringLoading && !monitoringError && !selectedSprintId && (
+            <div className="feedback">
+              <div className="feedback-label">summary</div>
+              <p>Enter a sprint ID to load monitoring visibility for this team.</p>
+            </div>
+          )}
+
+          {!monitoringLoading && !monitoringError && selectedSprintId && !hasMonitoringData && (
+            <div className="feedback">
+              <div className="feedback-label">empty</div>
+              <p>No monitoring data exists for this sprint yet.</p>
+            </div>
+          )}
+
+          {!monitoringLoading && !monitoringError && selectedSprintId && hasMonitoringData && monitoringSummary && (
+            <div className="group-summary-grid">
+              <div className="group-summary-item">
+                <span>Last Sync Time</span>
+                <strong>{formatDateTime(monitoringSummary.lastSyncTime)}</strong>
+              </div>
+              <div className="group-summary-item">
+                <span>Synced JIRA Stories</span>
+                <strong>{monitoringSummary.activeStoryCount}</strong>
+              </div>
+              <div className="group-summary-item">
+                <span>Synced GitHub PRs</span>
+                <strong>{monitoringSummary.activePullRequestCount}</strong>
+              </div>
+              <div className="group-summary-item">
+                <span>Matched PRs</span>
+                <strong>{monitoringSummary.matchedPullRequestCount}</strong>
+              </div>
+              <div className="group-summary-item">
+                <span>Merged PRs</span>
+                <strong>{monitoringSummary.mergedPullRequestCount}</strong>
+              </div>
+              {monitoringSummary.staleRecordCount > 0 && (
+                <div className="group-summary-item">
+                  <span>Stale Records</span>
+                  <strong>{monitoringSummary.staleRecordCount}</strong>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </section>
 

--- a/frontend/src/components/__tests__/issue308-SprintMonitoringFlows.test.jsx
+++ b/frontend/src/components/__tests__/issue308-SprintMonitoringFlows.test.jsx
@@ -11,9 +11,9 @@ jest.mock('../../contexts/AuthContext', () => ({
   }),
 }));
 
-function renderIntegrationPage(teamId = 'team-1') {
+function renderIntegrationPage(teamId = 'team-1', search = '') {
   return render(
-    <MemoryRouter initialEntries={[`/students/groups/${teamId}/integrations`]}>
+    <MemoryRouter initialEntries={[`/students/groups/${teamId}/integrations${search}`]}>
       <Routes>
         <Route path="/students/groups/:teamId/integrations" element={<IntegrationConfigurationPage />} />
       </Routes>
@@ -84,6 +84,93 @@ describe('Sprint monitoring frontend flows (issue #308)', () => {
     expect(screen.queryByDisplayValue('vault://jira/team-1')).not.toBeInTheDocument();
   });
 
+  test('integration configuration UI shows monitoring sync summary for a selected sprint', async () => {
+    apiClient.get
+      .mockResolvedValueOnce({
+        data: {
+          bindingId: 'binding-1',
+          teamId: 'team-1',
+          providerSet: ['GITHUB', 'JIRA'],
+          organizationName: 'acme-org',
+          repositoryName: 'senior-app',
+          jiraProjectKey: 'SPM',
+          defaultBranch: 'main',
+          status: 'ACTIVE',
+          hasGithubTokenRef: true,
+          hasJiraTokenRef: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          teamId: 'team-1',
+          sprintId: 'sprint-42',
+          integration: {
+            status: 'ACTIVE',
+          },
+          stories: [
+            {
+              issueKey: 'SPM-1',
+              isActive: true,
+              lastSeenAt: '2026-04-01T10:00:00.000Z',
+              linkedPullRequests: [
+                {
+                  prNumber: 12,
+                  mergeStatus: 'merged',
+                  isActive: true,
+                  lastSeenAt: '2026-04-01T10:05:00.000Z',
+                },
+              ],
+            },
+            {
+              issueKey: 'SPM-2',
+              isActive: true,
+              lastSeenAt: '2026-04-01T09:00:00.000Z',
+              linkedPullRequests: [
+                {
+                  prNumber: 15,
+                  mergeStatus: 'open',
+                  isActive: true,
+                  lastSeenAt: '2026-04-01T09:10:00.000Z',
+                },
+              ],
+            },
+            {
+              issueKey: 'SPM-3',
+              isActive: false,
+              lastSeenAt: '2026-03-31T11:00:00.000Z',
+              linkedPullRequests: [],
+            },
+          ],
+          unlinkedPullRequests: [
+            {
+              prNumber: 99,
+              isActive: true,
+              lastSeenAt: '2026-04-01T08:00:00.000Z',
+            },
+            {
+              prNumber: 98,
+              isActive: false,
+              lastSeenAt: '2026-03-31T08:00:00.000Z',
+            },
+          ],
+        },
+      });
+
+    renderIntegrationPage('team-1', '?sprintId=sprint-42');
+
+    expect(await screen.findByRole('heading', { name: /integration configuration/i })).toBeInTheDocument();
+    expect(await screen.findByText(/monitoring status \/ sync summary/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue('sprint-42')).toBeInTheDocument();
+    expect(screen.getByText(/synced jira stories/i).closest('.group-summary-item')).toHaveTextContent('2');
+    expect(screen.getByText(/synced github prs/i).closest('.group-summary-item')).toHaveTextContent('3');
+    expect(screen.getByText(/matched prs/i).closest('.group-summary-item')).toHaveTextContent('2');
+    expect(screen.getByText(/merged prs/i).closest('.group-summary-item')).toHaveTextContent('1');
+    expect(screen.getByText(/stale records/i).closest('.group-summary-item')).toHaveTextContent('2');
+    expect(screen.getByText(/stale records/i)).toBeInTheDocument();
+    expect(screen.getByText(/last sync time/i).closest('.group-summary-item')).toHaveTextContent(/Apr 2026/i);
+    expect(apiClient.get).toHaveBeenNthCalledWith(2, '/v1/teams/team-1/sprints/sprint-42/monitoring?includeStale=true');
+  });
+
   test('integration configuration UI shows loading and empty configuration states', async () => {
     const deferred = createDeferred();
     apiClient.get.mockReturnValueOnce(deferred.promise);
@@ -131,6 +218,56 @@ describe('Sprint monitoring frontend flows (issue #308)', () => {
 
     expect(await screen.findByText(/api unavailable/i)).toBeInTheDocument();
     expect(screen.getByText(/api unavailable/i)).toBeInTheDocument();
+  });
+
+  test('integration configuration UI shows monitoring empty and error states', async () => {
+    apiClient.get
+      .mockResolvedValueOnce({
+        data: {
+          teamId: 'team-5',
+          providerSet: ['GITHUB', 'JIRA'],
+          organizationName: 'acme-org',
+          repositoryName: 'senior-app',
+          jiraProjectKey: 'SPM',
+          status: 'PARTIAL',
+          hasGithubTokenRef: true,
+          hasJiraTokenRef: false,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          teamId: 'team-5',
+          sprintId: 'sprint-empty',
+          stories: [],
+          unlinkedPullRequests: [],
+        },
+      });
+
+    const { unmount } = renderIntegrationPage('team-5', '?sprintId=sprint-empty');
+
+    expect(await screen.findByText(/jira token missing/i)).toBeInTheDocument();
+    expect(await screen.findByText(/no monitoring data exists for this sprint yet/i)).toBeInTheDocument();
+
+    unmount();
+
+    apiClient.get
+      .mockResolvedValueOnce({
+        data: {
+          teamId: 'team-6',
+          providerSet: ['GITHUB', 'JIRA'],
+          organizationName: 'acme-org',
+          repositoryName: 'senior-app',
+          jiraProjectKey: 'SPM',
+          status: 'ACTIVE',
+          hasGithubTokenRef: true,
+          hasJiraTokenRef: true,
+        },
+      })
+      .mockRejectedValueOnce(new Error('Monitoring unavailable'));
+
+    renderIntegrationPage('team-6', '?sprintId=sprint-err');
+
+    expect(await screen.findByText(/monitoring unavailable/i)).toBeInTheDocument();
   });
 
   test('integration configuration UI clears stale team data when a new team load fails', async () => {

--- a/frontend/src/services/sprintMonitoring.js
+++ b/frontend/src/services/sprintMonitoring.js
@@ -1,0 +1,12 @@
+import apiClient from './apiClient';
+
+export async function getSprintMonitoringSnapshot(teamId, sprintId, options = {}) {
+  const params = new URLSearchParams();
+  if (options.includeStale) {
+    params.set('includeStale', 'true');
+  }
+
+  const query = params.toString();
+  const suffix = query ? `?${query}` : '';
+  return apiClient.get(`/v1/teams/${teamId}/sprints/${sprintId}/monitoring${suffix}`);
+}


### PR DESCRIPTION
## What changed
This PR extends the student/team leader integration configuration page with read-only monitoring visibility based on the sprint monitoring snapshot endpoint.

## Main updates
- Added a Monitoring Status / Sync Summary section under Configuration Summary
- Added a small frontend service for `/v1/teams/:teamId/sprints/:sprintId/monitoring`
- Added sprint-specific monitoring summary metrics:
  - last sync time
  - synced JIRA story count
  - synced GitHub PR count
  - matched PR count
  - merged PR count
  - stale record count when present
- Added warning, loading, empty, and error states for monitoring visibility
- Kept token references hidden from the UI
- Added frontend tests covering monitoring summary, empty state, and error state

## Why it changed
The integration page previously showed only saved configuration. This update makes it possible to see whether monitoring data actually exists for a selected sprint without adding evaluation or grading features.

## Validation
- Ran `npm --prefix frontend test -- issue308-SprintMonitoringFlows.test.jsx`
- Result: 7 tests passed
