### PR TITLE
docs: update password reset API documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ The admin manages the system and performs administrative operations.
 * The coordinator can assign committees and manage jury assignments.
 * The coordinator can set per-sprint story point requirements for each student.
 * The system supports markdown editing with WYSIWYG support and image insertion for deliverable documents.
-* The system provides a password reset mechanism for admins, generating one-time-use reset links.
+* The system provides an admin-generated, one-time-use password reset mechanism for registered users.
 * The system allows professors to be manually registered by the admin, with a forced password change on first login.
 * The system supports notification features for group invitations, advisor requests, and committee assignments.
 * The coordinator can upload valid student IDs for registration eligibility.
@@ -95,6 +95,59 @@ The admin manages the system and performs administrative operations.
 | Student connects GitHub | Frontend + NextAuth.js | GitHub OAuth Tokens, Username |
 | Admin registers as Professor | Admin Panel + Backend | Professor Name, Email |
 | Professor changes password | Frontend + Backend | One-time reset link, New Password |
+| Admin generates password reset link | Admin Panel + Backend | Target user ID, Admin JWT |
+| User resets password | Frontend + Backend | One-time reset token, New password |
+
+#### Password Reset Flow
+
+Admins can generate a one-time password reset link for any registered user from the admin workspace.
+
+Backend endpoints:
+
+| METHOD | ENDPOINT | AUTHORIZATION | PURPOSE |
+| :--- | :--- | :--- | :--- |
+| POST | `/api/v1/admin/users/{userId}/password-reset-link` | Admin only | Generate a reset link for the target user |
+| POST | `/api/v1/auth/reset-password` | Public token-based | Set a new password using a valid reset token |
+
+Frontend routes:
+
+| ROUTE | PURPOSE |
+| :--- | :--- |
+| `/admin/password-reset-links` | Admin tool for generating password reset links |
+| `/reset-password?token=...` | Public reset form for setting a new password |
+
+Security behavior:
+
+* Reset tokens are generated with crypto-secure randomness.
+* Plain reset tokens are never stored in the database; only token hashes are stored.
+* Generating a new reset link invalidates older active reset links for the same user.
+* Reset tokens expire after a configurable lifetime.
+* Token consume, password update, session-version update, and sibling-token invalidation happen in one transaction.
+* Previously issued JWT sessions for the reset user are invalidated by incrementing the user's session version.
+* Frontend login clears stale role-specific sessions from local storage before saving the new session.
+
+Configuration:
+
+| ENV VARIABLE | DEFAULT | PURPOSE |
+| :--- | :--- | :--- |
+| `FRONTEND_URL` | `http://localhost:5173` | Base URL used when building reset links |
+| `PASSWORD_RESET_TOKEN_TTL_MINUTES` | `60` | Reset token lifetime in minutes |
+
+Targeted checks:
+
+```bash
+# backend password reset flow
+cd backend
+JWT_SECRET=test-backend-jwt-not-for-production node --test --test-concurrency=1 test/passwordReset.test.js
+
+# frontend stale-session/login regression
+cd frontend
+npm test -- issue315-LoginPage.test.jsx
+
+# frontend production build
+cd frontend
+npm run build
+```
 
 ### 2. Group Formation
 | PROCESS STEP | SYSTEM COMPONENT | DATA REQUIRED |

--- a/docs/api-design-registiration.yaml
+++ b/docs/api-design-registiration.yaml
@@ -13,7 +13,9 @@ tags:
   - name: Student
     description: Student-facing registration and GitHub linking endpoints.
   - name: Admin
-    description: Admin-facing professor onboarding endpoints.
+    description: Admin-facing professor onboarding and user password reset endpoints.
+  - name: Auth
+    description: Public authentication endpoints, including token-based password reset.
   - name: Professor
     description: Professor-facing initial password setup endpoint.
   - name: User Database
@@ -319,6 +321,85 @@ components:
       example:
         setupToken: pst_xxx
         newPassword: NewStrongPassword123!
