### PR TITLE
[codex] fix jira search jql sync

### DIFF
--- a/backend/services/jiraRequestBuilder.js
+++ b/backend/services/jiraRequestBuilder.js
@@ -199,7 +199,7 @@ function buildJiraProjectOpenSprintIssuesRequest({ projectKey, includeStatuses =
     : '';
 
   return buildJiraRequest({
-    path: '/rest/api/3/search',
+    path: '/rest/api/3/search/jql',
     method: 'POST',
     body: {
       jql: `project = "${escapeJqlString(normalizedProjectKey)}" AND sprint in openSprints()${statusClause}`,

--- a/backend/services/jiraSprintSyncService.js
+++ b/backend/services/jiraSprintSyncService.js
@@ -165,8 +165,15 @@ async function fetchJiraSprintIssues({
         ? payload.nextPageToken
         : null;
       const isLast = payload?.isLast === true;
-      if (pageIssues.length === 0 || isLast || !resolvedNextPageToken) {
+      if (pageIssues.length === 0 || isLast) {
         break;
+      }
+      if (!resolvedNextPageToken) {
+        throw new ApiError(
+          502,
+          'JIRA_UPSTREAM_INVALID_PAGINATION',
+          'Jira cursor pagination response omitted nextPageToken before the last page',
+        );
       }
 
       nextPageToken = resolvedNextPageToken;

--- a/backend/services/jiraSprintSyncService.js
+++ b/backend/services/jiraSprintSyncService.js
@@ -58,7 +58,8 @@ async function parseErrorResponse(response) {
   }
 }
 
-function buildPaginatedJiraRequest(request, startAt) {
+function buildPaginatedJiraRequest(request, pagination = {}) {
+  const { startAt = 0, nextPageToken = null } = pagination;
   const paginatedOptions = {
     ...request.options,
     headers: {
@@ -68,12 +69,25 @@ function buildPaginatedJiraRequest(request, startAt) {
 
   if (paginatedOptions.body !== undefined) {
     const body = JSON.parse(paginatedOptions.body);
-    body.startAt = startAt;
+    const usesCursorPagination = String(request.url).includes('/rest/api/3/search/jql');
+
+    if (usesCursorPagination) {
+      if (nextPageToken) {
+        body.nextPageToken = nextPageToken;
+      } else {
+        delete body.nextPageToken;
+      }
+      delete body.startAt;
+    } else {
+      body.startAt = startAt;
+    }
+
     paginatedOptions.body = JSON.stringify(body);
     return {
       url: request.url,
       options: paginatedOptions,
       maxResults: Number.isInteger(body.maxResults) && body.maxResults > 0 ? body.maxResults : 100,
+      usesCursorPagination,
     };
   }
 
@@ -85,6 +99,7 @@ function buildPaginatedJiraRequest(request, startAt) {
     url: url.toString(),
     options: paginatedOptions,
     maxResults: Number.isInteger(maxResults) && maxResults > 0 ? maxResults : 100,
+    usesCursorPagination: false,
   };
 }
 
@@ -126,9 +141,10 @@ async function fetchJiraSprintIssues({
 
   const issues = [];
   let startAt = 0;
+  let nextPageToken = null;
 
   while (issues.length < MAX_JIRA_ISSUES_PER_SYNC) {
-    const paginatedRequest = buildPaginatedJiraRequest(request, startAt);
+    const paginatedRequest = buildPaginatedJiraRequest(request, { startAt, nextPageToken });
     const response = await getFetchImplementation()(paginatedRequest.url, paginatedRequest.options);
     if (!response.ok) {
       const errorPayload = await parseErrorResponse(response);
@@ -143,6 +159,19 @@ async function fetchJiraSprintIssues({
     const payload = await response.json();
     const pageIssues = Array.isArray(payload?.issues) ? payload.issues : [];
     issues.push(...pageIssues);
+
+    if (paginatedRequest.usesCursorPagination) {
+      const resolvedNextPageToken = typeof payload?.nextPageToken === 'string' && payload.nextPageToken
+        ? payload.nextPageToken
+        : null;
+      const isLast = payload?.isLast === true;
+      if (pageIssues.length === 0 || isLast || !resolvedNextPageToken) {
+        break;
+      }
+
+      nextPageToken = resolvedNextPageToken;
+      continue;
+    }
 
     const total = Number.isInteger(payload?.total) && payload.total >= 0
       ? payload.total

--- a/backend/test/issue283-jira-request-builder.test.js
+++ b/backend/test/issue283-jira-request-builder.test.js
@@ -26,7 +26,7 @@ test('builds Jira basic auth headers from explicit credentials', async () => {
 
 test('builds configurable Jira requests with query params and JSON body', async () => {
   const request = buildJiraRequest({
-    path: '/rest/api/3/search',
+    path: '/rest/api/3/search/jql',
     method: 'post',
     query: {
       expand: 'names',
@@ -48,7 +48,7 @@ test('builds configurable Jira requests with query params and JSON body', async 
 
   const url = new URL(request.url);
   assert.equal(url.origin, 'https://acme.atlassian.net');
-  assert.equal(url.pathname, '/rest/api/3/search');
+  assert.equal(url.pathname, '/rest/api/3/search/jql');
   assert.deepEqual(url.searchParams.getAll('fields'), ['summary', 'status']);
   assert.equal(url.searchParams.get('expand'), 'names');
   assert.equal(url.searchParams.get('maxResults'), '50');
@@ -124,7 +124,7 @@ test('builds open sprint issue search requests from Jira project key for schedul
     maxResults: 25,
   });
 
-  assert.equal(request.url, 'https://acme.atlassian.net/rest/api/3/search');
+  assert.equal(request.url, 'https://acme.atlassian.net/rest/api/3/search/jql');
   assert.equal(request.options.method, 'POST');
   assert.equal(request.mock, false);
 

--- a/backend/test/issue312-scheduled-sprint-monitoring-service.test.js
+++ b/backend/test/issue312-scheduled-sprint-monitoring-service.test.js
@@ -209,6 +209,7 @@ test('scheduled refresh follows Jira search/jql cursor pagination using nextPage
       assert.equal(new URL(normalizedUrl).pathname, '/rest/api/3/search/jql');
       assert.match(String(options?.headers?.Authorization || ''), /^Basic /);
       const requestBody = JSON.parse(String(options?.body || '{}'));
+      assert.equal('startAt' in requestBody, false);
       seenPageTokens.push(requestBody.nextPageToken || null);
 
       if (requestBody.nextPageToken === 'cursor-page-2') {

--- a/backend/test/issue312-scheduled-sprint-monitoring-service.test.js
+++ b/backend/test/issue312-scheduled-sprint-monitoring-service.test.js
@@ -73,7 +73,8 @@ test('scheduled refresh synchronizes active sprint Jira issues and matching GitH
   global.fetch = async (url, options = {}) => {
     const normalizedUrl = String(url);
 
-    if (normalizedUrl.includes('/rest/api/3/search')) {
+    if (normalizedUrl.includes('/rest/api/3/search/jql')) {
+      assert.equal(new URL(normalizedUrl).pathname, '/rest/api/3/search/jql');
       assert.match(String(options?.headers?.Authorization || ''), /^Basic /);
       return {
         ok: true,
@@ -174,6 +175,168 @@ test('scheduled refresh synchronizes active sprint Jira issues and matching GitH
   assert.equal(result.results[0].sprintCount, 1);
   assert.equal(result.results[0].sprintSummaries[0].sprintId, 'sprint-open-1');
   assert.equal(await SprintStory.count(), 1);
+  assert.equal(await SprintPullRequest.count(), 1);
+});
+
+test('scheduled refresh follows Jira search/jql cursor pagination using nextPageToken', async () => {
+  await IntegrationBinding.create({
+    teamId: 'team-scheduler-cursor',
+    providerSet: ['GITHUB', 'JIRA'],
+    organizationName: 'acme-org',
+    repositoryName: 'senior-app-1',
+    jiraWorkspaceId: 'workspace-acme',
+    jiraProjectKey: 'SPM',
+    defaultBranch: 'main',
+    initiatedBy: 'student-1',
+    status: 'ACTIVE',
+  });
+
+  await IntegrationTokenReference.create({
+    teamId: 'team-scheduler-cursor',
+    jiraTokenRef: 'vault://jira/team-scheduler-cursor',
+    githubTokenRef: 'vault://github/team-scheduler-cursor',
+  });
+
+  setTokenEnv('JIRA_TOKEN_REF', 'vault://jira/team-scheduler-cursor', 'jira-secret');
+  setTokenEnv('GITHUB_TOKEN_REF', 'vault://github/team-scheduler-cursor', 'github-secret');
+
+  const seenPageTokens = [];
+
+  global.fetch = async (url, options = {}) => {
+    const normalizedUrl = String(url);
+
+    if (normalizedUrl.includes('/rest/api/3/search/jql')) {
+      assert.equal(new URL(normalizedUrl).pathname, '/rest/api/3/search/jql');
+      assert.match(String(options?.headers?.Authorization || ''), /^Basic /);
+      const requestBody = JSON.parse(String(options?.body || '{}'));
+      seenPageTokens.push(requestBody.nextPageToken || null);
+
+      if (requestBody.nextPageToken === 'cursor-page-2') {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({
+            issues: [
+              {
+                key: 'SPM-215',
+                fields: {
+                  summary: 'Cursor pagination second page',
+                  status: { name: 'Done' },
+                  assignee: { accountId: 'student-12' },
+                  reporter: { accountId: 'advisor-3' },
+                  customfield_10016: 3,
+                  customfield_10020: [{ id: 'sprint-open-2', state: 'active' }],
+                },
+              },
+            ],
+            isLast: true,
+          }),
+        };
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({
+          issues: [
+            {
+              key: 'SPM-214',
+              fields: {
+                summary: 'Cursor pagination first page',
+                status: { name: 'In Progress' },
+                assignee: { accountId: 'student-11' },
+                reporter: { accountId: 'advisor-2' },
+                customfield_10016: 5,
+                customfield_10020: [{ id: 'sprint-open-2', state: 'active' }],
+              },
+            },
+          ],
+          nextPageToken: 'cursor-page-2',
+          isLast: false,
+        }),
+      };
+    }
+
+    if (normalizedUrl.endsWith('/pulls?state=all&per_page=100&page=1')) {
+      assert.match(String(options?.headers?.Authorization || ''), /^token /);
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ([
+          {
+            number: 43,
+            title: 'SPM-214 Cursor pagination PR',
+            body: 'Implements monitoring flow',
+            head: { ref: 'SPM-214-cursor-pagination' },
+          },
+        ]),
+      };
+    }
+
+    if (normalizedUrl.endsWith('/pulls?state=all&per_page=100&page=2')) {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ([]),
+      };
+    }
+
+    if (normalizedUrl.endsWith('/pulls/43')) {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({
+          number: 43,
+          title: 'SPM-214 Cursor pagination PR',
+          body: 'Implements monitoring flow',
+          state: 'open',
+          merged: false,
+          mergeable_state: 'clean',
+          head: { ref: 'SPM-214-cursor-pagination' },
+          html_url: 'https://github.com/acme-org/senior-app-1/pull/43',
+          created_at: '2026-05-02T10:00:00Z',
+          updated_at: '2026-05-02T10:30:00Z',
+          merged_at: null,
+          additions: 8,
+          deletions: 1,
+          changed_files: 1,
+        }),
+      };
+    }
+
+    if (normalizedUrl.endsWith('/pulls/43/files?per_page=100')) {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ([
+          {
+            filename: 'backend/services/jiraSprintSyncService.js',
+            status: 'modified',
+            additions: 8,
+            deletions: 1,
+            changes: 9,
+          },
+        ]),
+      };
+    }
+
+    throw new Error(`Unexpected fetch URL: ${normalizedUrl}`);
+  };
+
+  const result = await refreshAllTeamSprintMonitoring();
+
+  assert.equal(result.teamCount, 1);
+  assert.equal(result.results[0].teamId, 'team-scheduler-cursor');
+  assert.equal(result.results[0].sprintCount, 1);
+  assert.equal(result.results[0].sprintSummaries[0].sprintId, 'sprint-open-2');
+  assert.deepEqual(seenPageTokens, [null, 'cursor-page-2']);
+  assert.equal(await SprintStory.count(), 2);
   assert.equal(await SprintPullRequest.count(), 1);
 });
 


### PR DESCRIPTION
## What changed
- switched scheduled Jira open-sprint search from the removed `/rest/api/3/search` endpoint to `/rest/api/3/search/jql`
- updated Jira pagination handling to support cursor-based `nextPageToken` responses on the new search endpoint
- refreshed the Jira request-builder tests to assert the new endpoint and request shape

## Why
Jira Cloud removed the legacy search endpoint, which caused sprint monitoring refreshes to fail with `410 JIRA_UPSTREAM_REQUEST_FAILED` during integration monitoring sync.

## Impact
- scheduled sprint monitoring can fetch active Jira sprint issues again
- GitHub/Jira integration configs do not need to change
- monitoring sync resumes working for teams using auto-refresh or scheduled refresh

## Validation
- `node test/issue283-jira-request-builder.test.js`
- `node test/issue312-scheduled-sprint-monitoring-service.test.js`
- `npm test -- --runTestsByPath src/components/__tests__/issue308-SprintMonitoringFlows.test.jsx`
