### PR TITLE
Connector f12: Final Evaluation Weight Configuration

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -49,6 +49,11 @@ if (fs.existsSync(frontendDistPath)) {
 // Make models globally accessible
 app.locals.models = { User, Group, AuditLog };
 
+<<<<<<< Updated upstream
+=======
+// Routes
+app.use('/api/v1/final-evaluation', require('./routes/finalEvaluation'));
+>>>>>>> Stashed changes
 app.use('/api/v1/admin', adminRoutes);
 app.use('/api/v1/coordinator', coordinatorRoutes);
 app.use('/api/v1/advisors', advisorRoutes);

--- a/backend/controllers/finalEvaluationWeightController.js
+++ b/backend/controllers/finalEvaluationWeightController.js
@@ -1,0 +1,86 @@
+'use strict';
+
+// backend/controllers/finalEvaluationWeightController.js
+
+const { body, validationResult } = require('express-validator');
+const { setWeightConfig, getWeightConfig } = require('../services/finalEvaluationService');
+
+// ---------------------------------------------------------------------------
+// PUT /api/v1/final-evaluation/weight-configuration
+// Auth: COORDINATOR only
+// ---------------------------------------------------------------------------
+const putWeightConfiguration = [
+  body('advisorWeight')
+    .notEmpty().withMessage('advisorWeight is required')
+    .isFloat({ min: 0, max: 1 }).withMessage('advisorWeight must be a float between 0 and 1'),
+  body('committeeWeight')
+    .notEmpty().withMessage('committeeWeight is required')
+    .isFloat({ min: 0, max: 1 }).withMessage('committeeWeight must be a float between 0 and 1'),
+
+  async (req, res, next) => {
+    // --- Basic validation (null / empty / type) ---
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: errors.array()[0].msg,
+      });
+    }
+
+    const { advisorWeight, committeeWeight } = req.body;
+
+    try {
+      const config = await setWeightConfig(
+        parseFloat(advisorWeight),
+        parseFloat(committeeWeight),
+        req.user.id
+      );
+
+      return res.status(200).json({
+        advisorWeight: config.advisorWeight,
+        committeeWeight: config.committeeWeight,
+        updatedBy: config.updatedBy,
+        updatedAt: config.updatedAt,
+      });
+    } catch (error) {
+      if (error.status && error.code) {
+        return res.status(error.status).json({
+          code: error.code,
+          message: error.message,
+        });
+      }
+      return next(error);
+    }
+  },
+];
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/final-evaluation/weight-configuration
+// Auth: COORDINATOR, PROFESSOR, or ADVISOR
+// ---------------------------------------------------------------------------
+const getWeightConfiguration = async (req, res, next) => {
+  try {
+    const config = await getWeightConfig();
+
+    if (!config) {
+      return res.status(404).json({
+        code: 'WEIGHT_CONFIG_NOT_FOUND',
+        message: 'No weight configuration has been set yet.',
+      });
+    }
+
+    return res.status(200).json({
+      advisorWeight: config.advisorWeight,
+      committeeWeight: config.committeeWeight,
+      updatedBy: config.updatedBy,
+      updatedAt: config.updatedAt,
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+module.exports = {
+  putWeightConfiguration,
+  getWeightConfiguration,
+};

--- a/backend/models/FinalEvaluationWeight.js
+++ b/backend/models/FinalEvaluationWeight.js
@@ -1,0 +1,42 @@
+'use strict';
+
+// backend/models/FinalEvaluationWeight.js
+// Stores the single active advisor/committee weight configuration (upsert on id=1).
+
+module.exports = (sequelize, DataTypes) => {
+  const FinalEvaluationWeight = sequelize.define(
+    'FinalEvaluationWeight',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      advisorWeight: {
+        type: DataTypes.FLOAT,
+        allowNull: false,
+      },
+      committeeWeight: {
+        type: DataTypes.FLOAT,
+        allowNull: false,
+      },
+      updatedBy: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+    },
+    {
+      tableName: 'FinalEvaluationWeights',
+      timestamps: true,
+    }
+  );
+
+  FinalEvaluationWeight.associate = (models) => {
+    FinalEvaluationWeight.belongsTo(models.User, {
+      foreignKey: 'updatedBy',
+      as: 'coordinator',
+    });
+  };
+
+  return FinalEvaluationWeight;
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,11 +1,3 @@
-/**
- * models/index.js
- *
- * Central model registry.
- * Add every Sequelize model here so the rest of the app can import from
- * a single location and so `sequelize.sync()` / migrations see all tables.
- */
-
 const User = require('./User');
 const Professor = require('./Professor');
 const ValidStudentId = require('./ValidStudentId');
@@ -17,6 +9,7 @@ const GroupAdvisorAssignment = require('./GroupAdvisorAssignment');
 const Invitation = require('./Invitation');
 const AuditLog = require('./AuditLog');
 const Notification = require('./Notification');
+<<<<<<< Updated upstream
 const IntegrationTokenReference = require('./IntegrationTokenReference');
 const IntegrationBinding = require('./IntegrationBinding');
 const GradingRubric = require('./GradingRubric');
@@ -32,6 +25,9 @@ const PrMetric = require('./PrMetric');
 const SprintPullRequest = require('./SprintPullRequest');
 const SprintStory = require('./SprintStory');
 const StoryMetric = require('./StoryMetric');
+=======
+const FinalEvaluationWeight = require('./FinalEvaluationWeight');
+>>>>>>> Stashed changes
 
 module.exports = {
   User,
@@ -45,6 +41,7 @@ module.exports = {
   Invitation,
   AuditLog,
   Notification,
+<<<<<<< Updated upstream
   IntegrationTokenReference,
   IntegrationBinding,
   GradingRubric,
@@ -60,4 +57,7 @@ module.exports = {
   SprintPullRequest,
   SprintStory,
   StoryMetric,
+=======
+  FinalEvaluationWeight,
+>>>>>>> Stashed changes
 };

--- a/backend/routes/finalEvaluation.js
+++ b/backend/routes/finalEvaluation.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// backend/routes/finalEvaluation.js  (new file)
+// Mount in app.js / server.js with:
+//   app.use('/api/v1/final-evaluation', require('./routes/finalEvaluation'));
+
+const express = require('express');
+const { authenticate, authorize } = require('../middleware/auth');
+const {
+  putWeightConfiguration,
+  getWeightConfiguration,
+} = require('../controllers/finalEvaluationWeightController');
+
+const router = express.Router();
+
+// PUT  /api/v1/final-evaluation/weight-configuration
+router.put(
+  '/weight-configuration',
+  authenticate,
+  authorize(['COORDINATOR']),
+  putWeightConfiguration
+);
+
+// GET  /api/v1/final-evaluation/weight-configuration
+router.get(
+  '/weight-configuration',
+  authenticate,
+  authorize(['COORDINATOR', 'PROFESSOR', 'ADVISOR']),
+  getWeightConfiguration
+);
+
+module.exports = router;

--- a/backend/services/finalEvaluationService.js
+++ b/backend/services/finalEvaluationService.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// backend/services/finalEvaluationService.js  (weight-config section)
+// Add these two functions to the file, or create it if it does not yet exist.
+
+const { FinalEvaluationWeight } = require('../models');
+
+const WEIGHT_TOLERANCE = 0.001;
+// We keep exactly one config row by always targeting id = 1.
+const SINGLETON_ID = 1;
+
+/**
+ * Upsert the advisor / committee weight configuration.
+ *
+ * @param {number} advisorWeight
+ * @param {number} committeeWeight
+ * @param {number} updatedBy  – User.id of the calling COORDINATOR
+ * @returns {Promise<FinalEvaluationWeight>}
+ */
+async function setWeightConfig(advisorWeight, committeeWeight, updatedBy) {
+  if (Math.abs(advisorWeight + committeeWeight - 1.0) > WEIGHT_TOLERANCE) {
+    const err = new Error('advisorWeight and committeeWeight must sum to 1.0');
+    err.code = 'WEIGHTS_MUST_SUM_TO_ONE';
+    err.status = 400;
+    throw err;
+  }
+
+  const [record] = await FinalEvaluationWeight.upsert(
+    {
+      id: SINGLETON_ID,
+      advisorWeight,
+      committeeWeight,
+      updatedBy,
+    },
+    { returning: true }
+  );
+
+  return record;
+}
+
+/**
+ * Return the active weight configuration, or null when none has been saved yet.
+ *
+ * @returns {Promise<FinalEvaluationWeight|null>}
+ */
+async function getWeightConfig() {
+  return FinalEvaluationWeight.findOne({ where: { id: SINGLETON_ID } });
+}
+
+module.exports = {
+  setWeightConfig,
+  getWeightConfig,
+};


### PR DESCRIPTION
What was implementedThe goal was to allow the COORDINATOR to set and read the advisor/committee weight split used when computing the team scalar, exposed via PUT and GET /api/v1/final-evaluation/weight-configuration.Files createdFinalEvaluationWeight.js was created under backend/models/ as the Sequelize model holding advisorWeight, committeeWeight, and updatedBy fields, always stored as a singleton row at id=1.finalEvaluationService.js was created under backend/services/ with two functions: setWeightConfig() which validates the weight sum and performs the upsert, and getWeightConfig() which reads the singleton row.finalEvaluationWeightController.js was created under backend/controllers/ with the PUT handler (express-validator for null/empty/type checks, then service call) and the GET handler (returns 404 with WEIGHT_CONFIG_NOT_FOUND when no config exists yet).finalEvaluation.route.js was created under backend/routes/ wiring both endpoints with their respective auth guards.