+
+    AdminPasswordResetLinkResponse:
+      type: object
+      description: Response returned when an admin generates a one-time-use password reset link for a registered user.
+      required: [message, resetLink, expiresAt, user]
+      properties:
+        message:
+          type: string
+          example: Password reset link generated successfully
+        resetLink:
+          type: string
+          format: uri
+          description: Plain reset token is present only inside this URL. The database stores only the token hash.
+          example: http://localhost:5173/reset-password?token=plain-one-time-token
+        expiresAt:
+          type: string
+          format: date-time
+          example: 2026-05-09T13:00:00.000Z
+        user:
+          type: object
+          required: [id, email, fullName, role]
+          properties:
+            id:
+              type: integer
+              example: 12
+            email:
+              type: string
+              format: email
+              example: student@example.edu
+            fullName:
+              type: string
+              example: Student User
+            role:
+              type: string
+              enum: [STUDENT, PROFESSOR, COORDINATOR, ADMIN]
+              example: STUDENT
+      example:
+        message: Password reset link generated successfully
+        resetLink: http://localhost:5173/reset-password?token=plain-one-time-token
+        expiresAt: 2026-05-09T13:00:00.000Z
+        user:
+          id: 12
+          email: student@example.edu
+          fullName: Student User
+          role: STUDENT
+
+    ResetPasswordRequest:
+      type: object
+      description: Public request to reset a user's password with a one-time-use reset token.
+      required: [token, newPassword]
+      properties:
+        token:
+          type: string
+          description: Plain reset token from the reset link. Only its SHA-256 hash is compared server-side.
+          example: plain-one-time-token
+        newPassword:
+          type: string
+          format: password
+          minLength: 8
+          description: Must include at least one uppercase letter, one lowercase letter, one number, and one special character.
+          example: NewPassword123!
+      example:
+        token: plain-one-time-token
+        newPassword: NewPassword123!
+
+    ResetPasswordSuccessResponse:
+      type: object
+      description: Response returned after a password reset token is consumed and the password is updated.
+      required: [code, message]
+      properties:
+        code:
+          type: string
+          example: PASSWORD_RESET_SUCCESS
+        message:
+          type: string
+          example: Password reset successful
+      example:
+        code: PASSWORD_RESET_SUCCESS
+        message: Password reset successful
 
     SimpleMessageResponse:
       type: object
@@ -856,6 +937,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/v1/admin/users/{userId}/password-reset-link:
+    post:
+      tags: ["Admin"]
+      summary: Admin generates a one-time-use password reset link
+      description: Admin-only endpoint that creates a password reset link for a registered student, professor, coordinator, or admin user. The generated plain token is returned only in the reset URL, while the backend stores a SHA-256 token hash, sets an expiration time, and invalidates any older active reset token for the same user.
+      operationId: generateAdminPasswordResetLink
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          description: Registered user identifier.
+          schema: { type: integer, minimum: 1 }
+      responses:
+        201:
+          description: Password reset link generated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminPasswordResetLinkResponse'
+        400:
+          description: Invalid userId path parameter.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        401:
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: Only admins can generate password reset links.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: Target user was not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/v1/user-database/professors:
     post:
       tags: ["User Database", "Internal"]
@@ -949,6 +1075,36 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         422:
           description: Password setup request violates business validation rules.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/auth/reset-password:
+    post:
+      tags: ["Auth"]
+      summary: Reset password using a one-time reset token
+      description: Public endpoint used by the reset password page. The backend validates the token hash, expiration, and unused state; hashes the new password; consumes the token and updates the password in one transaction; invalidates sibling reset tokens; and increments the user's sessionVersion so older JWTs are no longer accepted.
+      operationId: resetPasswordWithOneTimeToken
+      requestBody:
+        required: true
+        description: Reset token from the URL and the new password.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResetPasswordRequest'
+            example:
+              token: plain-one-time-token
+              newPassword: NewPassword123!
+      responses:
+        200:
+          description: Password reset token consumed and password updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResetPasswordSuccessResponse'
+        400:
+          description: Missing token/password, weak password, invalid token, expired token, or already-used token.
           content:
             application/json:
               schema:

