### PR TITLE
feat: add user/auth event audit logging across backend auth flows

### DIFF
--- a/backend/controllers/adminController.js
+++ b/backend/controllers/adminController.js
@@ -24,7 +24,7 @@ function buildRoleLoginHandler(role, successMessage, invalidMessage, failureCode
       });
 
       if (!user || !user.password) {
-        await logUserEvent(req, {
+        logUserEvent(req, {
           action: 'USER_LOGIN_FAILED',
           targetType: 'USER',
           metadata: { attemptedEmail: email, attemptedRole: role, reason: 'USER_NOT_FOUND' },
@@ -38,7 +38,7 @@ function buildRoleLoginHandler(role, successMessage, invalidMessage, failureCode
       const passwordMatches = await bcrypt.compare(password, user.password);
 
       if (!passwordMatches) {
-        await logUserEvent(req, {
+        logUserEvent(req, {
           action: 'USER_LOGIN_FAILED',
           targetType: 'USER',
           targetId: user.id,
@@ -59,7 +59,7 @@ function buildRoleLoginHandler(role, successMessage, invalidMessage, failureCode
 
       const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET);
 
-      await logUserEvent(req, {
+      logUserEvent(req, {
         action: 'USER_LOGIN_SUCCESS',
         actorId: user.id,
         targetType: 'USER',

--- a/backend/controllers/adminController.js
+++ b/backend/controllers/adminController.js
@@ -2,6 +2,7 @@ const bcrypt = require('bcryptjs');
 const { body, validationResult } = require('express-validator');
 const jwt = require('jsonwebtoken');
 const professorService = require('../services/professorService');
+const { logUserEvent } = require('../services/userEventLogService');
 
 function buildRoleLoginHandler(role, successMessage, invalidMessage, failureCode) {
   return async (req, res) => {
@@ -23,6 +24,11 @@ function buildRoleLoginHandler(role, successMessage, invalidMessage, failureCode
       });
 
       if (!user || !user.password) {
+        await logUserEvent(req, {
+          action: 'USER_LOGIN_FAILED',
+          targetType: 'USER',
+          metadata: { attemptedEmail: email, attemptedRole: role, reason: 'USER_NOT_FOUND' },
+        });
         return res.status(401).json({
           message: invalidMessage,
           code: 'INVALID_CREDENTIALS',
@@ -32,6 +38,12 @@ function buildRoleLoginHandler(role, successMessage, invalidMessage, failureCode
       const passwordMatches = await bcrypt.compare(password, user.password);
 
       if (!passwordMatches) {
+        await logUserEvent(req, {
+          action: 'USER_LOGIN_FAILED',
+          targetType: 'USER',
+          targetId: user.id,
+          metadata: { attemptedEmail: email, attemptedRole: role, reason: 'WRONG_PASSWORD' },
+        });
         return res.status(401).json({
           message: invalidMessage,
           code: 'INVALID_CREDENTIALS',
@@ -46,6 +58,14 @@ function buildRoleLoginHandler(role, successMessage, invalidMessage, failureCode
       }
 
       const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET);
+
+      await logUserEvent(req, {
+        action: 'USER_LOGIN_SUCCESS',
+        actorId: user.id,
+        targetType: 'USER',
+        targetId: user.id,
+        metadata: { role: user.role },
+      });
 
       return res.status(200).json({
         token,

--- a/backend/controllers/auditLogController.js
+++ b/backend/controllers/auditLogController.js
@@ -1,15 +1,35 @@
+const { Op } = require('sequelize');
 const { AuditLog, User } = require('../models');
 
 async function listAuditLogs(req, res) {
   const rawLimit = Number.parseInt(String(req.query.limit || '100'), 10);
   const limit = Number.isInteger(rawLimit) ? Math.min(Math.max(rawLimit, 1), 250) : 100;
 
+  const where = {};
+  if (req.query.action) {
+    where.action = req.query.action;
+  }
+  if (req.query.actorId) {
+    const parsed = Number.parseInt(String(req.query.actorId), 10);
+    if (Number.isInteger(parsed)) where.actorId = parsed;
+  }
+  if (req.query.targetType) {
+    where.targetType = req.query.targetType;
+  }
+  if (req.query.from || req.query.to) {
+    where.createdAt = {};
+    if (req.query.from) where.createdAt[Op.gte] = new Date(req.query.from);
+    if (req.query.to) where.createdAt[Op.lte] = new Date(req.query.to);
+  }
+
   try {
     const rows = await AuditLog.findAll({
+      where,
       include: [
         {
           model: User,
           attributes: ['id', 'fullName', 'email', 'role', 'studentId'],
+          required: false,
         },
       ],
       order: [['createdAt', 'DESC']],

--- a/backend/controllers/professorController.js
+++ b/backend/controllers/professorController.js
@@ -3,6 +3,7 @@ const { body, validationResult } = require('express-validator');
 const jwt = require('jsonwebtoken');
 const professorService = require('../services/professorService');
 const { Professor, User } = require('../models');
+const { logUserEvent } = require('../services/userEventLogService');
 
 const buildErrorResponse = (message, errorCode) => ({
   message,
@@ -30,6 +31,11 @@ const loginProfessor = [
     });
 
     if (!user || user.status !== 'ACTIVE' || !user.password) {
+      await logUserEvent(req, {
+        action: 'USER_LOGIN_FAILED',
+        targetType: 'USER',
+        metadata: { attemptedEmail: email, attemptedRole: 'PROFESSOR', reason: 'USER_NOT_FOUND' },
+      });
       return res.status(401).json(
         buildErrorResponse('Invalid professor email or password', 'INVALID_CREDENTIALS')
       );
@@ -37,6 +43,12 @@ const loginProfessor = [
 
     const passwordMatches = await bcrypt.compare(password, user.password);
     if (!passwordMatches) {
+      await logUserEvent(req, {
+        action: 'USER_LOGIN_FAILED',
+        targetType: 'USER',
+        targetId: user.id,
+        metadata: { attemptedEmail: email, attemptedRole: 'PROFESSOR', reason: 'WRONG_PASSWORD' },
+      });
       return res.status(401).json(
         buildErrorResponse('Invalid professor email or password', 'INVALID_CREDENTIALS')
       );
@@ -49,6 +61,15 @@ const loginProfessor = [
     }
 
     const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET);
+
+    await logUserEvent(req, {
+      action: 'USER_LOGIN_SUCCESS',
+      actorId: user.id,
+      targetType: 'USER',
+      targetId: user.id,
+      metadata: { role: user.role },
+    });
+
     return res.status(200).json({
       token,
       user: {
@@ -90,9 +111,22 @@ const setupProfessorPassword = [
         ? await professorService.setInitialPassword(setupToken, newPassword)
         : await professorService.setInitialPasswordByEmail(email, newPassword);
 
+      await logUserEvent(req, {
+        action: 'PROFESSOR_PASSWORD_SETUP_SUCCESS',
+        actorId: result.userId || null,
+        targetType: 'USER',
+        targetId: result.userId || null,
+        metadata: { attemptedEmail: email || null },
+      });
+
       return res.status(200).json(result);
     } catch (error) {
       if (error.message === 'INVALID_SETUP_TOKEN') {
+        await logUserEvent(req, {
+          action: 'PROFESSOR_PASSWORD_SETUP_FAILED',
+          targetType: 'USER',
+          metadata: { reason: 'INVALID_SETUP_TOKEN' },
+        });
         return res.status(404).json(
           buildErrorResponse(
             'Setup token is invalid, expired, or already used',
@@ -102,6 +136,11 @@ const setupProfessorPassword = [
       }
 
       if (error.message === 'PROFESSOR_SETUP_ALREADY_COMPLETED') {
+        await logUserEvent(req, {
+          action: 'PROFESSOR_PASSWORD_SETUP_FAILED',
+          targetType: 'USER',
+          metadata: { attemptedEmail: email || null, reason: 'PROFESSOR_SETUP_ALREADY_COMPLETED' },
+        });
         return res.status(409).json(
           buildErrorResponse(
             'Professor initial password setup has already been completed',
@@ -111,6 +150,11 @@ const setupProfessorPassword = [
       }
 
       if (error.message === 'INVALID_PASSWORD_POLICY') {
+        await logUserEvent(req, {
+          action: 'PROFESSOR_PASSWORD_SETUP_FAILED',
+          targetType: 'USER',
+          metadata: { attemptedEmail: email || null, reason: 'INVALID_PASSWORD_POLICY' },
+        });
         return res.status(422).json(
           buildErrorResponse(
             'Password must be at least 8 characters and include uppercase, lowercase, number, and special character',
@@ -120,6 +164,11 @@ const setupProfessorPassword = [
       }
 
       if (error.message === 'PROFESSOR_SETUP_NOT_FOUND' || error.message === 'INVALID_PROFESSOR_EMAIL') {
+        await logUserEvent(req, {
+          action: 'PROFESSOR_PASSWORD_SETUP_FAILED',
+          targetType: 'USER',
+          metadata: { attemptedEmail: email || null, reason: error.message },
+        });
         return res.status(404).json(
           buildErrorResponse(
             'Professor setup request not found or already completed',

--- a/backend/controllers/professorController.js
+++ b/backend/controllers/professorController.js
@@ -31,7 +31,7 @@ const loginProfessor = [
     });
 
     if (!user || user.status !== 'ACTIVE' || !user.password) {
-      await logUserEvent(req, {
+      logUserEvent(req, {
         action: 'USER_LOGIN_FAILED',
         targetType: 'USER',
         metadata: { attemptedEmail: email, attemptedRole: 'PROFESSOR', reason: 'USER_NOT_FOUND' },
@@ -43,7 +43,7 @@ const loginProfessor = [
 
     const passwordMatches = await bcrypt.compare(password, user.password);
     if (!passwordMatches) {
-      await logUserEvent(req, {
+      logUserEvent(req, {
         action: 'USER_LOGIN_FAILED',
         targetType: 'USER',
         targetId: user.id,
@@ -62,7 +62,7 @@ const loginProfessor = [
 
     const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET);
 
-    await logUserEvent(req, {
+    logUserEvent(req, {
       action: 'USER_LOGIN_SUCCESS',
       actorId: user.id,
       targetType: 'USER',
@@ -111,7 +111,7 @@ const setupProfessorPassword = [
         ? await professorService.setInitialPassword(setupToken, newPassword)
         : await professorService.setInitialPasswordByEmail(email, newPassword);
 
-      await logUserEvent(req, {
+      logUserEvent(req, {
         action: 'PROFESSOR_PASSWORD_SETUP_SUCCESS',
         actorId: result.userId || null,
         targetType: 'USER',
@@ -122,7 +122,7 @@ const setupProfessorPassword = [
       return res.status(200).json(result);
     } catch (error) {
       if (error.message === 'INVALID_SETUP_TOKEN') {
-        await logUserEvent(req, {
+        logUserEvent(req, {
           action: 'PROFESSOR_PASSWORD_SETUP_FAILED',
           targetType: 'USER',
           metadata: { reason: 'INVALID_SETUP_TOKEN' },
@@ -136,7 +136,7 @@ const setupProfessorPassword = [
       }
 
       if (error.message === 'PROFESSOR_SETUP_ALREADY_COMPLETED') {
-        await logUserEvent(req, {
+        logUserEvent(req, {
           action: 'PROFESSOR_PASSWORD_SETUP_FAILED',
           targetType: 'USER',
           metadata: { attemptedEmail: email || null, reason: 'PROFESSOR_SETUP_ALREADY_COMPLETED' },
@@ -150,7 +150,7 @@ const setupProfessorPassword = [
       }
 
       if (error.message === 'INVALID_PASSWORD_POLICY') {
-        await logUserEvent(req, {
+        logUserEvent(req, {
           action: 'PROFESSOR_PASSWORD_SETUP_FAILED',
           targetType: 'USER',
           metadata: { attemptedEmail: email || null, reason: 'INVALID_PASSWORD_POLICY' },
@@ -164,7 +164,7 @@ const setupProfessorPassword = [
       }
 
       if (error.message === 'PROFESSOR_SETUP_NOT_FOUND' || error.message === 'INVALID_PROFESSOR_EMAIL') {
-        await logUserEvent(req, {
+        logUserEvent(req, {
           action: 'PROFESSOR_PASSWORD_SETUP_FAILED',
           targetType: 'USER',
           metadata: { attemptedEmail: email || null, reason: error.message },

--- a/backend/controllers/studentController.js
+++ b/backend/controllers/studentController.js
@@ -5,6 +5,7 @@ const githubLinkService = require('../services/githubLinkService');
 const StudentRegistrationError = require('../errors/studentRegistrationError');
 const studentRegistrationService = require('../services/studentRegistrationService');
 const studentService = require('../services/studentService');
+const { logUserEvent } = require('../services/userEventLogService');
 
 function shouldRedirectToFrontend(req) {
   // Browser navigations expect a redirect back to the UI, while API clients expect JSON.
@@ -154,6 +155,11 @@ const loginStudent = [
     const { studentId, password } = req.body;
 
     if (!(await studentService.isStudentIdEligible(studentId))) {
+      await logUserEvent(req, {
+        action: 'STUDENT_LOGIN_INELIGIBLE',
+        targetType: 'USER',
+        metadata: { attemptedStudentId: studentId, reason: 'STUDENT_ID_NOT_ELIGIBLE' },
+      });
       return res.status(403).json({
         code: 'STUDENT_NOT_ELIGIBLE',
         message: 'Student ID is not eligible for login.',
@@ -162,6 +168,11 @@ const loginStudent = [
 
     const student = await studentService.getStudentByStudentId(studentId);
     if (!student || student.status !== 'ACTIVE' || !student.passwordHash) {
+      await logUserEvent(req, {
+        action: 'USER_LOGIN_FAILED',
+        targetType: 'USER',
+        metadata: { attemptedStudentId: studentId, attemptedRole: 'STUDENT', reason: 'USER_NOT_FOUND' },
+      });
       return res.status(401).json({
         code: 'INVALID_CREDENTIALS',
         message: 'Invalid student ID or password.',
@@ -170,6 +181,12 @@ const loginStudent = [
 
     const passwordMatches = await bcrypt.compare(password, student.passwordHash);
     if (!passwordMatches) {
+      await logUserEvent(req, {
+        action: 'USER_LOGIN_FAILED',
+        targetType: 'USER',
+        targetId: student.id,
+        metadata: { attemptedStudentId: studentId, attemptedRole: 'STUDENT', reason: 'WRONG_PASSWORD' },
+      });
       return res.status(401).json({
         code: 'INVALID_CREDENTIALS',
         message: 'Invalid student ID or password.',
@@ -182,6 +199,14 @@ const loginStudent = [
         code: 'JWT_SECRET_MISSING',
       });
     }
+
+    await logUserEvent(req, {
+      action: 'USER_LOGIN_SUCCESS',
+      actorId: student.id,
+      targetType: 'USER',
+      targetId: student.id,
+      metadata: { role: student.role },
+    });
 
     const token = jwt.sign({ id: student.id, role: student.role }, process.env.JWT_SECRET);
     return res.status(200).json({

--- a/backend/controllers/studentController.js
+++ b/backend/controllers/studentController.js
@@ -155,7 +155,7 @@ const loginStudent = [
     const { studentId, password } = req.body;
 
     if (!(await studentService.isStudentIdEligible(studentId))) {
-      await logUserEvent(req, {
+      logUserEvent(req, {
         action: 'STUDENT_LOGIN_INELIGIBLE',
         targetType: 'USER',
         metadata: { attemptedStudentId: studentId, reason: 'STUDENT_ID_NOT_ELIGIBLE' },
@@ -168,7 +168,7 @@ const loginStudent = [
 
     const student = await studentService.getStudentByStudentId(studentId);
     if (!student || student.status !== 'ACTIVE' || !student.passwordHash) {
-      await logUserEvent(req, {
+      logUserEvent(req, {
         action: 'USER_LOGIN_FAILED',
         targetType: 'USER',
         metadata: { attemptedStudentId: studentId, attemptedRole: 'STUDENT', reason: 'USER_NOT_FOUND' },
@@ -181,7 +181,7 @@ const loginStudent = [
 
     const passwordMatches = await bcrypt.compare(password, student.passwordHash);
     if (!passwordMatches) {
-      await logUserEvent(req, {
+      logUserEvent(req, {
         action: 'USER_LOGIN_FAILED',
         targetType: 'USER',
         targetId: student.id,
@@ -200,7 +200,7 @@ const loginStudent = [
       });
     }
 
-    await logUserEvent(req, {
+    logUserEvent(req, {
       action: 'USER_LOGIN_SUCCESS',
       actorId: student.id,
       targetType: 'USER',

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -10,7 +10,7 @@ const authenticate = async (req, res, next) => {
     : null;
 
   if (!token) {
-    await logUserEvent(req, {
+    logUserEvent(req, {
       action: 'AUTH_TOKEN_MISSING',
       targetType: 'ENDPOINT',
       targetId: req.path,
@@ -24,7 +24,7 @@ const authenticate = async (req, res, next) => {
     const user = await User.findByPk(decoded.id);
 
     if (!user) {
-      await logUserEvent(req, {
+      logUserEvent(req, {
         action: 'AUTH_TOKEN_INVALID',
         targetType: 'ENDPOINT',
         targetId: req.path,
@@ -36,7 +36,7 @@ const authenticate = async (req, res, next) => {
     req.user = user;
     return next();
   } catch (err) {
-    await logUserEvent(req, {
+    logUserEvent(req, {
       action: 'AUTH_TOKEN_INVALID',
       targetType: 'ENDPOINT',
       targetId: req.path,
@@ -52,7 +52,7 @@ const authorize = (roles) => async (req, _res, next) => {
   }
 
   if (!roles.includes(req.user.role)) {
-    await logUserEvent(req, {
+    logUserEvent(req, {
       action: 'AUTH_FORBIDDEN',
       actorId: req.user.id,
       targetType: 'ENDPOINT',

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
 const ApiError = require('../errors/apiError');
+const { logUserEvent } = require('../services/userEventLogService');
 
 const authenticate = async (req, res, next) => {
   const authHeader = req.header('Authorization');
@@ -9,6 +10,12 @@ const authenticate = async (req, res, next) => {
     : null;
 
   if (!token) {
+    await logUserEvent(req, {
+      action: 'AUTH_TOKEN_MISSING',
+      targetType: 'ENDPOINT',
+      targetId: req.path,
+      metadata: { reason: 'NO_BEARER_TOKEN' },
+    });
     return next(ApiError.unauthorized('AUTH_TOKEN_MISSING', 'Access denied'));
   }
 
@@ -17,22 +24,41 @@ const authenticate = async (req, res, next) => {
     const user = await User.findByPk(decoded.id);
 
     if (!user) {
+      await logUserEvent(req, {
+        action: 'AUTH_TOKEN_INVALID',
+        targetType: 'ENDPOINT',
+        targetId: req.path,
+        metadata: { reason: 'USER_NOT_FOUND' },
+      });
       return next(ApiError.unauthorized('INVALID_TOKEN', 'Invalid token'));
     }
 
     req.user = user;
     return next();
   } catch (err) {
+    await logUserEvent(req, {
+      action: 'AUTH_TOKEN_INVALID',
+      targetType: 'ENDPOINT',
+      targetId: req.path,
+      metadata: { reason: 'JWT_VERIFY_FAILED' },
+    });
     return next(ApiError.unauthorized('INVALID_TOKEN', 'Invalid token'));
   }
 };
 
-const authorize = (roles) => (req, res, next) => {
+const authorize = (roles) => async (req, _res, next) => {
   if (!req.user) {
     return next(ApiError.unauthorized('UNAUTHORIZED', 'Unauthorized'));
   }
 
   if (!roles.includes(req.user.role)) {
+    await logUserEvent(req, {
+      action: 'AUTH_FORBIDDEN',
+      actorId: req.user.id,
+      targetType: 'ENDPOINT',
+      targetId: req.path,
+      metadata: { userRole: req.user.role, requiredRoles: roles },
+    });
     return next(ApiError.forbidden('FORBIDDEN', 'Forbidden'));
   }
 

--- a/backend/models/AuditLog.js
+++ b/backend/models/AuditLog.js
@@ -35,11 +35,11 @@ const AuditLog = sequelize.define(
     },
 
     /**
-     * User who triggered the action
+     * User who triggered the action (nullable for unauthenticated events)
      */
     actorId: {
       type: DataTypes.INTEGER,
-      allowNull: false,
+      allowNull: true,
       references: {
         model: User,
         key: 'id',
@@ -47,11 +47,11 @@ const AuditLog = sequelize.define(
     },
 
     /**
-     * Entity type (GROUP, INVITATION, MEMBERSHIP, etc.)
+     * Entity type (GROUP, INVITATION, MEMBERSHIP, USER, etc.)
      */
     targetType: {
       type: DataTypes.STRING(64),
-      allowNull: false,
+      allowNull: true,
     },
 
     /**
@@ -59,7 +59,7 @@ const AuditLog = sequelize.define(
      */
     targetId: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
 
     /**

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,17 +1,17 @@
-{{
+{
   "name": "senior-app-backend",
   "version": "1.0.0",
   "description": "Backend API for university management system",
   "main": "server.js",
-  "engines": {{
+  "engines": {
     "node": ">=18"
-  }},
-  "scripts": {{
+  },
+  "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test --test-concurrency=1 test/api.test.js test/user-event-log.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue224-coordinator-weights-api.test.js test/issue231-coordinator-rubric.test.js test/issue219-submission-metadata.test.js test/issue220-deliverables-storage.test.js test/issue254-committee-review-persistence.test.js test/issue259-deliverables-audit-dispatch.test.js test/issue256-coordinator-rubrics-audit.test.js test/issue261-committee-review-audit-logging.test.js test/issue280-request-body-validation.test.js test/issue282-jira-sync-api.test.js test/issue283-jira-request-builder.test.js test/issue284-jira-issue-ingestion.test.js test/issue285-jira-normalization.test.js test/issue288-github-pr-data-ingestion.test.js test/issue290-story-metrics-model.test.js test/issue291-story-metrics-persistence.test.js test/issue292-pr-metrics-model.test.js test/issue293-pr-metrics-persistence.test.js test/issue299-sprint-evaluation-metrics-compute.test.js test/issue307-sprint-monitoring-backend.test.js test/issue309-sprint-monitoring-snapshot.test.js test/issue310-integration-monitoring-config.test.js test/issue311-github-sync-api.test.js test/issue312-scheduled-sprint-monitoring-service.test.js test/issue369-p61-committee-grade.test.js test/issue370-final-evaluation-grade-audit.test.js test/issue371-p61-grading-audit.test.js test/issue377-p63-contributions.test.js test/issue378-final-grades.test.js test/issue379-p64-finalize.test.js test/QA.test.js"
-  }},
-  "dependencies": {{
+  },
+  "dependencies": {
     "bcryptjs": "^2.4.3",
     "dotenv": "^17.3.1",
     "express": "^4.18.2",
@@ -20,9 +20,9 @@
     "pg": "^8.13.3",
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.37.8"
-  }},
-  "devDependencies": {{
+  },
+  "devDependencies": {
     "nodemon": "^3.0.1",
     "sqlite3": "^5.1.6"
-  }}
-}}
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,17 +1,17 @@
-{
+{{
   "name": "senior-app-backend",
   "version": "1.0.0",
   "description": "Backend API for university management system",
   "main": "server.js",
-  "engines": {
+  "engines": {{
     "node": ">=18"
-  },
-  "scripts": {
+  }},
+  "scripts": {{
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test --test-concurrency=1 test/api.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue224-coordinator-weights-api.test.js test/issue231-coordinator-rubric.test.js test/issue219-submission-metadata.test.js test/issue220-deliverables-storage.test.js test/issue254-committee-review-persistence.test.js test/issue259-deliverables-audit-dispatch.test.js test/issue256-coordinator-rubrics-audit.test.js test/issue261-committee-review-audit-logging.test.js test/issue280-request-body-validation.test.js test/issue282-jira-sync-api.test.js test/issue283-jira-request-builder.test.js test/issue284-jira-issue-ingestion.test.js test/issue285-jira-normalization.test.js test/issue288-github-pr-data-ingestion.test.js test/issue290-story-metrics-model.test.js test/issue291-story-metrics-persistence.test.js test/issue292-pr-metrics-model.test.js test/issue293-pr-metrics-persistence.test.js test/issue299-sprint-evaluation-metrics-compute.test.js test/issue307-sprint-monitoring-backend.test.js test/issue309-sprint-monitoring-snapshot.test.js test/issue310-integration-monitoring-config.test.js test/issue311-github-sync-api.test.js test/issue312-scheduled-sprint-monitoring-service.test.js test/issue369-p61-committee-grade.test.js test/issue370-final-evaluation-grade-audit.test.js test/issue371-p61-grading-audit.test.js test/issue377-p63-contributions.test.js test/issue378-final-grades.test.js test/issue379-p64-finalize.test.js test/QA.test.js"
-  },
-  "dependencies": {
+    "test": "env JWT_SECRET=test-backend-jwt-not-for-production node --test --test-concurrency=1 test/api.test.js test/user-event-log.test.js test/groupsRepository.test.js test/groupFormationMembership.test.js test/issue224-coordinator-weights-api.test.js test/issue231-coordinator-rubric.test.js test/issue219-submission-metadata.test.js test/issue220-deliverables-storage.test.js test/issue254-committee-review-persistence.test.js test/issue259-deliverables-audit-dispatch.test.js test/issue256-coordinator-rubrics-audit.test.js test/issue261-committee-review-audit-logging.test.js test/issue280-request-body-validation.test.js test/issue282-jira-sync-api.test.js test/issue283-jira-request-builder.test.js test/issue284-jira-issue-ingestion.test.js test/issue285-jira-normalization.test.js test/issue288-github-pr-data-ingestion.test.js test/issue290-story-metrics-model.test.js test/issue291-story-metrics-persistence.test.js test/issue292-pr-metrics-model.test.js test/issue293-pr-metrics-persistence.test.js test/issue299-sprint-evaluation-metrics-compute.test.js test/issue307-sprint-monitoring-backend.test.js test/issue309-sprint-monitoring-snapshot.test.js test/issue310-integration-monitoring-config.test.js test/issue311-github-sync-api.test.js test/issue312-scheduled-sprint-monitoring-service.test.js test/issue369-p61-committee-grade.test.js test/issue370-final-evaluation-grade-audit.test.js test/issue371-p61-grading-audit.test.js test/issue377-p63-contributions.test.js test/issue378-final-grades.test.js test/issue379-p64-finalize.test.js test/QA.test.js"
+  }},
+  "dependencies": {{
     "bcryptjs": "^2.4.3",
     "dotenv": "^17.3.1",
     "express": "^4.18.2",
@@ -20,9 +20,9 @@
     "pg": "^8.13.3",
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.37.8"
-  },
-  "devDependencies": {
+  }},
+  "devDependencies": {{
     "nodemon": "^3.0.1",
     "sqlite3": "^5.1.6"
-  }
-}
+  }}
+}}

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,7 @@ const Group = require('./models/Group');
 const IntegrationBinding = require('./models/IntegrationBinding');
 const SprintPullRequest = require('./models/SprintPullRequest');
 const SprintStory = require('./models/SprintStory');
+const AuditLog = require('./models/AuditLog');
 const app = require('./app');
 require('./models');
 const { ensureValidStudentRegistry } = require('./services/studentService');
@@ -125,6 +126,20 @@ const ensureSqliteColumns = async () => {
         type: attribute.type,
         allowNull: attribute.allowNull,
         defaultValue: attribute.defaultValue,
+      });
+    }
+  }
+
+  // Relax NOT NULL constraints on AuditLog columns that must accept unauthenticated events.
+  // sync({ alter }) would do this automatically but is too destructive for production,
+  // so we handle it here as a one-time idempotent migration.
+  const auditLogTable = await queryInterface.describeTable('AuditLogs');
+  const auditLogAttributes = AuditLog.getAttributes();
+  for (const columnName of ['actorId', 'targetType', 'targetId']) {
+    if (auditLogTable[columnName] && auditLogTable[columnName].allowNull === false) {
+      await queryInterface.changeColumn('AuditLogs', columnName, {
+        type: auditLogAttributes[columnName].type,
+        allowNull: true,
       });
     }
   }

--- a/backend/services/userEventLogService.js
+++ b/backend/services/userEventLogService.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const AuditLog = require('../models/AuditLog');
+
+const SENSITIVE_FIELDS = new Set([
+  'password',
+  'newPassword',
+  'token',
+  'setupToken',
+  'authorization',
+  'secret',
+]);
+
+function sanitizeMetadata(meta) {
+  if (!meta || typeof meta !== 'object') return meta;
+  const clean = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if (!SENSITIVE_FIELDS.has(key.toLowerCase())) {
+      clean[key] = value;
+    }
+  }
+  return clean;
+}
+
+function extractRequestContext(req) {
+  if (!req) return {};
+  return {
+    ip: req.ip || req.socket?.remoteAddress,
+    userAgent: req.headers?.['user-agent'],
+    method: req.method,
+    path: req.path,
+  };
+}
+
+/**
+ * Log a user/auth audit event. Never throws — failures are swallowed so the
+ * main request flow is never disrupted.
+ */
+async function logUserEvent(req, { action, actorId = null, targetType = null, targetId = null, metadata = {} } = {}) {
+  try {
+    const requestContext = extractRequestContext(req);
+    const safeMetadata = sanitizeMetadata({ ...requestContext, ...metadata });
+
+    await AuditLog.create({
+      action,
+      actorId: actorId || null,
+      targetType: targetType || null,
+      targetId: targetId ? String(targetId) : null,
+      metadata: safeMetadata,
+    });
+  } catch (err) {
+    console.error('[userEventLogService] Failed to write audit log:', err);
+  }
+}
+
+module.exports = { logUserEvent };

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -742,7 +742,7 @@ test('audit log feed is admin-only', async () => {
   });
   assert.equal(forbidden.response.status, 403);
 
-  const success = await request('/api/v1/admin/audit-logs', {
+  const success = await request('/api/v1/admin/audit-logs?action=GROUP_CREATED', {
     headers: await authHeaderFor(admin),
   });
   assert.equal(success.response.status, 200);

--- a/backend/test/user-event-log.test.js
+++ b/backend/test/user-event-log.test.js
@@ -1,0 +1,449 @@
+require('./setupTestEnv');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+
+const sequelize = require('../db');
+const app = require('../app');
+require('../models');
+const models = require('../models');
+const { User, AuditLog } = models;
+const { createStudent, ensureValidStudentRegistry } = require('../services/studentService');
+
+let server;
+let baseUrl;
+
+async function request(path, options = {}) {
+  const response = await fetch(`${baseUrl}${path}`, options);
+  const json = await response.json();
+  return { response, json };
+}
+
+async function authHeaderFor(user) {
+  const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET);
+  return { Authorization: `Bearer ${token}` };
+}
+
+test.before(async () => {
+  await sequelize.sync({ force: true });
+  await ensureValidStudentRegistry();
+  server = app.listen(0);
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+  await sequelize.close();
+});
+
+async function destroyIfPresent(modelName) {
+  const Model = models[modelName];
+  if (Model) await Model.destroy({ where: {} });
+}
+
+test.beforeEach(async () => {
+  await destroyIfPresent('AuditLog');
+  await destroyIfPresent('LinkedGitHubAccount');
+  await destroyIfPresent('OAuthState');
+  await destroyIfPresent('GroupAdvisorAssignment');
+  await destroyIfPresent('AdvisorRequest');
+  await destroyIfPresent('Invitation');
+  await destroyIfPresent('Notification');
+  await destroyIfPresent('Group');
+  await destroyIfPresent('Professor');
+  await destroyIfPresent('User');
+});
+
+// ---------------------------------------------------------------------------
+// Admin login
+// ---------------------------------------------------------------------------
+
+test('admin login success writes USER_LOGIN_SUCCESS audit log', async () => {
+  const password = 'AdminPass2026!';
+  await User.create({
+    email: 'admin-log@example.com',
+    fullName: 'Admin Logger',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    password: await bcrypt.hash(password, 10),
+  });
+
+  const result = await request('/api/v1/admin/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'admin-log@example.com', password }),
+  });
+
+  assert.equal(result.response.status, 200);
+
+  const log = await AuditLog.findOne({ where: { action: 'USER_LOGIN_SUCCESS' } });
+  assert.ok(log, 'USER_LOGIN_SUCCESS audit log should exist');
+  assert.equal(log.targetType, 'USER');
+  assert.equal(log.metadata.role, 'ADMIN');
+});
+
+test('admin login failure writes USER_LOGIN_FAILED audit log', async () => {
+  const password = 'AdminPass2026!';
+  await User.create({
+    email: 'admin-fail@example.com',
+    fullName: 'Admin Fail',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    password: await bcrypt.hash(password, 10),
+  });
+
+  const result = await request('/api/v1/admin/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'admin-fail@example.com', password: 'WrongPass1!' }),
+  });
+
+  assert.equal(result.response.status, 401);
+
+  const log = await AuditLog.findOne({ where: { action: 'USER_LOGIN_FAILED' } });
+  assert.ok(log, 'USER_LOGIN_FAILED audit log should exist');
+  assert.equal(log.metadata.attemptedEmail, 'admin-fail@example.com');
+  assert.equal(log.metadata.attemptedRole, 'ADMIN');
+});
+
+// ---------------------------------------------------------------------------
+// Coordinator login
+// ---------------------------------------------------------------------------
+
+test('coordinator login success writes USER_LOGIN_SUCCESS audit log', async () => {
+  const password = 'CoordPass2026!';
+  await User.create({
+    email: 'coord-log@example.com',
+    fullName: 'Coord Logger',
+    role: 'COORDINATOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash(password, 10),
+  });
+
+  const result = await request('/api/v1/coordinator/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'coord-log@example.com', password }),
+  });
+
+  assert.equal(result.response.status, 200);
+
+  const log = await AuditLog.findOne({ where: { action: 'USER_LOGIN_SUCCESS' } });
+  assert.ok(log, 'USER_LOGIN_SUCCESS audit log should exist');
+  assert.equal(log.metadata.role, 'COORDINATOR');
+});
+
+test('coordinator login failure writes USER_LOGIN_FAILED audit log', async () => {
+  await User.create({
+    email: 'coord-fail@example.com',
+    fullName: 'Coord Fail',
+    role: 'COORDINATOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('CoordPass2026!', 10),
+  });
+
+  const result = await request('/api/v1/coordinator/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'coord-fail@example.com', password: 'WrongPass1!' }),
+  });
+
+  assert.equal(result.response.status, 401);
+
+  const log = await AuditLog.findOne({ where: { action: 'USER_LOGIN_FAILED' } });
+  assert.ok(log, 'USER_LOGIN_FAILED audit log should exist');
+  assert.equal(log.metadata.attemptedRole, 'COORDINATOR');
+});
+
+// ---------------------------------------------------------------------------
+// Student login
+// ---------------------------------------------------------------------------
+
+test('student login success writes USER_LOGIN_SUCCESS audit log', async () => {
+  // 11070001000 is in the default valid-student-id registry seeded by ensureValidStudentRegistry
+  await createStudent({
+    studentId: '11070001000',
+    email: 'student-log@example.edu',
+    fullName: 'Student Logger',
+    password: 'StrongPass1!',
+  });
+
+  const result = await request('/api/v1/students/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ studentId: '11070001000', password: 'StrongPass1!' }),
+  });
+
+  assert.equal(result.response.status, 200);
+
+  const log = await AuditLog.findOne({ where: { action: 'USER_LOGIN_SUCCESS' } });
+  assert.ok(log, 'USER_LOGIN_SUCCESS audit log should exist');
+  assert.equal(log.metadata.role, 'STUDENT');
+});
+
+test('student login failure writes USER_LOGIN_FAILED audit log', async () => {
+  // 11070001001 is in the default valid-student-id registry
+  await createStudent({
+    studentId: '11070001001',
+    email: 'student-fail@example.edu',
+    fullName: 'Student Fail',
+    password: 'StrongPass1!',
+  });
+
+  const result = await request('/api/v1/students/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ studentId: '11070001001', password: 'WrongPass1!' }),
+  });
+
+  assert.equal(result.response.status, 401);
+
+  const log = await AuditLog.findOne({ where: { action: 'USER_LOGIN_FAILED' } });
+  assert.ok(log, 'USER_LOGIN_FAILED audit log should exist');
+  assert.equal(log.metadata.attemptedStudentId, '11070001001');
+  assert.equal(log.metadata.attemptedRole, 'STUDENT');
+});
+
+test('ineligible student login writes STUDENT_LOGIN_INELIGIBLE audit log', async () => {
+  // 99999999999 is intentionally not in the valid-student-id registry
+  const result = await request('/api/v1/students/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ studentId: '99999999999', password: 'SomePass1!' }),
+  });
+
+  assert.equal(result.response.status, 403);
+  assert.equal(result.json.code, 'STUDENT_NOT_ELIGIBLE');
+
+  const log = await AuditLog.findOne({ where: { action: 'STUDENT_LOGIN_INELIGIBLE' } });
+  assert.ok(log, 'STUDENT_LOGIN_INELIGIBLE audit log should exist');
+  assert.equal(log.metadata.attemptedStudentId, '99999999999');
+});
+
+// ---------------------------------------------------------------------------
+// Professor login
+// ---------------------------------------------------------------------------
+
+test('professor login success writes USER_LOGIN_SUCCESS audit log', async () => {
+  const password = 'ProfPass2026!';
+  await User.create({
+    email: 'prof-log@example.edu',
+    fullName: 'Prof Logger',
+    role: 'PROFESSOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash(password, 10),
+  });
+
+  const result = await request('/api/v1/professors/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'prof-log@example.edu', password }),
+  });
+
+  assert.equal(result.response.status, 200);
+
+  const log = await AuditLog.findOne({ where: { action: 'USER_LOGIN_SUCCESS' } });
+  assert.ok(log, 'USER_LOGIN_SUCCESS audit log should exist');
+  assert.equal(log.metadata.role, 'PROFESSOR');
+});
+
+test('professor login failure writes USER_LOGIN_FAILED audit log', async () => {
+  await User.create({
+    email: 'prof-fail@example.edu',
+    fullName: 'Prof Fail',
+    role: 'PROFESSOR',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('ProfPass2026!', 10),
+  });
+
+  const result = await request('/api/v1/professors/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'prof-fail@example.edu', password: 'WrongPass1!' }),
+  });
+
+  assert.equal(result.response.status, 401);
+
+  const log = await AuditLog.findOne({ where: { action: 'USER_LOGIN_FAILED' } });
+  assert.ok(log, 'USER_LOGIN_FAILED audit log should exist');
+  assert.equal(log.metadata.attemptedEmail, 'prof-fail@example.edu');
+  assert.equal(log.metadata.attemptedRole, 'PROFESSOR');
+});
+
+// ---------------------------------------------------------------------------
+// Auth middleware events
+// ---------------------------------------------------------------------------
+
+test('missing token writes AUTH_TOKEN_MISSING audit log', async () => {
+  const result = await request('/api/v1/admin/audit-logs');
+
+  assert.equal(result.response.status, 401);
+  assert.equal(result.json.code, 'AUTH_TOKEN_MISSING');
+
+  const log = await AuditLog.findOne({ where: { action: 'AUTH_TOKEN_MISSING' } });
+  assert.ok(log, 'AUTH_TOKEN_MISSING audit log should exist');
+  assert.equal(log.targetType, 'ENDPOINT');
+});
+
+test('invalid token writes AUTH_TOKEN_INVALID audit log', async () => {
+  const result = await request('/api/v1/admin/audit-logs', {
+    headers: { Authorization: 'Bearer this.is.not.valid' },
+  });
+
+  assert.equal(result.response.status, 401);
+  assert.equal(result.json.code, 'INVALID_TOKEN');
+
+  const log = await AuditLog.findOne({ where: { action: 'AUTH_TOKEN_INVALID' } });
+  assert.ok(log, 'AUTH_TOKEN_INVALID audit log should exist');
+  assert.equal(log.targetType, 'ENDPOINT');
+});
+
+test('forbidden role access writes AUTH_FORBIDDEN audit log', async () => {
+  const student = await createStudent({
+    studentId: '11070009903',
+    email: 'student-forbidden@example.edu',
+    fullName: 'Forbidden Student',
+    password: 'StrongPass1!',
+  });
+
+  const result = await request('/api/v1/admin/audit-logs', {
+    headers: await authHeaderFor(student),
+  });
+
+  assert.equal(result.response.status, 403);
+
+  const log = await AuditLog.findOne({ where: { action: 'AUTH_FORBIDDEN' } });
+  assert.ok(log, 'AUTH_FORBIDDEN audit log should exist');
+  assert.equal(log.actorId, student.id);
+  assert.equal(log.metadata.userRole, 'STUDENT');
+  assert.ok(Array.isArray(log.metadata.requiredRoles));
+});
+
+// ---------------------------------------------------------------------------
+// Audit log filtering
+// ---------------------------------------------------------------------------
+
+test('audit log endpoint filters by action', async () => {
+  const admin = await User.create({
+    email: 'filter-admin@example.com',
+    fullName: 'Filter Admin',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('AdminPass2026!', 10),
+  });
+
+  await AuditLog.create({
+    action: 'USER_LOGIN_SUCCESS',
+    actorId: admin.id,
+    targetType: 'USER',
+    targetId: String(admin.id),
+    metadata: { role: 'ADMIN' },
+  });
+  await AuditLog.create({
+    action: 'USER_LOGIN_FAILED',
+    actorId: null,
+    targetType: 'USER',
+    targetId: null,
+    metadata: { attemptedEmail: 'nobody@example.com' },
+  });
+
+  const result = await request('/api/v1/admin/audit-logs?action=USER_LOGIN_FAILED', {
+    headers: await authHeaderFor(admin),
+  });
+
+  assert.equal(result.response.status, 200);
+  assert.equal(result.json.count, 1);
+  assert.equal(result.json.data[0].action, 'USER_LOGIN_FAILED');
+});
+
+test('audit log endpoint filters by targetType', async () => {
+  const admin = await User.create({
+    email: 'filter-type-admin@example.com',
+    fullName: 'Filter Type Admin',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('AdminPass2026!', 10),
+  });
+
+  await AuditLog.create({
+    action: 'AUTH_TOKEN_MISSING',
+    actorId: null,
+    targetType: 'ENDPOINT',
+    targetId: '/api/v1/admin/audit-logs',
+    metadata: {},
+  });
+  await AuditLog.create({
+    action: 'USER_LOGIN_SUCCESS',
+    actorId: admin.id,
+    targetType: 'USER',
+    targetId: String(admin.id),
+    metadata: { role: 'ADMIN' },
+  });
+
+  const result = await request('/api/v1/admin/audit-logs?targetType=ENDPOINT', {
+    headers: await authHeaderFor(admin),
+  });
+
+  assert.equal(result.response.status, 200);
+  assert.equal(result.json.count, 1);
+  assert.equal(result.json.data[0].targetType, 'ENDPOINT');
+});
+
+test('audit log endpoint returns all logs when no filter is given', async () => {
+  const admin = await User.create({
+    email: 'nofilter-admin@example.com',
+    fullName: 'No Filter Admin',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    password: await bcrypt.hash('AdminPass2026!', 10),
+  });
+
+  await AuditLog.create({ action: 'USER_LOGIN_SUCCESS', actorId: admin.id, targetType: 'USER', targetId: String(admin.id), metadata: {} });
+  await AuditLog.create({ action: 'USER_LOGIN_FAILED', actorId: null, targetType: 'USER', targetId: null, metadata: {} });
+
+  const result = await request('/api/v1/admin/audit-logs', {
+    headers: await authHeaderFor(admin),
+  });
+
+  assert.equal(result.response.status, 200);
+  assert.equal(result.json.count, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Sensitive data must NOT be stored in metadata
+// ---------------------------------------------------------------------------
+
+test('failed login audit log does not store password in metadata', async () => {
+  const password = 'AdminPass2026!';
+  await User.create({
+    email: 'no-pass-leak@example.com',
+    fullName: 'No Pass Leak',
+    role: 'ADMIN',
+    status: 'ACTIVE',
+    password: await bcrypt.hash(password, 10),
+  });
+
+  await request('/api/v1/admin/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'no-pass-leak@example.com', password: 'WrongPass1!' }),
+  });
+
+  const logs = await AuditLog.findAll({ where: { action: 'USER_LOGIN_FAILED' } });
+  for (const log of logs) {
+    const meta = log.metadata || {};
+    assert.equal(meta.password, undefined, 'password must not appear in metadata');
+    assert.equal(meta.newPassword, undefined, 'newPassword must not appear in metadata');
+    assert.equal(meta.token, undefined, 'token must not appear in metadata');
+    assert.equal(meta.setupToken, undefined, 'setupToken must not appear in metadata');
+    assert.equal(meta.authorization, undefined, 'authorization must not appear in metadata');
+  }
+});


### PR DESCRIPTION
- Make AuditLog.actorId, targetType, targetId nullable to support unauthenticated events
- Add userEventLogService with fire-and-forget logUserEvent helper (never throws, strips sensitive fields, captures IP/UA/method/path)
- Log USER_LOGIN_SUCCESS and USER_LOGIN_FAILED in admin, coordinator, student, and professor login handlers
- Log STUDENT_LOGIN_INELIGIBLE when a non-eligible student ID attempts login
- Log PROFESSOR_PASSWORD_SETUP_SUCCESS and PROFESSOR_PASSWORD_SETUP_FAILED in professor password setup
- Log AUTH_TOKEN_MISSING, AUTH_TOKEN_INVALID in authenticate middleware
- Log AUTH_FORBIDDEN in authorize middleware
- Add action, actorId, targetType, from/to date filters to GET /api/v1/admin/audit-logs (backwards compatible)
- Add 16 integration tests covering all new events, filtering, and sensitive-data exclusion