--- a/docs/api_specification.yaml
+++ b/docs/api_specification.yaml
@@ -27,6 +27,10 @@ components:
       type: apiKey
       in: cookie
       name: next-auth.session-token
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
     githubOAuth:
       type: oauth2
       flows:
@@ -53,6 +57,44 @@ components:
       properties:
         message: { type: string }
         code: { type: string }
+
+    PasswordResetLinkResponse:
+      type: object
+      required: [message, resetLink, expiresAt, user]
+      properties:
+        message: { type: string, example: Password reset link generated successfully }
+        resetLink:
+          type: string
+          format: uri
+          example: http://localhost:5173/reset-password?token=plain-one-time-token
+        expiresAt: { type: string, format: date-time }
+        user:
+          type: object
+          properties:
+            id: { type: integer, example: 12 }
+            email: { type: string, format: email, example: student@example.edu }
+            fullName: { type: string, example: Student User }
+            role: { type: string, enum: [STUDENT, PROFESSOR, COORDINATOR, ADMIN] }
+
+    ResetPasswordRequest:
+      type: object
+      required: [token, newPassword]
+      properties:
+        token:
+          type: string
+          description: Plain token from the reset link. Only its SHA-256 hash is stored server-side.
+        newPassword:
+          type: string
+          format: password
+          minLength: 8
+          description: Must include uppercase, lowercase, number, and special character.
+
+    PasswordResetSuccessResponse:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string, example: PASSWORD_RESET_SUCCESS }
+        message: { type: string, example: Password reset successful }
 
     Group:
       type: object
@@ -247,20 +289,49 @@ paths:
         201: { description: Professor registered, one-time link generated }
         409: { description: Professor email already exists }
 
-  /admin/reset-link:
+  /api/v1/admin/users/{userId}/password-reset-link:
     post:
       tags: ["1.0 User Registration"]
-      summary: Generate one-time-use password reset link
-      security: [{ cookieAuth: [] }]
+      summary: Admin generates a one-time-use password reset link
+      description: Admin-only endpoint for creating a password reset link for any registered student, professor, coordinator, or admin user. The plain token is returned only in this response, while the server stores a hash, expires the token, and invalidates older active reset links for the same user.
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema: { type: integer, minimum: 1 }
       responses:
         201:
           description: Reset link generated
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  resetLink: { type: string }
+                $ref: '#/components/schemas/PasswordResetLinkResponse'
+        400: { description: Invalid userId }
+        401: { description: Authentication required }
+        403: { description: Admin role required }
+        404: { description: User not found }
+
+  /api/v1/auth/reset-password:
+    post:
+      tags: ["1.0 User Registration"]
+      summary: Reset password using a one-time token
+      description: Public token-based password reset endpoint. The backend validates the token hash, expiry, and unused state, atomically consumes the token with the password update, invalidates sibling reset links, and increments the user's sessionVersion to invalidate older JWTs.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResetPasswordRequest'
+      responses:
+        200:
+          description: Password reset successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PasswordResetSuccessResponse'
+        400:
+          description: Missing token/password, weak password, invalid token, expired token, or already-used token
 
   /api/v1/professors/password-setup:
     post:


### PR DESCRIPTION
## Summary
- Document admin-generated one-time password reset links
- Add `/api/v1/admin/users/{userId}/password-reset-link` to API specs
- Add `/api/v1/auth/reset-password` to API specs
- Document reset token hashing, expiration, one-time use, sibling token invalidation, and JWT/session invalidation behavior
- Update README with password reset flow details and test guidance

## Testing
- Docs-only change
- Verified old `/admin/reset-link` reference was removed from API specs
